### PR TITLE
Implement PMDF assembler support

### DIFF
--- a/MISSING_INSTRUCTIONS.md
+++ b/MISSING_INSTRUCTIONS.md
@@ -16,7 +16,6 @@ Basic addition (`ADD`) and subtraction (`SUB`) instructions are now supported in
 the assembler. The remaining missing set includes:
 
 - **BCD Arithmetic**: `DADL`, `DSBL`.
-- **Packed BCD Modify**: `PMDF`.
 
 ## 3. Program Flow Instructions
 Besides `RET`, `RETI`, and `RETF`, jump instructions are absent:

--- a/sc62015/pysc62015/asm.lark
+++ b/sc62015/pysc62015/asm.lark
@@ -74,6 +74,8 @@ instruction: "NOP"i -> nop
            | adcl_imem_a
            | sbcl_imem_imem
            | sbcl_imem_a
+           | pmdf_imem_imm
+           | pmdf_imem_a
 
 and_imem_a.2: "AND"i imem_operand "," _A
 and_a_imem.2: "AND"i _A "," imem_operand
@@ -106,6 +108,8 @@ adcl_imem_imem.2: "ADCL"i imem_operand "," imem_operand
 adcl_imem_a.2:    "ADCL"i imem_operand "," _A
 sbcl_imem_imem.2: "SBCL"i imem_operand "," imem_operand
 sbcl_imem_a.2:    "SBCL"i imem_operand "," _A
+pmdf_imem_imm.1: "PMDF"i imem_operand "," expression
+pmdf_imem_a.2:   "PMDF"i imem_operand "," _A
 
 
 // --- Data Directives ---

--- a/sc62015/pysc62015/asm.py
+++ b/sc62015/pysc62015/asm.py
@@ -33,6 +33,7 @@ from .instr import (
     SBC,
     ADCL,
     SBCL,
+    PMDF,
     CALL,
     Imm16,
     Imm20,
@@ -532,6 +533,20 @@ class AsmTransformer(Transformer):
         op1 = items[0]
         return {
             "instruction": {"instr_class": SBCL, "instr_opts": Opts(ops=[op1, Reg("A")])}
+        }
+
+    def pmdf_imem_imm(self, items: List[Any]) -> InstructionNode:
+        op1, val = items
+        imm = Imm8()
+        imm.value = val
+        return {
+            "instruction": {"instr_class": PMDF, "instr_opts": Opts(ops=[op1, imm])}
+        }
+
+    def pmdf_imem_a(self, items: List[Any]) -> InstructionNode:
+        op1 = items[0]
+        return {
+            "instruction": {"instr_class": PMDF, "instr_opts": Opts(ops=[op1, Reg("A")])}
         }
 
     def def_arg(self, items: List[Any]) -> str:

--- a/sc62015/pysc62015/test_asm.py
+++ b/sc62015/pysc62015/test_asm.py
@@ -437,6 +437,25 @@ assembler_test_cases: List[AssemblerTestCase] = [
             q
         """,
     ),
+    # --- PMDF Instruction Tests ---
+    AssemblerTestCase(
+        test_id="pmdf_imem_imm",
+        asm_code="PMDF (0x70), 0x03",
+        expected_ti="""
+            @0000
+            47 70 03
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="pmdf_imem_a",
+        asm_code="PMDF (0x80), A",
+        expected_ti="""
+            @0000
+            57 80
+            q
+        """,
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary
- implement PMDF instruction in assembler
- add grammar rules and transformer handlers
- include new PMDF assembler tests
- update missing-instruction list

## Testing
- `ruff check`
- `MYPYPATH=stubs mypy sc62015/pysc62015`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684426df92548331b784b8f20388b034