### PR TITLE
Fix Reg3 test register type

### DIFF
--- a/sc62015/pysc62015/test_instr.py
+++ b/sc62015/pysc62015/test_instr.py
@@ -48,6 +48,7 @@ from .mock_llil import MockLowLevelILFunction, MockLLIL, MockFlag, mllil, mreg
 from binaryninja.lowlevelil import (
     LLIL_TEMP,
 )
+from binaryninja.architecture import RegisterName
 
 import os
 from pprint import pprint
@@ -303,7 +304,7 @@ def test_emem_value_offset_helper_widths() -> None:
 
 def test_emem_reg_offset_helper_widths() -> None:
     reg = Reg3()
-    reg.reg = "X"
+    reg.reg = RegisterName("X")
 
     for width, suffix in [(2, "w"), (3, "l")]:
         h = EMemRegOffsetHelper(width, reg, EMemRegMode.SIMPLE, offset=None)


### PR DESCRIPTION
## Summary
- import `RegisterName` from `binaryninja.architecture`
- set `Reg3.reg` via `RegisterName("X")` for clarity

## Testing
- `ruff check`
- `mypy sc62015/pysc62015`
- `pytest -q` *(fails: ImportError: cannot import name 'Lark')*

------
https://chatgpt.com/codex/tasks/task_e_6843cbc2c6ac8331ba8fe0fba29921d5