### PR TITLE
Remove lark submodule

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,8 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: recursive
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "third-party/lark"]
-	path = third-party/lark
-	url = https://github.com/lark-parser/lark

--- a/README.md
+++ b/README.md
@@ -17,17 +17,10 @@ Apache License 2.0.
 
 ## Development
 
-First make sure the `lark` submodule is initialized:
-
-```bash
-git submodule update --init --recursive
-```
-
-Then install the package in editable mode with development dependencies and run the
+Install the package in editable mode with development dependencies and run the
 checks:
 
 ```bash
-python -m pip install -e ./third-party/lark
 python -m pip install -e .[dev]
 ruff check
 mypy sc62015/pysc62015

--- a/__init__.py
+++ b/__init__.py
@@ -1,11 +1,5 @@
 import sys
-import os
 import importlib.util
-
-# Ensure bundled lark submodule is preferred over any installed version
-third_party = os.path.join(os.path.dirname(__file__), "third-party")
-if os.path.isdir(third_party) and third_party not in sys.path:
-    sys.path.insert(0, third_party)
 
 def module_exists(module_name):
     if module_name in sys.modules:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,2 @@
 [pytest]
-norecursedirs = third-party
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,6 +1,3 @@
-
-extend-exclude = ['third-party/lark']
-
 [lint]
 ignore = ['F405', 'E701']
 

--- a/sc62015/__init__.py
+++ b/sc62015/__init__.py
@@ -1,7 +1,2 @@
-import os
-import sys
-
-third_party = os.path.join(os.path.dirname(os.path.dirname(__file__)), "third-party")
-if os.path.isdir(third_party) and third_party not in sys.path:
-    sys.path.insert(0, third_party)
+"""sc62015 package."""
 


### PR DESCRIPTION
## Summary
- delete `third-party/lark` submodule
- drop submodule checkout from CI
- update README instructions
- remove dynamic `sys.path` edits
- clean up config files

## Testing
- `ruff check`
- `python scripts/run_mypy.py` *(fails: Cannot find module 'bincopy', 'plumbum')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'lark')*

------
https://chatgpt.com/codex/tasks/task_e_6843fc379f1c8331a7e1e152e0c48688