### PR TITLE
Implement jump assembly and tests

### DIFF
--- a/MISSING_INSTRUCTIONS.md
+++ b/MISSING_INSTRUCTIONS.md
@@ -23,7 +23,7 @@ No arithmetic operations are present in the grammar. The missing set includes:
 ## 3. Program Flow Instructions
 Besides `RET`, `RETI`, and `RETF`, jump and call instructions are absent:
 
-- **Unconditional Jumps**: `JP`, `JR` and their far or register forms.
+ - **Unconditional Jumps**: far or register forms.
 - **Conditional Jumps**: `JPZ`, `JPNZ`, `JPC`, `JPNC`.
 - **Conditional Relative Jumps**: `JRZ`, `JRNZ`, `JRC`, `JRNC`.
 - **Calls**: `CALL`, `CALLF`.

--- a/sc62015/pysc62015/asm.lark
+++ b/sc62015/pysc62015/asm.lark
@@ -40,6 +40,9 @@ instruction: "NOP"i -> nop
            | "PUSHU"i _IMR -> pushu_imr
            | "POPU"i _IMR -> popu_imr
            | "MV"i imem_operand "," imem_operand -> mv_imem_imem
+           | "JP"i expression -> jp_abs
+           | "JPF"i expression -> jpf_abs
+           | "JR"i SIGN expression -> jr
 
 
 // --- Data Directives ---
@@ -81,6 +84,9 @@ _IMR: "IMR"i
 _BP: "BP"i
 _PX: "PX"i
 _PY: "PY"i
+PLUS: "+"
+MINUS: "-"
+SIGN: PLUS | MINUS
 
 
 // --- Common Terminals ---

--- a/sc62015/pysc62015/asm.py
+++ b/sc62015/pysc62015/asm.py
@@ -26,6 +26,11 @@ from .instr import (
     POPS,
     PUSHU,
     POPU,
+    JP_Abs,
+    JP_Rel,
+    Imm16,
+    Imm20,
+    ImmOffset,
     Reg,
     RegB,
     RegF,
@@ -229,6 +234,27 @@ class AsmTransformer(Transformer):
         return {
             "instruction": {"instr_class": POPU, "instr_opts": Opts(ops=[RegIMR()])}
         }
+
+    def jp_abs(self, items: List[Any]) -> InstructionNode:
+        op = Imm16()
+        op.value = items[0]
+        return {"instruction": {"instr_class": JP_Abs, "instr_opts": Opts(ops=[op])}}
+
+    def jpf_abs(self, items: List[Any]) -> InstructionNode:
+        op = Imm20()
+        op.value = items[0]
+        return {
+            "instruction": {
+                "instr_class": JP_Abs,
+                "instr_opts": Opts(name="JPF", ops=[op]),
+            }
+        }
+
+    def jr(self, items: List[Any]) -> InstructionNode:
+        sign, expr = items
+        op = ImmOffset("+" if sign == "+" else "-")
+        op.value = expr
+        return {"instruction": {"instr_class": JP_Rel, "instr_opts": Opts(ops=[op])}}
 
     def reg(self, items: List[Token]) -> Reg:
         reg_name = str(items[0]).upper()

--- a/sc62015/pysc62015/instr.py
+++ b/sc62015/pysc62015/instr.py
@@ -733,6 +733,9 @@ class IMemOperand(Operand, HasWidth):
 class ImmOperand(Operand, HasWidth):
     value: Optional[int]
 
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(value={self.value!r})"
+
     def lift(self, il: LowLevelILFunction, pre: Optional[AddressingMode] = None, side_effects: bool = True) -> ExpressionIndex:
         assert self.value is not None, "Value not set"
         return il.const(self.width(), self.value)
@@ -826,6 +829,9 @@ class ImmOffset(Imm8):
     def lift_offset(self, il: LowLevelILFunction, value: ExpressionIndex) -> ExpressionIndex:
         offset = il.const(self.width(), self.offset_value())
         return il.add(self.width(), value, offset)
+
+    def __repr__(self) -> str:
+        return f"ImmOffset(sign={self.sign!r}, value={self.value!r})"
 
 
 # Internal Memory Addressing Modes:

--- a/sc62015/pysc62015/test_asm.py
+++ b/sc62015/pysc62015/test_asm.py
@@ -50,6 +50,36 @@ assembler_test_cases: List[AssemblerTestCase] = [
         """
     ),
     AssemblerTestCase(
+        test_id="jp_absolute_label",
+        asm_code="""
+        start:
+            JP start
+        """,
+        expected_ti="""
+            @0000
+            02 00 00
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="jr_positive_offset",
+        asm_code="JR +2",
+        expected_ti="""
+            @0000
+            12 02
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="jr_negative_offset",
+        asm_code="JR -2",
+        expected_ti="""
+            @0000
+            13 02
+            q
+        """,
+    ),
+    AssemblerTestCase(
         test_id="data_directive_defb_with_code",
         asm_code="""
             SECTION code


### PR DESCRIPTION
## Summary
- support JR sign token in the grammar
- relax assembler operand matching for labels
- update jump documentation

## Testing
- `ruff check`
- `mypy sc62015/pysc62015` *(fails: binaryninja missing)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843feb5c27c8331a55487731c275771