### PR TITLE
Implement exchange instructions

### DIFF
--- a/MISSING_INSTRUCTIONS.md
+++ b/MISSING_INSTRUCTIONS.md
@@ -27,9 +27,10 @@ Logical, test, and compare instructions are still partially unimplemented:
 - **Compare**: `CMP`, `CMPW`, `CMPP`.
 
 ## 5. Increment, Decrement, and Exchange Instructions
-Only `EX A,B` is implemented. Missing variants include:
+`EX A,B` and memory-to-memory forms are implemented. Missing variants include:
 
-- **Exchange**: `EX`, `EXW`, `EXP`, `EXL` with register and memory operands.
+- **Exchange**: register-to-register forms beyond `A,B`, and register-to-memory
+  combinations for `EX`, `EXW`, `EXP`, `EXL`.
 
 ## 6. Shift and Rotate Instructions
 The grammar supports the accumulator forms (`ROR A`, `ROL A`, `SHR A`, `SHL A`) but omits:

--- a/sc62015/pysc62015/asm.lark
+++ b/sc62015/pysc62015/asm.lark
@@ -54,6 +54,10 @@ instruction: "NOP"i -> nop
            | "DEC"i reg -> dec_reg
            | "DEC"i imem_operand -> dec_imem
            | "MV"i imem_operand "," imem_operand -> mv_imem_imem
+           | "EX"i imem_operand "," imem_operand -> ex_imem_imem
+           | "EXW"i imem_operand "," imem_operand -> exw_imem_imem
+           | "EXP"i imem_operand "," imem_operand -> exp_imem_imem
+           | "EXL"i imem_operand "," imem_operand -> exl_imem_imem
            | and_imem_a
            | and_a_imem
            | and_a_imm

--- a/sc62015/pysc62015/asm.py
+++ b/sc62015/pysc62015/asm.py
@@ -22,6 +22,7 @@ from .instr import (
     SHL,
     MV,
     EX,
+    EXL,
     PUSHS,
     POPS,
     PUSHU,
@@ -416,6 +417,30 @@ class AsmTransformer(Transformer):
         op1, op2 = items
         return {
             "instruction": {"instr_class": MV, "instr_opts": Opts(ops=[op1, op2])}
+        }
+
+    def ex_imem_imem(self, items: List[Any]) -> InstructionNode:
+        op1, op2 = items
+        return {
+            "instruction": {"instr_class": EX, "instr_opts": Opts(ops=[op1, op2])}
+        }
+
+    def exw_imem_imem(self, items: List[Any]) -> InstructionNode:
+        op1, op2 = items
+        return {
+            "instruction": {"instr_class": EX, "instr_opts": Opts(name="EXW", ops=[op1, op2])}
+        }
+
+    def exp_imem_imem(self, items: List[Any]) -> InstructionNode:
+        op1, op2 = items
+        return {
+            "instruction": {"instr_class": EX, "instr_opts": Opts(name="EXP", ops=[op1, op2])}
+        }
+
+    def exl_imem_imem(self, items: List[Any]) -> InstructionNode:
+        op1, op2 = items
+        return {
+            "instruction": {"instr_class": EXL, "instr_opts": Opts(ops=[op1, op2])}
         }
 
     def and_a_imm(self, items: List[Any]) -> InstructionNode:

--- a/sc62015/pysc62015/instr.py
+++ b/sc62015/pysc62015/instr.py
@@ -2361,6 +2361,19 @@ class ExchangeInstruction(Instruction):
         tmp.lift_assign(il, first.lift(il))
         first.lift_assign(il, second.lift(il))
         second.lift_assign(il, tmp.lift(il))
+
+    def encode(self, encoder: Encoder, addr: int) -> None:
+        op1, op2 = self.operands()
+        if isinstance(op1, IMemOperand) and isinstance(op2, IMemOperand):
+            pre_key = (op1.mode, op2.mode)
+            pre_byte = REVERSE_PRE_TABLE.get(pre_key)
+            if pre_byte is None:
+                raise ValueError(
+                    f"Invalid addressing mode combination for {self.name()}: {op1.mode.value} and {op2.mode.value}"
+                )
+            self._pre = pre_byte
+
+        super().encode(encoder, addr)
 class EX(ExchangeInstruction):
     def lift(self, il: LowLevelILFunction, addr: int) -> None:
         self.lift_single_exchange(il, addr)

--- a/sc62015/pysc62015/test_asm.py
+++ b/sc62015/pysc62015/test_asm.py
@@ -659,6 +659,52 @@ assembler_test_cases: List[AssemblerTestCase] = [
             q
         """,
     ),
+    # --- Exchange Instruction Tests ---
+    AssemblerTestCase(
+        test_id="ex_imem_imem_simple",
+        asm_code="EX (0x10), (0x20)",
+        expected_ti="""
+            @0000
+            32 C0 10 20
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="ex_imem_imem_complex",
+        asm_code="EX (BP+0x10), (PY+0x20)",
+        expected_ti="""
+            @0000
+            23 C0 10 20
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="exw_imem_imem_simple",
+        asm_code="EXW (0x30), (0x40)",
+        expected_ti="""
+            @0000
+            32 C1 30 40
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="exp_imem_imem_simple",
+        asm_code="EXP (0x50), (0x60)",
+        expected_ti="""
+            @0000
+            32 C2 50 60
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="exl_imem_imem_simple",
+        asm_code="EXL (0x70), (0x80)",
+        expected_ti="""
+            @0000
+            32 C3 70 80
+            q
+        """,
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary
- implement EX, EXW, EXP and EXL in the assembler
- handle PRE byte for exchange instructions
- update list of missing instructions
- add test cases for exchange instructions

## Testing
- `ruff check`
- `mypy sc62015/pysc62015` *(fails: Cannot find implementation or library stub for module named "binaryninja")*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844be8efc5c83318a898eb23b75c54d