### PR TITLE
Add ADC and SBC assembler support

### DIFF
--- a/MISSING_INSTRUCTIONS.md
+++ b/MISSING_INSTRUCTIONS.md
@@ -15,8 +15,6 @@ Only a few `MV` forms are parsed today (`MV A,B`, `MV B,A`, and `MV (imem),(imem
 Basic addition (`ADD`) and subtraction (`SUB`) instructions are now supported in
 the assembler. The remaining missing set includes:
 
-- **Addition with carry**: `ADC`.
-- **Subtraction with borrow**: `SBC`.
 - **Multi-byte Arithmetic**: `ADCL`, `SBCL`.
 - **BCD Arithmetic**: `DADL`, `DSBL`.
 - **Packed BCD Modify**: `PMDF`.

--- a/sc62015/pysc62015/asm.lark
+++ b/sc62015/pysc62015/asm.lark
@@ -56,10 +56,18 @@ instruction: "NOP"i -> nop
            | add_imem_imm
            | add_a_imem
            | add_imem_a
+           | adc_a_imm
+           | adc_imem_imm
+           | adc_a_imem
+           | adc_imem_a
            | sub_a_imm
            | sub_imem_imm
            | sub_a_imem
            | sub_imem_a
+           | sbc_a_imm
+           | sbc_imem_imm
+           | sbc_a_imem
+           | sbc_imem_a
 
 and_imem_a.2: "AND"i imem_operand "," _A
 and_a_imem.2: "AND"i _A "," imem_operand
@@ -73,10 +81,20 @@ add_imem_imm.1: "ADD"i imem_operand "," expression
 add_a_imem.2: "ADD"i _A "," imem_operand
 add_imem_a.2: "ADD"i imem_operand "," _A
 
+adc_a_imm.1: "ADC"i _A "," expression
+adc_imem_imm.1: "ADC"i imem_operand "," expression
+adc_a_imem.2: "ADC"i _A "," imem_operand
+adc_imem_a.2: "ADC"i imem_operand "," _A
+
 sub_a_imm.1: "SUB"i _A "," expression
 sub_imem_imm.1: "SUB"i imem_operand "," expression
 sub_a_imem.2: "SUB"i _A "," imem_operand
 sub_imem_a.2: "SUB"i imem_operand "," _A
+
+sbc_a_imm.1: "SBC"i _A "," expression
+sbc_imem_imm.1: "SBC"i imem_operand "," expression
+sbc_a_imem.2: "SBC"i _A "," imem_operand
+sbc_imem_a.2: "SBC"i imem_operand "," _A
 
 
 // --- Data Directives ---

--- a/sc62015/pysc62015/asm.py
+++ b/sc62015/pysc62015/asm.py
@@ -28,7 +28,9 @@ from .instr import (
     POPU,
     AND,
     ADD,
+    ADC,
     SUB,
+    SBC,
     CALL,
     Imm16,
     Imm20,
@@ -417,6 +419,33 @@ class AsmTransformer(Transformer):
             "instruction": {"instr_class": ADD, "instr_opts": Opts(ops=[op1, Reg("A")])}
         }
 
+    def adc_a_imm(self, items: List[Any]) -> InstructionNode:
+        imm = Imm8()
+        imm.value = items[0]
+        return {
+            "instruction": {"instr_class": ADC, "instr_opts": Opts(ops=[Reg("A"), imm])}
+        }
+
+    def adc_imem_imm(self, items: List[Any]) -> InstructionNode:
+        op1, val = items
+        imm = Imm8()
+        imm.value = val
+        return {
+            "instruction": {"instr_class": ADC, "instr_opts": Opts(ops=[op1, imm])}
+        }
+
+    def adc_a_imem(self, items: List[Any]) -> InstructionNode:
+        op1 = items[0]
+        return {
+            "instruction": {"instr_class": ADC, "instr_opts": Opts(ops=[Reg("A"), op1])}
+        }
+
+    def adc_imem_a(self, items: List[Any]) -> InstructionNode:
+        op1 = items[0]
+        return {
+            "instruction": {"instr_class": ADC, "instr_opts": Opts(ops=[op1, Reg("A")])}
+        }
+
     def sub_a_imm(self, items: List[Any]) -> InstructionNode:
         imm = Imm8()
         imm.value = items[0]
@@ -442,6 +471,33 @@ class AsmTransformer(Transformer):
         op1 = items[0]
         return {
             "instruction": {"instr_class": SUB, "instr_opts": Opts(ops=[op1, Reg("A")])}
+        }
+
+    def sbc_a_imm(self, items: List[Any]) -> InstructionNode:
+        imm = Imm8()
+        imm.value = items[0]
+        return {
+            "instruction": {"instr_class": SBC, "instr_opts": Opts(ops=[Reg("A"), imm])}
+        }
+
+    def sbc_imem_imm(self, items: List[Any]) -> InstructionNode:
+        op1, val = items
+        imm = Imm8()
+        imm.value = val
+        return {
+            "instruction": {"instr_class": SBC, "instr_opts": Opts(ops=[op1, imm])}
+        }
+
+    def sbc_a_imem(self, items: List[Any]) -> InstructionNode:
+        op1 = items[0]
+        return {
+            "instruction": {"instr_class": SBC, "instr_opts": Opts(ops=[Reg("A"), op1])}
+        }
+
+    def sbc_imem_a(self, items: List[Any]) -> InstructionNode:
+        op1 = items[0]
+        return {
+            "instruction": {"instr_class": SBC, "instr_opts": Opts(ops=[op1, Reg("A")])}
         }
 
     def def_arg(self, items: List[Any]) -> str:

--- a/sc62015/pysc62015/test_asm.py
+++ b/sc62015/pysc62015/test_asm.py
@@ -299,6 +299,80 @@ assembler_test_cases: List[AssemblerTestCase] = [
             q
         """,
     ),
+    # --- ADC Instruction Tests ---
+    AssemblerTestCase(
+        test_id="adc_a_imm",
+        asm_code="ADC A, 0x01",
+        expected_ti="""
+            @0000
+            50 01
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="adc_imem_imm",
+        asm_code="ADC (0x10), 0x02",
+        expected_ti="""
+            @0000
+            51 10 02
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="adc_a_imem",
+        asm_code="ADC A, (0x20)",
+        expected_ti="""
+            @0000
+            52 20
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="adc_imem_a",
+        asm_code="ADC (0x30), A",
+        expected_ti="""
+            @0000
+            53 30
+            q
+        """,
+    ),
+    # --- SBC Instruction Tests ---
+    AssemblerTestCase(
+        test_id="sbc_a_imm",
+        asm_code="SBC A, 0x01",
+        expected_ti="""
+            @0000
+            58 01
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="sbc_imem_imm",
+        asm_code="SBC (0x10), 0x02",
+        expected_ti="""
+            @0000
+            59 10 02
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="sbc_a_imem",
+        asm_code="SBC A, (0x20)",
+        expected_ti="""
+            @0000
+            5A 20
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="sbc_imem_a",
+        asm_code="SBC (0x30), A",
+        expected_ti="""
+            @0000
+            5B 30
+            q
+        """,
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary
- implement ADC and SBC in the assembler grammar and transformer
- update missing-instruction list
- add ADC and SBC tests for each addressing mode

## Testing
- `ruff check`
- `mypy pysc62015`
- `pytest -vv`

------
https://chatgpt.com/codex/tasks/task_e_68442304bc788331ad93a1c492827b06