### PR TITLE
Fix PRE_DEC addressing handling

### DIFF
--- a/sc62015/pysc62015/instr.py
+++ b/sc62015/pysc62015/instr.py
@@ -1235,9 +1235,9 @@ class RegIncrementDecrementHelper(OperandHelper):
             value = tmp.lift(il)
 
         if self.mode == EMemRegMode.PRE_DEC:
-            sub = il.sub(self.reg.width(), value, il.const(1, self.width))
+            value = il.sub(self.reg.width(), value, il.const(1, self.width))
             if side_effects:
-                self.reg.lift_assign(il, sub)
+                self.reg.lift_assign(il, value)
 
         return value
 


### PR DESCRIPTION
## Summary
- correct the returned address for pre-decrement addressing mode

## Testing
- `ruff check sc62015/pysc62015`
- `mypy sc62015/pysc62015` *(fails: Cannot find implementation or library stub for module named 'binaryninja')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'lark')*

------
https://chatgpt.com/codex/tasks/task_e_6843b643946c8331beb30b8106367473