### PR TITLE
Add disassembly checks for emulator InstructionTestCases

### DIFF
--- a/sc62015/pysc62015/test_emulator.py
+++ b/sc62015/pysc62015/test_emulator.py
@@ -209,36 +209,42 @@ instruction_test_cases: List[InstructionTestCase] = [
         instr_bytes=bytes.fromhex("EE"),
         init_regs={RegisterName.A: 0x12, RegisterName.FC: 0, RegisterName.FZ: 1},
         expected_regs={RegisterName.A: 0x21, RegisterName.FZ: 0, RegisterName.FC: 0},
+        expected_asm_str="SWAP  A",
     ),
     InstructionTestCase(
         test_id="SWAP_A_non_zero_FC_unaffected",
         instr_bytes=bytes.fromhex("EE"),
         init_regs={RegisterName.A: 0xAB, RegisterName.FC: 1, RegisterName.FZ: 1},
         expected_regs={RegisterName.A: 0xBA, RegisterName.FZ: 0, RegisterName.FC: 1},
+        expected_asm_str="SWAP  A",
     ),
     InstructionTestCase(
         test_id="SWAP_A_zero_to_zero_sets_FZ",
         instr_bytes=bytes.fromhex("EE"),
         init_regs={RegisterName.A: 0x00, RegisterName.FC: 1, RegisterName.FZ: 0},
         expected_regs={RegisterName.A: 0x00, RegisterName.FZ: 1, RegisterName.FC: 1},
+        expected_asm_str="SWAP  A",
     ),
     InstructionTestCase(
         test_id="SWAP_A_edge_case_F0",
         instr_bytes=bytes.fromhex("EE"),
         init_regs={RegisterName.A: 0xF0, RegisterName.FC: 0, RegisterName.FZ: 1},
         expected_regs={RegisterName.A: 0x0F, RegisterName.FZ: 0, RegisterName.FC: 0},
+        expected_asm_str="SWAP  A",
     ),
     InstructionTestCase(
         test_id="SWAP_A_edge_case_0F",
         instr_bytes=bytes.fromhex("EE"),
         init_regs={RegisterName.A: 0x0F, RegisterName.FC: 0, RegisterName.FZ: 1},
         expected_regs={RegisterName.A: 0xF0, RegisterName.FZ: 0, RegisterName.FC: 0},
+        expected_asm_str="SWAP  A",
     ),
     InstructionTestCase(
         test_id="SWAP_A_edge_case_FF",
         instr_bytes=bytes.fromhex("EE"),
         init_regs={RegisterName.A: 0xFF, RegisterName.FC: 1, RegisterName.FZ: 1},
         expected_regs={RegisterName.A: 0xFF, RegisterName.FZ: 0, RegisterName.FC: 1},
+        expected_asm_str="SWAP  A",
     ),
     # --- MVL/MVLD Edge Cases ---
     # FIXME: failing
@@ -275,6 +281,7 @@ instruction_test_cases: List[InstructionTestCase] = [
             INTERNAL_MEMORY_START + 0x52: 0xAA,
             INTERNAL_MEMORY_START + 0x53: 0xAA,
         },
+        expected_asm_str="MVL   (51), (50)",
     ),
     InstructionTestCase(
         test_id="MVLD_imem_overlap_bwd_correct",
@@ -294,6 +301,7 @@ instruction_test_cases: List[InstructionTestCase] = [
             INTERNAL_MEMORY_START + 0x50: 0xBB,
             INTERNAL_MEMORY_START + 0x4F: 0xCC,
         },
+        expected_asm_str="MVLD  (51), (50)",
     ),
     # FIXME: failing
     # InstructionTestCase(


### PR DESCRIPTION
## Summary
- verify disassembly text for swap and MVL/MVLD emulator test cases

## Testing
- `ruff check`
- `MYPYPATH=stubs mypy sc62015/pysc62015`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'lark')*

------
https://chatgpt.com/codex/tasks/task_e_6843bf0256448331a557115ea50357d8