### PR TITLE
Fix immediate operand typing

### DIFF
--- a/sc62015/pysc62015/instr.py
+++ b/sc62015/pysc62015/instr.py
@@ -731,7 +731,7 @@ class IMemOperand(Operand, HasWidth):
 
 
 class ImmOperand(Operand, HasWidth):
-    value: Optional[int]
+    value: Optional[Union[str, int]]
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}()"
@@ -743,7 +743,7 @@ class ImmOperand(Operand, HasWidth):
 
 # n: encoded as `n`
 class Imm8(ImmOperand):
-    def __init__(self, value: Optional[int]=None) -> None:
+    def __init__(self, value: Optional[Union[str, int]] = None) -> None:
         super().__init__()
         self.value = value
 


### PR DESCRIPTION
## Summary
- allow immediate operand classes to store unresolved label strings

## Testing
- `ruff check`
- `mypy sc62015/pysc62015` *(fails: Cannot find implementation or library stub for module named "binaryninja" etc.)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844be15b95083319b3059c7688ad6e0