### PR TITLE
Add CALL instruction support

### DIFF
--- a/MISSING_INSTRUCTIONS.md
+++ b/MISSING_INSTRUCTIONS.md
@@ -21,12 +21,11 @@ No arithmetic operations are present in the grammar. The missing set includes:
 - **Packed BCD Modify**: `PMDF`.
 
 ## 3. Program Flow Instructions
-Besides `RET`, `RETI`, and `RETF`, jump and call instructions are absent:
+Besides `RET`, `RETI`, and `RETF`, jump instructions are absent:
 
 - **Unconditional Jumps**: `JP`, `JR` and their far or register forms.
 - **Conditional Jumps**: `JPZ`, `JPNZ`, `JPC`, `JPNC`.
 - **Conditional Relative Jumps**: `JRZ`, `JRNZ`, `JRC`, `JRNC`.
-- **Calls**: `CALL`, `CALLF`.
 
 ## 4. Logical and Compare Instructions
 None of the logical, test, or compare operations are handled:

--- a/sc62015/pysc62015/asm.lark
+++ b/sc62015/pysc62015/asm.lark
@@ -39,6 +39,8 @@ instruction: "NOP"i -> nop
            | "POPU"i _F -> popu_f
            | "PUSHU"i _IMR -> pushu_imr
            | "POPU"i _IMR -> popu_imr
+           | "CALL"i expression -> call
+           | "CALLF"i expression -> callf
            | "MV"i imem_operand "," imem_operand -> mv_imem_imem
 
 

--- a/sc62015/pysc62015/asm.py
+++ b/sc62015/pysc62015/asm.py
@@ -26,6 +26,9 @@ from .instr import (
     POPS,
     PUSHU,
     POPU,
+    CALL,
+    Imm16,
+    Imm20,
     Reg,
     RegB,
     RegF,
@@ -228,6 +231,26 @@ class AsmTransformer(Transformer):
     def popu_imr(self, _: List[Any]) -> InstructionNode:
         return {
             "instruction": {"instr_class": POPU, "instr_opts": Opts(ops=[RegIMR()])}
+        }
+
+    def call(self, items: List[Any]) -> InstructionNode:
+        imm = Imm16()
+        imm.value = items[0]
+        return {
+            "instruction": {
+                "instr_class": CALL,
+                "instr_opts": Opts(ops=[imm]),
+            }
+        }
+
+    def callf(self, items: List[Any]) -> InstructionNode:
+        imm = Imm20()
+        imm.value = items[0]
+        return {
+            "instruction": {
+                "instr_class": CALL,
+                "instr_opts": Opts(name="CALLF", ops=[imm]),
+            }
         }
 
     def reg(self, items: List[Token]) -> Reg:

--- a/sc62015/pysc62015/instr.py
+++ b/sc62015/pysc62015/instr.py
@@ -784,6 +784,7 @@ class Imm20(ImmOperand):
     def __init__(self) -> None:
         super().__init__()
         self.value = None
+        self.extra_hi = None
 
     def width(self) -> int:
         return 3

--- a/sc62015/pysc62015/sc_asm.py
+++ b/sc62015/pysc62015/sc_asm.py
@@ -9,7 +9,7 @@ from plumbum import cli  # type: ignore[import-untyped]
 # Assuming the provided library files are in a package named 'sc62015'
 from .asm import AsmTransformer, asm_parser, ParsedInstruction
 from .coding import Encoder
-from .instr import Instruction, OPCODES, Opts, IMemOperand, IMem8
+from .instr import Instruction, OPCODES, Opts, IMemOperand, IMem8, ImmOperand, Imm20
 
 # A simple cache for the reverse lookup table
 REVERSE_OPCODES_CACHE: Dict[str, List[Dict[str, Any]]] = {}
@@ -93,6 +93,9 @@ class Assembler:
                 for p_op, t_op in zip(provided_ops, template_ops):
                     if isinstance(t_op, IMem8) and isinstance(p_op, IMemOperand):
                         continue
+                    if isinstance(t_op, ImmOperand) and isinstance(p_op, ImmOperand):
+                        if type(p_op) is type(t_op):
+                            continue
                     if repr(p_op) != repr(t_op):
                         converted_match = False
                         break
@@ -119,6 +122,8 @@ class Assembler:
                                 setattr(op, "value", int(getattr(op, "value"), 0))
                             except ValueError:
                                 setattr(op, "value", 0)
+                        if isinstance(op, Imm20) and isinstance(op.value, int):
+                            op.extra_hi = (op.value >> 16) & 0xFF
 
                     encoder = Encoder()
                     try:
@@ -236,6 +241,13 @@ class Assembler:
             for op in instr.operands():
                 if isinstance(op, IMemOperand) and isinstance(op.n_val, str):
                     op.n_val = self._evaluate_operand(op.n_val)
+                if hasattr(op, "value"):
+                    val = getattr(op, "value")
+                    if isinstance(val, str):
+                        val = self._evaluate_operand(val)
+                        setattr(op, "value", val)
+                    if isinstance(op, Imm20) and isinstance(val, int):
+                        op.extra_hi = (val >> 16) & 0xFF
             encoder = Encoder()
             instr.encode(encoder, self.current_address)
             return encoder.buf

--- a/sc62015/pysc62015/test_asm.py
+++ b/sc62015/pysc62015/test_asm.py
@@ -160,6 +160,18 @@ assembler_test_cases: List[AssemblerTestCase] = [
         test_id="mv_imem_imem_invalid_combo",
         asm_code='MV (BP+PX), (BP+PY)'
     ),
+    AssemblerTestCase(
+        test_id="call_and_callf",
+        asm_code="""
+            CALL 0xAABB
+            CALLF 0xAABBCC
+        """,
+        expected_ti="""
+            @0000
+            04 BB AA 05 CC BB AA
+            q
+        """,
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary
- support `CALL` and `CALLF` in assembler
- convert immediate operands in second pass
- clarify missing instructions
- test CALL code generation
- fix Imm20 initialization and address handling

## Testing
- `ruff check .`
- `mypy sc62015/pysc62015` *(fails: import errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843fea820148331a180bf9505ff944e