### PR TITLE
Add AND instruction support

### DIFF
--- a/MISSING_INSTRUCTIONS.md
+++ b/MISSING_INSTRUCTIONS.md
@@ -29,9 +29,9 @@ Besides `RET`, `RETI`, and `RETF`, jump and call instructions are absent:
 - **Calls**: `CALL`, `CALLF`.
 
 ## 4. Logical and Compare Instructions
-None of the logical, test, or compare operations are handled:
+Logical, test, and compare instructions are largely unimplemented:
 
-- **Logical Ops**: `AND`, `OR`, `XOR` with all addressing modes.
+- **Logical Ops**: `OR`, `XOR` with all addressing modes.
 - **Test**: `TEST` in all forms.
 - **Compare**: `CMP`, `CMPW`, `CMPP`.
 

--- a/sc62015/pysc62015/asm.lark
+++ b/sc62015/pysc62015/asm.lark
@@ -40,6 +40,19 @@ instruction: "NOP"i -> nop
            | "PUSHU"i _IMR -> pushu_imr
            | "POPU"i _IMR -> popu_imr
            | "MV"i imem_operand "," imem_operand -> mv_imem_imem
+           | and_imem_a
+           | and_a_imem
+           | and_a_imm
+           | and_imem_imm
+           | and_emem_imm
+           | and_imem_imem
+
+and_imem_a.2: "AND"i imem_operand "," _A
+and_a_imem.2: "AND"i _A "," imem_operand
+and_a_imm.1: "AND"i _A "," expression
+and_imem_imm.1: "AND"i imem_operand "," expression
+and_emem_imm.1: "AND"i emem_addr "," expression
+and_imem_imem.1: "AND"i imem_operand "," imem_operand
 
 
 // --- Data Directives ---
@@ -72,6 +85,9 @@ imem_py_n:  "(" _PY "+" expression ")"
 imem_bp_px: "(" _BP "+" _PX ")"
 imem_bp_py: "(" _BP "+" _PY ")"
 
+emem_addr: "[" expression "]"
+emem_operand: emem_addr
+
 
 // --- Terminals with higher priority ---
 _A: "A"i
@@ -86,10 +102,11 @@ _PY: "PY"i
 // --- Common Terminals ---
 NUMBER: /0x[0-9a-fA-F]+/i | /[0-9]+/
 
-%import common.CNAME
 %import common.ESCAPED_STRING
 %import common.NEWLINE
 %import common.WS
+
+CNAME: /[a-zA-Z_][a-zA-Z0-9_]*/
 
 %ignore WS
 // Ignore comments starting with ;

--- a/sc62015/pysc62015/instr.py
+++ b/sc62015/pysc62015/instr.py
@@ -733,6 +733,9 @@ class IMemOperand(Operand, HasWidth):
 class ImmOperand(Operand, HasWidth):
     value: Optional[int]
 
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}()"
+
     def lift(self, il: LowLevelILFunction, pre: Optional[AddressingMode] = None, side_effects: bool = True) -> ExpressionIndex:
         assert self.value is not None, "Value not set"
         return il.const(self.width(), self.value)
@@ -1166,6 +1169,8 @@ class EMemAddr(Imm20, Pointer):
     def __init__(self, width: int) -> None:
         super().__init__()
         self._width = width
+        # Ensure extra_hi exists so assembler can populate it
+        self.extra_hi = 0
 
     def width(self) -> int:
         return self._width

--- a/sc62015/pysc62015/sc_asm.py
+++ b/sc62015/pysc62015/sc_asm.py
@@ -119,6 +119,8 @@ class Assembler:
                                 setattr(op, "value", int(getattr(op, "value"), 0))
                             except ValueError:
                                 setattr(op, "value", 0)
+                        if hasattr(op, "extra_hi") and getattr(op, "value", None) is not None:
+                            setattr(op, "extra_hi", (int(getattr(op, "value")) >> 16) & 0xFF)
 
                     encoder = Encoder()
                     try:
@@ -236,6 +238,11 @@ class Assembler:
             for op in instr.operands():
                 if isinstance(op, IMemOperand) and isinstance(op.n_val, str):
                     op.n_val = self._evaluate_operand(op.n_val)
+                if hasattr(op, "value") and isinstance(getattr(op, "value"), str):
+                    val = self._evaluate_operand(getattr(op, "value"))
+                    setattr(op, "value", val)
+                    if hasattr(op, "extra_hi"):
+                        setattr(op, "extra_hi", (val >> 16) & 0xFF)
             encoder = Encoder()
             instr.encode(encoder, self.current_address)
             return encoder.buf

--- a/sc62015/pysc62015/test_asm.py
+++ b/sc62015/pysc62015/test_asm.py
@@ -160,6 +160,23 @@ assembler_test_cases: List[AssemblerTestCase] = [
         test_id="mv_imem_imem_invalid_combo",
         asm_code='MV (BP+PX), (BP+PY)'
     ),
+    AssemblerTestCase(
+        test_id="and_all_forms",
+        asm_code="""
+            AND A, 0x55
+            AND (0x10), 0x01
+            AND [0x12345], 0x02
+            AND (0x20), A
+            AND A, (0x30)
+            AND (0x40), (0x50)
+        """,
+        expected_ti="""
+            @0000
+            70 55 71 10 01 72 45 23 01 02 73 20 77 30 76 40
+            50
+            q
+        """
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary
- ensure assembler properly aggregates instructions
- handle external memory AND addressing
- refactor AND grammar to disambiguate A register
- split TI TXT output line in test

## Testing
- `ruff check`
- `python scripts/run_mypy.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843fed19e308331aee902688fed5e5b