### PR TITLE
Fix EMemValueOffsetHelper width

### DIFF
--- a/sc62015/pysc62015/instr.py
+++ b/sc62015/pysc62015/instr.py
@@ -1133,10 +1133,14 @@ class EMemAddr(Imm20, Pointer):
 
 
 class EMemValueOffsetHelper(OperandHelper, Pointer):
-    def __init__(self, value: Operand, offset: Optional[ImmOffset]):
+    def __init__(self, value: Operand, offset: Optional[ImmOffset], width: int = 1) -> None:
         super().__init__()
         self.value = value
         self.offset = offset
+        self._width = width
+
+    def width(self) -> int:
+        return self._width
 
     def lift_current_addr(
         self,
@@ -1166,8 +1170,8 @@ class EMemValueOffsetHelper(OperandHelper, Pointer):
         pre: Optional[AddressingMode] = None,
         side_effects: bool = True,
     ) -> ExpressionIndex:
-        # FIXME: need to figure out the size to use, currently hardcoded to 1
-        return il.load(1, self.lift_current_addr(il, pre=pre, side_effects=side_effects))
+        # width is determined by the context in which this helper is used
+        return il.load(self.width(), self.lift_current_addr(il, pre=pre, side_effects=side_effects))
 
     def lift_assign(
         self,
@@ -1175,9 +1179,8 @@ class EMemValueOffsetHelper(OperandHelper, Pointer):
         value: ExpressionIndex,
         pre: Optional[AddressingMode] = None,
     ) -> None:
-        # FIXME: what's the width? Hardcoded to 1.
         il.append(
-            il.store(1, self.lift_current_addr(il, pre=pre, side_effects=True), value)
+            il.store(self.width(), self.lift_current_addr(il, pre=pre, side_effects=True), value)
         )
 
 # page 74 of the book
@@ -1259,7 +1262,7 @@ class EMemRegOffsetHelper(HasOperands, OperandHelper):
         else:
             reg = self.reg
 
-        op = EMemValueOffsetHelper(reg, self.offset)
+        op = EMemValueOffsetHelper(reg, self.offset, width=self.width)
         yield op
 
 class RegIMemOffsetOrder(enum.Enum):
@@ -1407,7 +1410,7 @@ class EMemIMem(HasOperands, Imm8):
             self.offset.encode(encoder, addr)
 
     def operands(self) -> Generator[Operand, None, None]:
-        op = EMemValueOffsetHelper(self.imem, self.offset)
+        op = EMemValueOffsetHelper(self.imem, self.offset, width=1)
         yield op
 
 class EMemIMemOffsetOrder(enum.Enum):
@@ -1446,10 +1449,10 @@ class EMemIMemOffset(HasOperands, Operand):
     def operands(self) -> Generator[Operand, None, None]:
         if self.order == EMemIMemOffsetOrder.DEST_INT_MEM:
             yield self.imem1
-            op = EMemValueOffsetHelper(self.imem2, self.offset)
+            op = EMemValueOffsetHelper(self.imem2, self.offset, width=1)
             yield op
         else:
-            op = EMemValueOffsetHelper(self.imem1, self.offset)
+            op = EMemValueOffsetHelper(self.imem1, self.offset, width=1)
             yield op
             yield self.imem2
 

--- a/sc62015/pysc62015/test_emulator.py
+++ b/sc62015/pysc62015/test_emulator.py
@@ -166,6 +166,31 @@ instruction_test_cases: List[InstructionTestCase] = [
         expected_mem_state={0x20: 0x03, 0x21: 0x02, 0x22: 0x01},
         expected_asm_str="MV    [00020], X",
     ),
+    # External memory via register pointer
+    InstructionTestCase(
+        test_id="MV_A_from_emem_reg",
+        instr_bytes=bytes.fromhex("9004"),
+        init_regs={RegisterName.X: 0x0040},
+        init_mem={0x40: 0xAA},
+        expected_regs={RegisterName.A: 0xAA},
+        expected_asm_str="MV    A, [X]",
+    ),
+    InstructionTestCase(
+        test_id="MV_BA_from_emem_reg",
+        instr_bytes=bytes.fromhex("9204"),
+        init_regs={RegisterName.X: 0x0050},
+        init_mem={0x50: 0x11, 0x51: 0x22},
+        expected_regs={RegisterName.BA: 0x2211},
+        expected_asm_str="MV    BA, [X]",
+    ),
+    InstructionTestCase(
+        test_id="MV_X_to_emem_reg",
+        instr_bytes=bytes.fromhex("B405"),
+        init_regs={RegisterName.X: 0x010203, RegisterName.Y: 0x0060},
+        expected_mem_writes=[(0x60, 0x03), (0x61, 0x02), (0x62, 0x01)],
+        expected_mem_state={0x60: 0x03, 0x61: 0x02, 0x62: 0x01},
+        expected_asm_str="MV    [Y], X",
+    ),
     # --- ADD Instructions ---
     InstructionTestCase(
         test_id="ADD_A_imm_simple",


### PR DESCRIPTION
## Summary
- allow EMemValueOffsetHelper width specification
- test width for EMemValueOffsetHelper
- test EMemRegOffsetHelper uses custom widths

## Testing
- `ruff check`
- `MYPYPATH=stubs mypy sc62015/pysc62015`
- `pytest -vv` *(fails: ModuleNotFoundError: No module named 'lark')*


------
https://chatgpt.com/codex/tasks/task_e_6843bf97a3d08331b935b28c0506ffb7