### PR TITLE
Implement user stack instructions in assembler

### DIFF
--- a/MISSING_INSTRUCTIONS.md
+++ b/MISSING_INSTRUCTIONS.md
@@ -46,10 +46,5 @@ The grammar supports the accumulator forms (`ROR A`, `ROL A`, `SHR A`, `SHL A`) 
 - **Decimal Shifts**: `DSRL`, `DSLL`.
 
 ## 7. Stack Instructions
-Stack operations are limited to the `F` and `IMR` registers. Missing user stack operations include:
-
-- `PUSHU r`
-- `POPU r`
-
-for `A`, `IL`, `BA`, `I`, `X`, and `Y`.
+All user stack operations are now supported in the assembler.
 

--- a/sc62015/pysc62015/asm.lark
+++ b/sc62015/pysc62015/asm.lark
@@ -39,6 +39,8 @@ instruction: "NOP"i -> nop
            | "POPU"i _F -> popu_f
            | "PUSHU"i _IMR -> pushu_imr
            | "POPU"i _IMR -> popu_imr
+           | "PUSHU"i reg -> pushu_reg
+           | "POPU"i reg -> popu_reg
            | "CALL"i expression -> call
            | "CALLF"i expression -> callf
            | "INC"i reg -> inc_reg

--- a/sc62015/pysc62015/asm.py
+++ b/sc62015/pysc62015/asm.py
@@ -239,6 +239,14 @@ class AsmTransformer(Transformer):
             "instruction": {"instr_class": POPU, "instr_opts": Opts(ops=[RegIMR()])}
         }
 
+    def pushu_reg(self, items: List[Any]) -> InstructionNode:
+        reg = cast(Reg, items[0])
+        return {"instruction": {"instr_class": PUSHU, "instr_opts": Opts(ops=[reg])}}
+
+    def popu_reg(self, items: List[Any]) -> InstructionNode:
+        reg = cast(Reg, items[0])
+        return {"instruction": {"instr_class": POPU, "instr_opts": Opts(ops=[reg])}}
+
     def call(self, items: List[Any]) -> InstructionNode:
         imm = Imm16()
         imm.value = items[0]

--- a/sc62015/pysc62015/test_asm.py
+++ b/sc62015/pysc62015/test_asm.py
@@ -50,6 +50,32 @@ assembler_test_cases: List[AssemblerTestCase] = [
         """
     ),
     AssemblerTestCase(
+        test_id="user_stack_register_ops",
+        asm_code="""
+            PUSHU A
+            PUSHU IL
+            PUSHU BA
+            PUSHU I
+            PUSHU X
+            PUSHU Y
+            PUSHU F
+            PUSHU IMR
+            POPU A
+            POPU IL
+            POPU BA
+            POPU I
+            POPU X
+            POPU Y
+            POPU F
+            POPU IMR
+        """,
+        expected_ti="""
+            @0000
+            28 29 2A 2B 2C 2D 2E 2F 38 39 3A 3B 3C 3D 3E 3F
+            q
+        """
+    ),
+    AssemblerTestCase(
         test_id="data_directive_defb_with_code",
         asm_code="""
             SECTION code


### PR DESCRIPTION
## Summary
- add PUSHU/POPU rules for generic registers
- expose helpers in `AsmTransformer`
- update missing instructions list
- expand assembler tests for PUSHU/POPU

## Testing
- `ruff check`
- `MYPYPATH=stubs mypy sc62015/pysc62015`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684420fd1bb88331913d941836e53f11