### PR TITLE
Add DADL/DSBL assembler

### DIFF
--- a/MISSING_INSTRUCTIONS.md
+++ b/MISSING_INSTRUCTIONS.md
@@ -15,7 +15,7 @@ Only a few `MV` forms are parsed today (`MV A,B`, `MV B,A`, and `MV (imem),(imem
 Basic addition (`ADD`) and subtraction (`SUB`) instructions are now supported in
 the assembler. The remaining missing set includes:
 
-- **BCD Arithmetic**: `DADL`, `DSBL`.
+- **BCD Arithmetic**: *(all implemented)*
 - **Packed BCD Modify**: `PMDF`.
 
 ## 3. Program Flow Instructions

--- a/sc62015/pysc62015/asm.lark
+++ b/sc62015/pysc62015/asm.lark
@@ -74,6 +74,10 @@ instruction: "NOP"i -> nop
            | adcl_imem_a
            | sbcl_imem_imem
            | sbcl_imem_a
+           | dadl_imem_imem
+           | dadl_imem_a
+           | dsbl_imem_imem
+           | dsbl_imem_a
 
 and_imem_a.2: "AND"i imem_operand "," _A
 and_a_imem.2: "AND"i _A "," imem_operand
@@ -106,6 +110,10 @@ adcl_imem_imem.2: "ADCL"i imem_operand "," imem_operand
 adcl_imem_a.2:    "ADCL"i imem_operand "," _A
 sbcl_imem_imem.2: "SBCL"i imem_operand "," imem_operand
 sbcl_imem_a.2:    "SBCL"i imem_operand "," _A
+dadl_imem_imem.2: "DADL"i imem_operand "," imem_operand
+dadl_imem_a.2:    "DADL"i imem_operand "," _A
+dsbl_imem_imem.2: "DSBL"i imem_operand "," imem_operand
+dsbl_imem_a.2:    "DSBL"i imem_operand "," _A
 
 
 // --- Data Directives ---

--- a/sc62015/pysc62015/asm.py
+++ b/sc62015/pysc62015/asm.py
@@ -33,6 +33,8 @@ from .instr import (
     SBC,
     ADCL,
     SBCL,
+    DADL,
+    DSBL,
     CALL,
     Imm16,
     Imm20,
@@ -532,6 +534,30 @@ class AsmTransformer(Transformer):
         op1 = items[0]
         return {
             "instruction": {"instr_class": SBCL, "instr_opts": Opts(ops=[op1, Reg("A")])}
+        }
+
+    def dadl_imem_imem(self, items: List[Any]) -> InstructionNode:
+        dst, src = items
+        return {
+            "instruction": {"instr_class": DADL, "instr_opts": Opts(ops=[dst, src])}
+        }
+
+    def dadl_imem_a(self, items: List[Any]) -> InstructionNode:
+        op1 = items[0]
+        return {
+            "instruction": {"instr_class": DADL, "instr_opts": Opts(ops=[op1, Reg("A")])}
+        }
+
+    def dsbl_imem_imem(self, items: List[Any]) -> InstructionNode:
+        dst, src = items
+        return {
+            "instruction": {"instr_class": DSBL, "instr_opts": Opts(ops=[dst, src])}
+        }
+
+    def dsbl_imem_a(self, items: List[Any]) -> InstructionNode:
+        op1 = items[0]
+        return {
+            "instruction": {"instr_class": DSBL, "instr_opts": Opts(ops=[op1, Reg("A")])}
         }
 
     def def_arg(self, items: List[Any]) -> str:

--- a/sc62015/pysc62015/test_asm.py
+++ b/sc62015/pysc62015/test_asm.py
@@ -437,6 +437,44 @@ assembler_test_cases: List[AssemblerTestCase] = [
             q
         """,
     ),
+    # --- DADL Instruction Tests ---
+    AssemblerTestCase(
+        test_id="dadl_imem_imem",
+        asm_code="DADL (0x10), (0x20)",
+        expected_ti="""
+            @0000
+            C4 10 20
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="dadl_imem_a",
+        asm_code="DADL (0x30), A",
+        expected_ti="""
+            @0000
+            C5 30
+            q
+        """,
+    ),
+    # --- DSBL Instruction Tests ---
+    AssemblerTestCase(
+        test_id="dsbl_imem_imem",
+        asm_code="DSBL (0x40), (0x50)",
+        expected_ti="""
+            @0000
+            D4 40 50
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="dsbl_imem_a",
+        asm_code="DSBL (0x60), A",
+        expected_ti="""
+            @0000
+            D5 60
+            q
+        """,
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary
- implement assembler support for DADL and DSBL
- document completed BCD arithmetic support
- add DADL/DSBL rules to grammar and parser
- test code generation for each addressing mode

## Testing
- `ruff check`
- `MYPYPATH=stubs mypy sc62015/pysc62015`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684426b9ae10833198696738708e1445