### PR TITLE
Add INC/DEC assembler support

### DIFF
--- a/MISSING_INSTRUCTIONS.md
+++ b/MISSING_INSTRUCTIONS.md
@@ -37,8 +37,6 @@ None of the logical, test, or compare operations are handled:
 ## 5. Increment, Decrement, and Exchange Instructions
 Only `EX A,B` is implemented. Missing variants include:
 
-- **Increment**: `INC` for registers and memory locations.
-- **Decrement**: `DEC` for registers and memory locations.
 - **Exchange**: `EX`, `EXW`, `EXP`, `EXL` with register and memory operands.
 
 ## 6. Shift and Rotate Instructions

--- a/sc62015/pysc62015/asm.lark
+++ b/sc62015/pysc62015/asm.lark
@@ -41,6 +41,10 @@ instruction: "NOP"i -> nop
            | "POPU"i _IMR -> popu_imr
            | "CALL"i expression -> call
            | "CALLF"i expression -> callf
+           | "INC"i reg -> inc_reg
+           | "INC"i imem_operand -> inc_imem
+           | "DEC"i reg -> dec_reg
+           | "DEC"i imem_operand -> dec_imem
            | "MV"i imem_operand "," imem_operand -> mv_imem_imem
 
 

--- a/sc62015/pysc62015/asm.py
+++ b/sc62015/pysc62015/asm.py
@@ -29,6 +29,9 @@ from .instr import (
     CALL,
     Imm16,
     Imm20,
+    INC,
+    DEC,
+    Reg3,
     Reg,
     RegB,
     RegF,
@@ -252,6 +255,30 @@ class AsmTransformer(Transformer):
                 "instr_opts": Opts(name="CALLF", ops=[imm]),
             }
         }
+
+    def inc_reg(self, items: List[Any]) -> InstructionNode:
+        reg = cast(Reg, items[0])
+        r = Reg3()
+        r.reg = reg.reg
+        r.reg_raw = Reg3.reg_idx(reg.reg)
+        r.high4 = 0
+        return {"instruction": {"instr_class": INC, "instr_opts": Opts(ops=[r])}}
+
+    def inc_imem(self, items: List[Any]) -> InstructionNode:
+        op = cast(IMemOperand, items[0])
+        return {"instruction": {"instr_class": INC, "instr_opts": Opts(ops=[op])}}
+
+    def dec_reg(self, items: List[Any]) -> InstructionNode:
+        reg = cast(Reg, items[0])
+        r = Reg3()
+        r.reg = reg.reg
+        r.reg_raw = Reg3.reg_idx(reg.reg)
+        r.high4 = 0
+        return {"instruction": {"instr_class": DEC, "instr_opts": Opts(ops=[r])}}
+
+    def dec_imem(self, items: List[Any]) -> InstructionNode:
+        op = cast(IMemOperand, items[0])
+        return {"instruction": {"instr_class": DEC, "instr_opts": Opts(ops=[op])}}
 
     def reg(self, items: List[Token]) -> Reg:
         reg_name = str(items[0]).upper()

--- a/sc62015/pysc62015/sc_asm.py
+++ b/sc62015/pysc62015/sc_asm.py
@@ -9,7 +9,7 @@ from plumbum import cli  # type: ignore[import-untyped]
 # Assuming the provided library files are in a package named 'sc62015'
 from .asm import AsmTransformer, asm_parser, ParsedInstruction
 from .coding import Encoder
-from .instr import Instruction, OPCODES, Opts, IMemOperand, IMem8, ImmOperand, Imm20
+from .instr import Instruction, OPCODES, Opts, IMemOperand, IMem8, ImmOperand, Imm20, Reg3
 
 # A simple cache for the reverse lookup table
 REVERSE_OPCODES_CACHE: Dict[str, List[Dict[str, Any]]] = {}
@@ -96,6 +96,8 @@ class Assembler:
                     if isinstance(t_op, ImmOperand) and isinstance(p_op, ImmOperand):
                         if type(p_op) is type(t_op):
                             continue
+                    if isinstance(t_op, Reg3) and isinstance(p_op, Reg3):
+                        continue
                     if repr(p_op) != repr(t_op):
                         converted_match = False
                         break

--- a/sc62015/pysc62015/test_asm.py
+++ b/sc62015/pysc62015/test_asm.py
@@ -172,6 +172,42 @@ assembler_test_cases: List[AssemblerTestCase] = [
             q
         """,
     ),
+    AssemblerTestCase(
+        test_id="inc_reg",
+        asm_code="INC A",
+        expected_ti="""
+            @0000
+            6C 00
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="inc_imem",
+        asm_code="INC (0x10)",
+        expected_ti="""
+            @0000
+            6D 10
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="dec_reg",
+        asm_code="DEC S",
+        expected_ti="""
+            @0000
+            7C 07
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="dec_imem",
+        asm_code="DEC (0x20)",
+        expected_ti="""
+            @0000
+            7D 20
+            q
+        """,
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary
- implement INC and DEC in assembler grammar and transformer
- update assembler to match Reg3 operands
- document remaining missing instructions
- add unit tests for INC/DEC assembly code generation

## Testing
- `ruff check`
- `MYPYPATH=stubs mypy sc62015/pysc62015`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684404a366448331b9d813228cb98d9f