### PR TITLE
Add ADD and SUB assembler support

### DIFF
--- a/MISSING_INSTRUCTIONS.md
+++ b/MISSING_INSTRUCTIONS.md
@@ -12,10 +12,11 @@ Only a few `MV` forms are parsed today (`MV A,B`, `MV B,A`, and `MV (imem),(imem
 - **Register to Register Moves** – generic forms like `MV r2, r'2` or `MV r3, r'3`.
 
 ## 2. Arithmetic Instructions
-No arithmetic operations are present in the grammar. The missing set includes:
+Basic addition (`ADD`) and subtraction (`SUB`) instructions are now supported in
+the assembler. The remaining missing set includes:
 
-- **Addition**: `ADD`, `ADC`.
-- **Subtraction**: `SUB`, `SBC`.
+- **Addition with carry**: `ADC`.
+- **Subtraction with borrow**: `SBC`.
 - **Multi-byte Arithmetic**: `ADCL`, `SBCL`.
 - **BCD Arithmetic**: `DADL`, `DSBL`.
 - **Packed BCD Modify**: `PMDF`.

--- a/sc62015/pysc62015/asm.lark
+++ b/sc62015/pysc62015/asm.lark
@@ -52,6 +52,14 @@ instruction: "NOP"i -> nop
            | and_imem_imm
            | and_emem_imm
            | and_imem_imem
+           | add_a_imm
+           | add_imem_imm
+           | add_a_imem
+           | add_imem_a
+           | sub_a_imm
+           | sub_imem_imm
+           | sub_a_imem
+           | sub_imem_a
 
 and_imem_a.2: "AND"i imem_operand "," _A
 and_a_imem.2: "AND"i _A "," imem_operand
@@ -59,6 +67,16 @@ and_a_imm.1: "AND"i _A "," expression
 and_imem_imm.1: "AND"i imem_operand "," expression
 and_emem_imm.1: "AND"i emem_addr "," expression
 and_imem_imem.1: "AND"i imem_operand "," imem_operand
+
+add_a_imm.1: "ADD"i _A "," expression
+add_imem_imm.1: "ADD"i imem_operand "," expression
+add_a_imem.2: "ADD"i _A "," imem_operand
+add_imem_a.2: "ADD"i imem_operand "," _A
+
+sub_a_imm.1: "SUB"i _A "," expression
+sub_imem_imm.1: "SUB"i imem_operand "," expression
+sub_a_imem.2: "SUB"i _A "," imem_operand
+sub_imem_a.2: "SUB"i imem_operand "," _A
 
 
 // --- Data Directives ---

--- a/sc62015/pysc62015/asm.py
+++ b/sc62015/pysc62015/asm.py
@@ -27,6 +27,8 @@ from .instr import (
     PUSHU,
     POPU,
     AND,
+    ADD,
+    SUB,
     CALL,
     Imm16,
     Imm20,
@@ -386,6 +388,60 @@ class AsmTransformer(Transformer):
         op1, op2 = items
         return {
             "instruction": {"instr_class": AND, "instr_opts": Opts(ops=[op1, op2])}
+        }
+
+    def add_a_imm(self, items: List[Any]) -> InstructionNode:
+        imm = Imm8()
+        imm.value = items[0]
+        return {
+            "instruction": {"instr_class": ADD, "instr_opts": Opts(ops=[Reg("A"), imm])}
+        }
+
+    def add_imem_imm(self, items: List[Any]) -> InstructionNode:
+        op1, val = items
+        imm = Imm8()
+        imm.value = val
+        return {
+            "instruction": {"instr_class": ADD, "instr_opts": Opts(ops=[op1, imm])}
+        }
+
+    def add_a_imem(self, items: List[Any]) -> InstructionNode:
+        op1 = items[0]
+        return {
+            "instruction": {"instr_class": ADD, "instr_opts": Opts(ops=[Reg("A"), op1])}
+        }
+
+    def add_imem_a(self, items: List[Any]) -> InstructionNode:
+        op1 = items[0]
+        return {
+            "instruction": {"instr_class": ADD, "instr_opts": Opts(ops=[op1, Reg("A")])}
+        }
+
+    def sub_a_imm(self, items: List[Any]) -> InstructionNode:
+        imm = Imm8()
+        imm.value = items[0]
+        return {
+            "instruction": {"instr_class": SUB, "instr_opts": Opts(ops=[Reg("A"), imm])}
+        }
+
+    def sub_imem_imm(self, items: List[Any]) -> InstructionNode:
+        op1, val = items
+        imm = Imm8()
+        imm.value = val
+        return {
+            "instruction": {"instr_class": SUB, "instr_opts": Opts(ops=[op1, imm])}
+        }
+
+    def sub_a_imem(self, items: List[Any]) -> InstructionNode:
+        op1 = items[0]
+        return {
+            "instruction": {"instr_class": SUB, "instr_opts": Opts(ops=[Reg("A"), op1])}
+        }
+
+    def sub_imem_a(self, items: List[Any]) -> InstructionNode:
+        op1 = items[0]
+        return {
+            "instruction": {"instr_class": SUB, "instr_opts": Opts(ops=[op1, Reg("A")])}
         }
 
     def def_arg(self, items: List[Any]) -> str:

--- a/sc62015/pysc62015/test_asm.py
+++ b/sc62015/pysc62015/test_asm.py
@@ -225,6 +225,80 @@ assembler_test_cases: List[AssemblerTestCase] = [
             q
         """,
     ),
+    # --- ADD Instruction Tests ---
+    AssemblerTestCase(
+        test_id="add_a_imm",
+        asm_code="ADD A, 0x01",
+        expected_ti="""
+            @0000
+            40 01
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="add_imem_imm",
+        asm_code="ADD (0x10), 0x02",
+        expected_ti="""
+            @0000
+            41 10 02
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="add_a_imem",
+        asm_code="ADD A, (0x20)",
+        expected_ti="""
+            @0000
+            42 20
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="add_imem_a",
+        asm_code="ADD (0x30), A",
+        expected_ti="""
+            @0000
+            43 30
+            q
+        """,
+    ),
+    # --- SUB Instruction Tests ---
+    AssemblerTestCase(
+        test_id="sub_a_imm",
+        asm_code="SUB A, 0x01",
+        expected_ti="""
+            @0000
+            48 01
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="sub_imem_imm",
+        asm_code="SUB (0x10), 0x02",
+        expected_ti="""
+            @0000
+            49 10 02
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="sub_a_imem",
+        asm_code="SUB A, (0x20)",
+        expected_ti="""
+            @0000
+            4A 20
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="sub_imem_a",
+        asm_code="SUB (0x30), A",
+        expected_ti="""
+            @0000
+            4B 30
+            q
+        """,
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary
- support ADD and SUB instruction forms in assembler
- document new arithmetic support
- test assembler code generation for ADD and SUB addressing modes

## Testing
- `ruff check`
- `MYPYPATH=stubs mypy sc62015/pysc62015`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684420c8f694833193477f10187e6596