### PR TITLE
Ignore third-party when running pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+norecursedirs = third-party
+


### PR DESCRIPTION
## Summary
- ensure running `pytest` from the project root skips `third-party`

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'Lark')*

------
https://chatgpt.com/codex/tasks/task_e_6843cf25409483319ee3cc2e8237c96f