### PR TITLE
Add OR/XOR assembler support and tests

### DIFF
--- a/MISSING_INSTRUCTIONS.md
+++ b/MISSING_INSTRUCTIONS.md
@@ -29,9 +29,8 @@ Besides `RET`, `RETI`, and `RETF`, jump instructions are absent:
 - **Conditional Relative Jumps**: `JRZ`, `JRNZ`, `JRC`, `JRNC`.
 
 ## 4. Logical and Compare Instructions
-Logical, test, and compare instructions are largely unimplemented:
+Logical, test, and compare instructions are still partially unimplemented:
 
-- **Logical Ops**: `OR`, `XOR` with all addressing modes.
 - **Test**: `TEST` in all forms.
 - **Compare**: `CMP`, `CMPW`, `CMPP`.
 

--- a/sc62015/pysc62015/asm.lark
+++ b/sc62015/pysc62015/asm.lark
@@ -62,6 +62,18 @@ instruction: "NOP"i -> nop
            | sub_imem_imm
            | sub_a_imem
            | sub_imem_a
+           | or_imem_a
+           | or_a_imem
+           | or_a_imm
+           | or_imem_imm
+           | or_emem_imm
+           | or_imem_imem
+           | xor_imem_a
+           | xor_a_imem
+           | xor_a_imm
+           | xor_imem_imm
+           | xor_emem_imm
+           | xor_imem_imem
 
 and_imem_a.2: "AND"i imem_operand "," _A
 and_a_imem.2: "AND"i _A "," imem_operand
@@ -79,6 +91,20 @@ sub_a_imm.1: "SUB"i _A "," expression
 sub_imem_imm.1: "SUB"i imem_operand "," expression
 sub_a_imem.2: "SUB"i _A "," imem_operand
 sub_imem_a.2: "SUB"i imem_operand "," _A
+
+or_imem_a.2: "OR"i imem_operand "," _A
+or_a_imem.2: "OR"i _A "," imem_operand
+or_a_imm.1: "OR"i _A "," expression
+or_imem_imm.1: "OR"i imem_operand "," expression
+or_emem_imm.1: "OR"i emem_addr "," expression
+or_imem_imem.1: "OR"i imem_operand "," imem_operand
+
+xor_imem_a.2: "XOR"i imem_operand "," _A
+xor_a_imem.2: "XOR"i _A "," imem_operand
+xor_a_imm.1: "XOR"i _A "," expression
+xor_imem_imm.1: "XOR"i imem_operand "," expression
+xor_emem_imm.1: "XOR"i emem_addr "," expression
+xor_imem_imem.1: "XOR"i imem_operand "," imem_operand
 
 
 // --- Data Directives ---

--- a/sc62015/pysc62015/asm.py
+++ b/sc62015/pysc62015/asm.py
@@ -27,6 +27,8 @@ from .instr import (
     PUSHU,
     POPU,
     AND,
+    OR,
+    XOR,
     ADD,
     SUB,
     CALL,
@@ -450,6 +452,88 @@ class AsmTransformer(Transformer):
         op1 = items[0]
         return {
             "instruction": {"instr_class": SUB, "instr_opts": Opts(ops=[op1, Reg("A")])}
+        }
+
+    def or_a_imm(self, items: List[Any]) -> InstructionNode:
+        imm = Imm8()
+        imm.value = items[0]
+        return {
+            "instruction": {"instr_class": OR, "instr_opts": Opts(ops=[Reg("A"), imm])}
+        }
+
+    def or_imem_imm(self, items: List[Any]) -> InstructionNode:
+        op1, val = items
+        imm = Imm8()
+        imm.value = val
+        return {
+            "instruction": {"instr_class": OR, "instr_opts": Opts(ops=[op1, imm])}
+        }
+
+    def or_emem_imm(self, items: List[Any]) -> InstructionNode:
+        op1, val = items
+        imm = Imm8()
+        imm.value = val
+        return {
+            "instruction": {"instr_class": OR, "instr_opts": Opts(ops=[op1, imm])}
+        }
+
+    def or_imem_a(self, items: List[Any]) -> InstructionNode:
+        op1 = items[0]
+        return {
+            "instruction": {"instr_class": OR, "instr_opts": Opts(ops=[op1, Reg("A")])}
+        }
+
+    def or_a_imem(self, items: List[Any]) -> InstructionNode:
+        op1 = items[0]
+        return {
+            "instruction": {"instr_class": OR, "instr_opts": Opts(ops=[Reg("A"), op1])}
+        }
+
+    def or_imem_imem(self, items: List[Any]) -> InstructionNode:
+        op1, op2 = items
+        return {
+            "instruction": {"instr_class": OR, "instr_opts": Opts(ops=[op1, op2])}
+        }
+
+    def xor_a_imm(self, items: List[Any]) -> InstructionNode:
+        imm = Imm8()
+        imm.value = items[0]
+        return {
+            "instruction": {"instr_class": XOR, "instr_opts": Opts(ops=[Reg("A"), imm])}
+        }
+
+    def xor_imem_imm(self, items: List[Any]) -> InstructionNode:
+        op1, val = items
+        imm = Imm8()
+        imm.value = val
+        return {
+            "instruction": {"instr_class": XOR, "instr_opts": Opts(ops=[op1, imm])}
+        }
+
+    def xor_emem_imm(self, items: List[Any]) -> InstructionNode:
+        op1, val = items
+        imm = Imm8()
+        imm.value = val
+        return {
+            "instruction": {"instr_class": XOR, "instr_opts": Opts(ops=[op1, imm])}
+        }
+
+    def xor_imem_a(self, items: List[Any]) -> InstructionNode:
+        op1 = items[0]
+        return {
+            "instruction": {"instr_class": XOR, "instr_opts": Opts(ops=[op1, Reg("A")])}
+        }
+
+    def xor_a_imem(self, items: List[Any]) -> InstructionNode:
+        op1 = items[0]
+        return {
+            "instruction": {"instr_class": XOR, "instr_opts": Opts(ops=[Reg("A"), op1])}
+        }
+
+    def xor_imem_imem(self, items: List[Any]) -> InstructionNode:
+        op1, op2 = items
+        return {
+            "instruction": {"instr_class": XOR, "instr_opts": Opts(ops=[op1, op2])}
         }
 
     def def_arg(self, items: List[Any]) -> str:

--- a/sc62015/pysc62015/test_asm.py
+++ b/sc62015/pysc62015/test_asm.py
@@ -325,6 +325,116 @@ assembler_test_cases: List[AssemblerTestCase] = [
             q
         """,
     ),
+    # --- OR Instruction Tests ---
+    AssemblerTestCase(
+        test_id="or_a_imm",
+        asm_code="OR A, 0x55",
+        expected_ti="""
+            @0000
+            78 55
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="or_imem_imm",
+        asm_code="OR (0x10), 0x01",
+        expected_ti="""
+            @0000
+            79 10 01
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="or_emem_imm",
+        asm_code="OR [0x12345], 0x02",
+        expected_ti="""
+            @0000
+            7A 45 23 01 02
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="or_imem_a",
+        asm_code="OR (0x20), A",
+        expected_ti="""
+            @0000
+            7B 20
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="or_a_imem",
+        asm_code="OR A, (0x30)",
+        expected_ti="""
+            @0000
+            7F 30
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="or_imem_imem",
+        asm_code="OR (0x40), (0x50)",
+        expected_ti="""
+            @0000
+            7E 40 50
+            q
+        """,
+    ),
+    # --- XOR Instruction Tests ---
+    AssemblerTestCase(
+        test_id="xor_a_imm",
+        asm_code="XOR A, 0x55",
+        expected_ti="""
+            @0000
+            68 55
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="xor_imem_imm",
+        asm_code="XOR (0x10), 0x01",
+        expected_ti="""
+            @0000
+            69 10 01
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="xor_emem_imm",
+        asm_code="XOR [0x12345], 0x02",
+        expected_ti="""
+            @0000
+            6A 45 23 01 02
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="xor_imem_a",
+        asm_code="XOR (0x20), A",
+        expected_ti="""
+            @0000
+            6B 20
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="xor_a_imem",
+        asm_code="XOR A, (0x30)",
+        expected_ti="""
+            @0000
+            6F 30
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="xor_imem_imem",
+        asm_code="XOR (0x40), (0x50)",
+        expected_ti="""
+            @0000
+            6E 40 50
+            q
+        """,
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary
- implement `OR` and `XOR` instruction forms in the assembler
- remove them from the missing instructions list
- extend the grammar and transformer for all addressing modes
- add assembler test cases for `OR` and `XOR`

## Testing
- `ruff check`
- `MYPYPATH=stubs mypy sc62015/pysc62015`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68442389a34c8331bed86764cb2fa508