### PR TITLE
Exclude third-party/lark from Ruff checks

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,3 +1,6 @@
+
+extend-exclude = ['third-party/lark']
+
 [lint]
 ignore = ['F405', 'E701']
 


### PR DESCRIPTION
## Summary
- update ruff configuration to ignore warnings inside `third-party/lark`

## Testing
- `ruff check --quiet .`

------
https://chatgpt.com/codex/tasks/task_e_6843cc09707c8331861ad3a089dd6cff