### PR TITLE
Implement JP/JR assembler

### DIFF
--- a/MISSING_INSTRUCTIONS.md
+++ b/MISSING_INSTRUCTIONS.md
@@ -22,7 +22,7 @@ the assembler. The remaining missing set includes:
 ## 3. Program Flow Instructions
 Besides `RET`, `RETI`, and `RETF`, jump instructions are absent:
 
-- **Unconditional Jumps**: `JP`, `JR` and their far or register forms.
+- **Unconditional Jumps**: far or register forms of `JP` and `JR`.
 - **Conditional Jumps**: `JPZ`, `JPNZ`, `JPC`, `JPNC`.
 - **Conditional Relative Jumps**: `JRZ`, `JRNZ`, `JRC`, `JRNC`.
 

--- a/sc62015/pysc62015/asm.lark
+++ b/sc62015/pysc62015/asm.lark
@@ -43,6 +43,12 @@ instruction: "NOP"i -> nop
            | "POPU"i reg -> popu_reg
            | "CALL"i expression -> call
            | "CALLF"i expression -> callf
+           | jp_reg
+           | jp_imem
+           | jp_abs
+           | jpf_abs
+           | "JR"i "+" expression -> jr_plus
+           | "JR"i "-" expression -> jr_minus
            | "INC"i reg -> inc_reg
            | "INC"i imem_operand -> inc_imem
            | "DEC"i reg -> dec_reg
@@ -70,6 +76,11 @@ instruction: "NOP"i -> nop
            | sbc_imem_imm
            | sbc_a_imem
            | sbc_imem_a
+
+jp_reg.2: "JP"i reg
+jp_imem.2: "JP"i imem_operand
+jp_abs.1: "JP"i expression
+jpf_abs.1: "JPF"i expression
 
 and_imem_a.2: "AND"i imem_operand "," _A
 and_a_imem.2: "AND"i _A "," imem_operand

--- a/sc62015/pysc62015/asm.py
+++ b/sc62015/pysc62015/asm.py
@@ -32,8 +32,12 @@ from .instr import (
     SUB,
     SBC,
     CALL,
+    JP_Abs,
+    JP_Rel,
     Imm16,
     Imm20,
+    ImmOffset,
+    IMem20,
     INC,
     DEC,
     Reg3,
@@ -270,6 +274,54 @@ class AsmTransformer(Transformer):
                 "instr_opts": Opts(name="CALLF", ops=[imm]),
             }
         }
+
+    def jp_abs(self, items: List[Any]) -> InstructionNode:
+        imm = Imm16()
+        imm.value = items[0]
+        return {
+            "instruction": {
+                "instr_class": JP_Abs,
+                "instr_opts": Opts(ops=[imm]),
+            }
+        }
+
+    def jpf_abs(self, items: List[Any]) -> InstructionNode:
+        imm = Imm20()
+        imm.value = items[0]
+        return {
+            "instruction": {
+                "instr_class": JP_Abs,
+                "instr_opts": Opts(name="JPF", ops=[imm]),
+            }
+        }
+
+    def jp_reg(self, items: List[Any]) -> InstructionNode:
+        reg = cast(Reg, items[0])
+        r = Reg3()
+        r.reg = reg.reg
+        r.reg_raw = Reg3.reg_idx(reg.reg)
+        r.high4 = 0
+        return {
+            "instruction": {"instr_class": JP_Abs, "instr_opts": Opts(ops=[r])}}
+
+    def jp_imem(self, items: List[Any]) -> InstructionNode:
+        op = cast(IMemOperand, items[0])
+        imm = IMem20()
+        imm.value = op.n_val
+        return {
+            "instruction": {"instr_class": JP_Abs, "instr_opts": Opts(ops=[imm])}}
+
+    def jr_plus(self, items: List[Any]) -> InstructionNode:
+        imm = ImmOffset("+")
+        imm.value = items[0]
+        return {
+            "instruction": {"instr_class": JP_Rel, "instr_opts": Opts(ops=[imm])}}
+
+    def jr_minus(self, items: List[Any]) -> InstructionNode:
+        imm = ImmOffset("-")
+        imm.value = items[0]
+        return {
+            "instruction": {"instr_class": JP_Rel, "instr_opts": Opts(ops=[imm])}}
 
     def inc_reg(self, items: List[Any]) -> InstructionNode:
         reg = cast(Reg, items[0])

--- a/sc62015/pysc62015/sc_asm.py
+++ b/sc62015/pysc62015/sc_asm.py
@@ -9,7 +9,17 @@ from plumbum import cli  # type: ignore[import-untyped]
 # Assuming the provided library files are in a package named 'sc62015'
 from .asm import AsmTransformer, asm_parser, ParsedInstruction
 from .coding import Encoder
-from .instr import Instruction, OPCODES, Opts, IMemOperand, IMem8, ImmOperand, Imm20, Reg3
+from .instr import (
+    Instruction,
+    OPCODES,
+    Opts,
+    IMemOperand,
+    IMem8,
+    ImmOperand,
+    Imm20,
+    ImmOffset,
+    Reg3,
+)
 
 # A simple cache for the reverse lookup table
 REVERSE_OPCODES_CACHE: Dict[str, List[Dict[str, Any]]] = {}
@@ -93,7 +103,16 @@ class Assembler:
                 for p_op, t_op in zip(provided_ops, template_ops):
                     if isinstance(t_op, IMem8) and isinstance(p_op, IMemOperand):
                         continue
-                    if isinstance(t_op, ImmOperand) and isinstance(p_op, ImmOperand):
+                    if isinstance(t_op, ImmOffset) and isinstance(p_op, ImmOffset):
+                        if t_op.sign != p_op.sign:
+                            converted_match = False
+                            break
+                        continue
+                    if (
+                        isinstance(t_op, ImmOperand)
+                        and isinstance(p_op, ImmOperand)
+                        and not isinstance(t_op, ImmOffset)
+                    ):
                         if type(p_op) is type(t_op):
                             continue
                     if isinstance(t_op, Reg3) and isinstance(p_op, Reg3):

--- a/sc62015/pysc62015/test_asm.py
+++ b/sc62015/pysc62015/test_asm.py
@@ -399,6 +399,61 @@ assembler_test_cases: List[AssemblerTestCase] = [
             q
         """,
     ),
+    # --- JP/JR Instruction Tests ---
+    AssemblerTestCase(
+        test_id="jp_abs",
+        asm_code="JP 0x1234",
+        expected_ti="""
+            @0000
+            02 34 12
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="jpf_abs",
+        asm_code="JPF 0xABCDE",
+        expected_ti="""
+            @0000
+            03 DE BC 0A
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="jp_imem",
+        asm_code="JP (0x10)",
+        expected_ti="""
+            @0000
+            10 10
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="jp_reg",
+        asm_code="JP S",
+        expected_ti="""
+            @0000
+            11 07
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="jr_plus",
+        asm_code="JR +0x05",
+        expected_ti="""
+            @0000
+            12 05
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="jr_minus",
+        asm_code="JR -0x02",
+        expected_ti="""
+            @0000
+            13 02
+            q
+        """,
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary
- handle JP and JR instructions in the assembler grammar
- implement transformer support for JP/JPF/JP register/imem and JR +/- forms
- support ImmOffset sign comparison when selecting opcodes
- add tests for the new jump instructions
- document implemented instructions

## Testing
- `ruff check`
- `mypy pysc62015` *(fails: Cannot find implementation or library stub for module named "binaryninja" etc.)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684425ed458c8331b6c8ffd7d45fafaf