### PR TITLE
Implement CMP assembler support

### DIFF
--- a/MISSING_INSTRUCTIONS.md
+++ b/MISSING_INSTRUCTIONS.md
@@ -24,7 +24,7 @@ Besides `RET`, `RETI`, and `RETF`, jump instructions are absent:
 Logical, test, and compare instructions are still partially unimplemented:
 
 - **Test**: `TEST` in all forms.
-- **Compare**: `CMP`, `CMPW`, `CMPP`.
+- **Compare**: all forms now implemented.
 
 ## 5. Increment, Decrement, and Exchange Instructions
 Only `EX A,B` is implemented. Missing variants include:

--- a/sc62015/pysc62015/asm.lark
+++ b/sc62015/pysc62015/asm.lark
@@ -98,6 +98,15 @@ instruction: "NOP"i -> nop
            | xor_imem_imm
            | xor_emem_imm
            | xor_imem_imem
+           | cmp_a_imm
+           | cmp_imem_imm
+           | cmp_emem_imm
+           | cmp_imem_a
+           | cmp_imem_imem
+           | cmpw_imem_imem
+           | cmpp_imem_imem
+           | cmpw_imem_reg
+           | cmpp_imem_reg
 
 jp_reg.2: "JP"i reg
 jp_imem.2: "JP"i imem_operand
@@ -156,6 +165,16 @@ xor_a_imm.1: "XOR"i _A "," expression
 xor_imem_imm.1: "XOR"i imem_operand "," expression
 xor_emem_imm.1: "XOR"i emem_addr "," expression
 xor_imem_imem.1: "XOR"i imem_operand "," imem_operand
+
+cmp_a_imm.1: "CMP"i _A "," expression
+cmp_imem_imm.1: "CMP"i imem_operand "," expression
+cmp_emem_imm.1: "CMP"i emem_addr "," expression
+cmp_imem_a.2: "CMP"i imem_operand "," _A
+cmp_imem_imem.1: "CMP"i imem_operand "," imem_operand
+cmpw_imem_imem.1: "CMPW"i imem_operand "," imem_operand
+cmpp_imem_imem.1: "CMPP"i imem_operand "," imem_operand
+cmpw_imem_reg.2: "CMPW"i imem_operand "," reg
+cmpp_imem_reg.2: "CMPP"i imem_operand "," reg
 
 
 // --- Data Directives ---

--- a/sc62015/pysc62015/asm.py
+++ b/sc62015/pysc62015/asm.py
@@ -38,6 +38,9 @@ from .instr import (
     DADL,
     DSBL,
     PMDF,
+    CMP,
+    CMPW,
+    CMPP,
     CALL,
     JP_Abs,
     JP_Rel,
@@ -45,6 +48,7 @@ from .instr import (
     Imm20,
     ImmOffset,
     IMem20,
+    IMem16,
     INC,
     DEC,
     Reg3,
@@ -314,7 +318,7 @@ class AsmTransformer(Transformer):
     def jp_imem(self, items: List[Any]) -> InstructionNode:
         op = cast(IMemOperand, items[0])
         imm = IMem20()
-        imm.value = op.n_val
+        imm.value = cast(int, op.n_val)
         return {
             "instruction": {"instr_class": JP_Abs, "instr_opts": Opts(ops=[imm])}}
 
@@ -709,6 +713,85 @@ class AsmTransformer(Transformer):
         op1, op2 = items
         return {
             "instruction": {"instr_class": XOR, "instr_opts": Opts(ops=[op1, op2])}
+        }
+
+    def cmp_a_imm(self, items: List[Any]) -> InstructionNode:
+        imm = Imm8()
+        imm.value = items[0]
+        return {
+            "instruction": {"instr_class": CMP, "instr_opts": Opts(ops=[Reg("A"), imm])}
+        }
+
+    def cmp_imem_imm(self, items: List[Any]) -> InstructionNode:
+        op1, val = items
+        imm = Imm8()
+        imm.value = val
+        return {
+            "instruction": {"instr_class": CMP, "instr_opts": Opts(ops=[op1, imm])}
+        }
+
+    def cmp_emem_imm(self, items: List[Any]) -> InstructionNode:
+        op1, val = items
+        imm = Imm8()
+        imm.value = val
+        return {
+            "instruction": {"instr_class": CMP, "instr_opts": Opts(ops=[op1, imm])}
+        }
+
+    def cmp_imem_a(self, items: List[Any]) -> InstructionNode:
+        op1 = items[0]
+        return {
+            "instruction": {"instr_class": CMP, "instr_opts": Opts(ops=[op1, Reg("A")])}
+        }
+
+    def cmp_imem_imem(self, items: List[Any]) -> InstructionNode:
+        op1, op2 = items
+        return {
+            "instruction": {"instr_class": CMP, "instr_opts": Opts(ops=[op1, op2])}
+        }
+
+    def cmpw_imem_imem(self, items: List[Any]) -> InstructionNode:
+        op1, op2 = items
+        m1 = IMem16()
+        m1.value = op1.n_val
+        m2 = IMem16()
+        m2.value = op2.n_val
+        return {
+            "instruction": {"instr_class": CMPW, "instr_opts": Opts(ops=[m1, m2])}
+        }
+
+    def cmpp_imem_imem(self, items: List[Any]) -> InstructionNode:
+        op1, op2 = items
+        m1 = IMem20()
+        m1.value = op1.n_val
+        m2 = IMem20()
+        m2.value = op2.n_val
+        return {
+            "instruction": {"instr_class": CMPP, "instr_opts": Opts(ops=[m1, m2])}
+        }
+
+    def cmpw_imem_reg(self, items: List[Any]) -> InstructionNode:
+        op1, reg = items
+        m = IMem16()
+        m.value = op1.n_val
+        r = Reg3()
+        r.reg = cast(Reg, reg).reg
+        r.reg_raw = Reg3.reg_idx(cast(str, r.reg))
+        r.high4 = 0
+        return {
+            "instruction": {"instr_class": CMPW, "instr_opts": Opts(ops=[m, r])}
+        }
+
+    def cmpp_imem_reg(self, items: List[Any]) -> InstructionNode:
+        op1, reg = items
+        m = IMem20()
+        m.value = op1.n_val
+        r = Reg3()
+        r.reg = cast(Reg, reg).reg
+        r.reg_raw = Reg3.reg_idx(cast(str, r.reg))
+        r.high4 = 0
+        return {
+            "instruction": {"instr_class": CMPP, "instr_opts": Opts(ops=[m, r])}
         }
 
     def def_arg(self, items: List[Any]) -> str:

--- a/sc62015/pysc62015/test_asm.py
+++ b/sc62015/pysc62015/test_asm.py
@@ -659,6 +659,88 @@ assembler_test_cases: List[AssemblerTestCase] = [
             q
         """,
     ),
+    # --- CMP Instruction Tests ---
+    AssemblerTestCase(
+        test_id="cmp_a_imm",
+        asm_code="CMP A, 0x55",
+        expected_ti="""
+            @0000
+            60 55
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="cmp_imem_imm",
+        asm_code="CMP (0x10), 0x02",
+        expected_ti="""
+            @0000
+            61 10 02
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="cmp_emem_imm",
+        asm_code="CMP [0x12345], 0x02",
+        expected_ti="""
+            @0000
+            62 45 23 01 02
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="cmp_imem_a",
+        asm_code="CMP (0x30), A",
+        expected_ti="""
+            @0000
+            63 30
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="cmp_imem_imem",
+        asm_code="CMP (0x40), (0x50)",
+        expected_ti="""
+            @0000
+            B7 40 50
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="cmpw_imem_imem",
+        asm_code="CMPW (0x10), (0x20)",
+        expected_ti="""
+            @0000
+            C6 10 20
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="cmpw_imem_reg",
+        asm_code="CMPW (0x30), BA",
+        expected_ti="""
+            @0000
+            D6 02 30
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="cmpp_imem_imem",
+        asm_code="CMPP (0x10), (0x20)",
+        expected_ti="""
+            @0000
+            C7 10 20
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="cmpp_imem_reg",
+        asm_code="CMPP (0x40), X",
+        expected_ti="""
+            @0000
+            D7 04 40
+            q
+        """,
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary
- add CMP, CMPW, and CMPP parsing rules
- implement assembler generation for CMP instructions
- document that compare instructions are now implemented
- test CMP code generation for all addressing modes

## Testing
- `ruff check`
- `MYPYPATH=stubs mypy sc62015/pysc62015`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844be7393008331a5741e31aa3bc775