### PR TITLE
Add pyproject and dev instructions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,8 +15,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-      - run: pip install -r requirements.txt
-      - run: pip install mypy ruff
+      - run: python -m pip install -e .[dev]
       - run: ruff check
       - run: mypy sc62015/pysc62015 || true
       - run: pytest -q

--- a/README.md
+++ b/README.md
@@ -15,3 +15,15 @@ Overall structure of instruction logic based on
 
 Apache License 2.0.
 
+## Development
+
+Install the package in editable mode with development dependencies and run the
+checks:
+
+```bash
+python -m pip install -e .[dev]
+ruff check
+mypy sc62015/pysc62015
+pytest -q
+```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "binja-esr"
+version = "0.1.0"
+description = "Binary Ninja SC62015 architecture plugin"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "lark",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "mypy",
+    "ruff",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+exclude = ["sc62015/pysc62015/test*"]


### PR DESCRIPTION
## Summary
- package project using a `pyproject.toml`
- install dependencies with `pip install -e .[dev]` in CI
- document how to run checks locally

## Testing
- `ruff check`
- `mypy sc62015/pysc62015` *(fails: Cannot find implementation or library stub for module named 'lark')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'lark')*

------
https://chatgpt.com/codex/tasks/task_e_6843ae584f6883319a138a5f368c0f3a