### PR TITLE
Add conditional jump instructions

### DIFF
--- a/MISSING_INSTRUCTIONS.md
+++ b/MISSING_INSTRUCTIONS.md
@@ -14,11 +14,7 @@ Only a few `MV` forms are parsed today (`MV A,B`, `MV B,A`, and `MV (imem),(imem
 ## 2. Arithmetic Instructions: supposedly all implemented
 
 ## 3. Program Flow Instructions
-Besides `RET`, `RETI`, and `RETF`, jump instructions are absent:
-
-- **Unconditional Jumps**: far or register forms of `JP` and `JR`.
-- **Conditional Jumps**: `JPZ`, `JPNZ`, `JPC`, `JPNC`.
-- **Conditional Relative Jumps**: `JRZ`, `JRNZ`, `JRC`, `JRNC`.
+All jump, call, and return instructions are now supported by the assembler.
 
 ## 4. Logical and Compare Instructions
 Logical, test, and compare instructions are still partially unimplemented:

--- a/sc62015/pysc62015/asm.lark
+++ b/sc62015/pysc62015/asm.lark
@@ -47,8 +47,20 @@ instruction: "NOP"i -> nop
            | jp_imem
            | jp_abs
            | jpf_abs
+           | jpz_abs
+           | jpnz_abs
+           | jpc_abs
+           | jpnc_abs
            | "JR"i "+" expression -> jr_plus
            | "JR"i "-" expression -> jr_minus
+           | jrz_plus
+           | jrz_minus
+           | jrnz_plus
+           | jrnz_minus
+           | jrc_plus
+           | jrc_minus
+           | jrnc_plus
+           | jrnc_minus
            | "INC"i reg -> inc_reg
            | "INC"i imem_operand -> inc_imem
            | "DEC"i reg -> dec_reg
@@ -103,6 +115,18 @@ jp_reg.2: "JP"i reg
 jp_imem.2: "JP"i imem_operand
 jp_abs.1: "JP"i expression
 jpf_abs.1: "JPF"i expression
+jpz_abs.1: "JPZ"i expression
+jpnz_abs.1: "JPNZ"i expression
+jpc_abs.1: "JPC"i expression
+jpnc_abs.1: "JPNC"i expression
+jrz_plus.1: "JRZ"i "+" expression
+jrz_minus.1: "JRZ"i "-" expression
+jrnz_plus.1: "JRNZ"i "+" expression
+jrnz_minus.1: "JRNZ"i "-" expression
+jrc_plus.1: "JRC"i "+" expression
+jrc_minus.1: "JRC"i "-" expression
+jrnc_plus.1: "JRNC"i "+" expression
+jrnc_minus.1: "JRNC"i "-" expression
 
 and_imem_a.2: "AND"i imem_operand "," _A
 and_a_imem.2: "AND"i _A "," imem_operand

--- a/sc62015/pysc62015/asm.py
+++ b/sc62015/pysc62015/asm.py
@@ -302,6 +302,46 @@ class AsmTransformer(Transformer):
             }
         }
 
+    def jpz_abs(self, items: List[Any]) -> InstructionNode:
+        imm = Imm16()
+        imm.value = items[0]
+        return {
+            "instruction": {
+                "instr_class": JP_Abs,
+                "instr_opts": Opts(cond="Z", ops=[imm]),
+            }
+        }
+
+    def jpnz_abs(self, items: List[Any]) -> InstructionNode:
+        imm = Imm16()
+        imm.value = items[0]
+        return {
+            "instruction": {
+                "instr_class": JP_Abs,
+                "instr_opts": Opts(cond="NZ", ops=[imm]),
+            }
+        }
+
+    def jpc_abs(self, items: List[Any]) -> InstructionNode:
+        imm = Imm16()
+        imm.value = items[0]
+        return {
+            "instruction": {
+                "instr_class": JP_Abs,
+                "instr_opts": Opts(cond="C", ops=[imm]),
+            }
+        }
+
+    def jpnc_abs(self, items: List[Any]) -> InstructionNode:
+        imm = Imm16()
+        imm.value = items[0]
+        return {
+            "instruction": {
+                "instr_class": JP_Abs,
+                "instr_opts": Opts(cond="NC", ops=[imm]),
+            }
+        }
+
     def jp_reg(self, items: List[Any]) -> InstructionNode:
         reg = cast(Reg, items[0])
         r = Reg3()
@@ -314,7 +354,7 @@ class AsmTransformer(Transformer):
     def jp_imem(self, items: List[Any]) -> InstructionNode:
         op = cast(IMemOperand, items[0])
         imm = IMem20()
-        imm.value = op.n_val
+        imm.value = cast(Any, op.n_val)
         return {
             "instruction": {"instr_class": JP_Abs, "instr_opts": Opts(ops=[imm])}}
 
@@ -329,6 +369,86 @@ class AsmTransformer(Transformer):
         imm.value = items[0]
         return {
             "instruction": {"instr_class": JP_Rel, "instr_opts": Opts(ops=[imm])}}
+
+    def jrz_plus(self, items: List[Any]) -> InstructionNode:
+        imm = ImmOffset("+")
+        imm.value = items[0]
+        return {
+            "instruction": {
+                "instr_class": JP_Rel,
+                "instr_opts": Opts(cond="Z", ops=[imm]),
+            }
+        }
+
+    def jrz_minus(self, items: List[Any]) -> InstructionNode:
+        imm = ImmOffset("-")
+        imm.value = items[0]
+        return {
+            "instruction": {
+                "instr_class": JP_Rel,
+                "instr_opts": Opts(cond="Z", ops=[imm]),
+            }
+        }
+
+    def jrnz_plus(self, items: List[Any]) -> InstructionNode:
+        imm = ImmOffset("+")
+        imm.value = items[0]
+        return {
+            "instruction": {
+                "instr_class": JP_Rel,
+                "instr_opts": Opts(cond="NZ", ops=[imm]),
+            }
+        }
+
+    def jrnz_minus(self, items: List[Any]) -> InstructionNode:
+        imm = ImmOffset("-")
+        imm.value = items[0]
+        return {
+            "instruction": {
+                "instr_class": JP_Rel,
+                "instr_opts": Opts(cond="NZ", ops=[imm]),
+            }
+        }
+
+    def jrc_plus(self, items: List[Any]) -> InstructionNode:
+        imm = ImmOffset("+")
+        imm.value = items[0]
+        return {
+            "instruction": {
+                "instr_class": JP_Rel,
+                "instr_opts": Opts(cond="C", ops=[imm]),
+            }
+        }
+
+    def jrc_minus(self, items: List[Any]) -> InstructionNode:
+        imm = ImmOffset("-")
+        imm.value = items[0]
+        return {
+            "instruction": {
+                "instr_class": JP_Rel,
+                "instr_opts": Opts(cond="C", ops=[imm]),
+            }
+        }
+
+    def jrnc_plus(self, items: List[Any]) -> InstructionNode:
+        imm = ImmOffset("+")
+        imm.value = items[0]
+        return {
+            "instruction": {
+                "instr_class": JP_Rel,
+                "instr_opts": Opts(cond="NC", ops=[imm]),
+            }
+        }
+
+    def jrnc_minus(self, items: List[Any]) -> InstructionNode:
+        imm = ImmOffset("-")
+        imm.value = items[0]
+        return {
+            "instruction": {
+                "instr_class": JP_Rel,
+                "instr_opts": Opts(cond="NC", ops=[imm]),
+            }
+        }
 
     def inc_reg(self, items: List[Any]) -> InstructionNode:
         reg = cast(Reg, items[0])

--- a/sc62015/pysc62015/sc_asm.py
+++ b/sc62015/pysc62015/sc_asm.py
@@ -86,6 +86,7 @@ class Assembler:
 
         mnemonic = (instr_opts.name or instr_class.__name__.split("_")[0]).upper()
         provided_ops = instr_opts.ops or []
+        provided_cond = instr_opts.cond
 
         if mnemonic not in self._reverse_opcodes:
             raise AssemblerError(f"Unknown mnemonic: {mnemonic}")
@@ -93,6 +94,9 @@ class Assembler:
         # For the unambiguous grammar, we can match on class and operand representation
         for template in self._reverse_opcodes[mnemonic]:
             if template["class"] is not instr_class:
+                continue
+
+            if provided_cond is not None and template["opts"].cond != provided_cond:
                 continue
 
             template_ops = template["opts"].ops or []

--- a/sc62015/pysc62015/test_asm.py
+++ b/sc62015/pysc62015/test_asm.py
@@ -530,6 +530,114 @@ assembler_test_cases: List[AssemblerTestCase] = [
             q
         """,
     ),
+    AssemblerTestCase(
+        test_id="jpz_abs",
+        asm_code="JPZ 0x1234",
+        expected_ti="""
+            @0000
+            14 34 12
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="jpnz_abs",
+        asm_code="JPNZ 0x1234",
+        expected_ti="""
+            @0000
+            15 34 12
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="jpc_abs",
+        asm_code="JPC 0x1234",
+        expected_ti="""
+            @0000
+            16 34 12
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="jpnc_abs",
+        asm_code="JPNC 0x1234",
+        expected_ti="""
+            @0000
+            17 34 12
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="jrz_plus",
+        asm_code="JRZ +0x05",
+        expected_ti="""
+            @0000
+            18 05
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="jrz_minus",
+        asm_code="JRZ -0x02",
+        expected_ti="""
+            @0000
+            19 02
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="jrnz_plus",
+        asm_code="JRNZ +0x05",
+        expected_ti="""
+            @0000
+            1A 05
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="jrnz_minus",
+        asm_code="JRNZ -0x02",
+        expected_ti="""
+            @0000
+            1B 02
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="jrc_plus",
+        asm_code="JRC +0x05",
+        expected_ti="""
+            @0000
+            1C 05
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="jrc_minus",
+        asm_code="JRC -0x02",
+        expected_ti="""
+            @0000
+            1D 02
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="jrnc_plus",
+        asm_code="JRNC +0x05",
+        expected_ti="""
+            @0000
+            1E 05
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="jrnc_minus",
+        asm_code="JRNC -0x02",
+        expected_ti="""
+            @0000
+            1F 02
+            q
+        """,
+    ),
     # --- PMDF Instruction Tests ---
     AssemblerTestCase(
         test_id="pmdf_imem_imm",


### PR DESCRIPTION
## Summary
- implement conditional jumps in the assembler and parser
- update missing-instructions document
- extend code generation unit tests for new jump forms
- support conditional lookup in assembler backend

## Testing
- `ruff check`
- `MYPYPATH=stubs mypy sc62015/pysc62015`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844be4c331c8331b2a0edd39438a1c7