### PR TITLE
Add ADCL/SBCL assembler support

### DIFF
--- a/MISSING_INSTRUCTIONS.md
+++ b/MISSING_INSTRUCTIONS.md
@@ -15,7 +15,6 @@ Only a few `MV` forms are parsed today (`MV A,B`, `MV B,A`, and `MV (imem),(imem
 Basic addition (`ADD`) and subtraction (`SUB`) instructions are now supported in
 the assembler. The remaining missing set includes:
 
-- **Multi-byte Arithmetic**: `ADCL`, `SBCL`.
 - **BCD Arithmetic**: `DADL`, `DSBL`.
 - **Packed BCD Modify**: `PMDF`.
 

--- a/sc62015/pysc62015/asm.lark
+++ b/sc62015/pysc62015/asm.lark
@@ -70,6 +70,10 @@ instruction: "NOP"i -> nop
            | sbc_imem_imm
            | sbc_a_imem
            | sbc_imem_a
+           | adcl_imem_imem
+           | adcl_imem_a
+           | sbcl_imem_imem
+           | sbcl_imem_a
 
 and_imem_a.2: "AND"i imem_operand "," _A
 and_a_imem.2: "AND"i _A "," imem_operand
@@ -97,6 +101,11 @@ sbc_a_imm.1: "SBC"i _A "," expression
 sbc_imem_imm.1: "SBC"i imem_operand "," expression
 sbc_a_imem.2: "SBC"i _A "," imem_operand
 sbc_imem_a.2: "SBC"i imem_operand "," _A
+
+adcl_imem_imem.2: "ADCL"i imem_operand "," imem_operand
+adcl_imem_a.2:    "ADCL"i imem_operand "," _A
+sbcl_imem_imem.2: "SBCL"i imem_operand "," imem_operand
+sbcl_imem_a.2:    "SBCL"i imem_operand "," _A
 
 
 // --- Data Directives ---

--- a/sc62015/pysc62015/asm.py
+++ b/sc62015/pysc62015/asm.py
@@ -31,6 +31,8 @@ from .instr import (
     ADC,
     SUB,
     SBC,
+    ADCL,
+    SBCL,
     CALL,
     Imm16,
     Imm20,
@@ -506,6 +508,30 @@ class AsmTransformer(Transformer):
         op1 = items[0]
         return {
             "instruction": {"instr_class": SBC, "instr_opts": Opts(ops=[op1, Reg("A")])}
+        }
+
+    def adcl_imem_imem(self, items: List[Any]) -> InstructionNode:
+        dst, src = items
+        return {
+            "instruction": {"instr_class": ADCL, "instr_opts": Opts(ops=[dst, src])}
+        }
+
+    def adcl_imem_a(self, items: List[Any]) -> InstructionNode:
+        op1 = items[0]
+        return {
+            "instruction": {"instr_class": ADCL, "instr_opts": Opts(ops=[op1, Reg("A")])}
+        }
+
+    def sbcl_imem_imem(self, items: List[Any]) -> InstructionNode:
+        dst, src = items
+        return {
+            "instruction": {"instr_class": SBCL, "instr_opts": Opts(ops=[dst, src])}
+        }
+
+    def sbcl_imem_a(self, items: List[Any]) -> InstructionNode:
+        op1 = items[0]
+        return {
+            "instruction": {"instr_class": SBCL, "instr_opts": Opts(ops=[op1, Reg("A")])}
         }
 
     def def_arg(self, items: List[Any]) -> str:

--- a/sc62015/pysc62015/test_asm.py
+++ b/sc62015/pysc62015/test_asm.py
@@ -399,6 +399,44 @@ assembler_test_cases: List[AssemblerTestCase] = [
             q
         """,
     ),
+    # --- ADCL Instruction Tests ---
+    AssemblerTestCase(
+        test_id="adcl_imem_imem",
+        asm_code="ADCL (0x10), (0x20)",
+        expected_ti="""
+            @0000
+            54 10 20
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="adcl_imem_a",
+        asm_code="ADCL (0x30), A",
+        expected_ti="""
+            @0000
+            55 30
+            q
+        """,
+    ),
+    # --- SBCL Instruction Tests ---
+    AssemblerTestCase(
+        test_id="sbcl_imem_imem",
+        asm_code="SBCL (0x40), (0x50)",
+        expected_ti="""
+            @0000
+            5C 40 50
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="sbcl_imem_a",
+        asm_code="SBCL (0x60), A",
+        expected_ti="""
+            @0000
+            5D 60
+            q
+        """,
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary
- implement ADCL and SBCL in the assembler grammar and transformer
- remove them from the list of missing instructions
- provide assembler tests for ADCL/SBCL

## Testing
- `ruff check`
- `mypy pysc62015` *(fails: Cannot find implementation or library stub for module named "binaryninja")*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68442494c3108331a7a621d3b4b2adb8