### PR TITLE
Add register-register exchange support

### DIFF
--- a/MISSING_INSTRUCTIONS.md
+++ b/MISSING_INSTRUCTIONS.md
@@ -23,10 +23,10 @@ Logical, test, and compare instructions are still partially unimplemented:
 - **Compare**: `CMP`, `CMPW`, `CMPP`.
 
 ## 5. Increment, Decrement, and Exchange Instructions
-`EX A,B` and memory-to-memory forms are implemented. Missing variants include:
+`EX A,B`, register-to-register forms, and memory-to-memory forms are implemented.
+Missing variants include:
 
-- **Exchange**: register-to-register forms beyond `A,B`, and register-to-memory
-  combinations for `EX`, `EXW`, `EXP`, `EXL`.
+- **Exchange**: register-to-memory combinations for `EX`, `EXW`, `EXP`, `EXL`.
 
 ## 6. Shift and Rotate Instructions
 The grammar supports the accumulator forms (`ROR A`, `ROL A`, `SHR A`, `SHL A`) but omits:

--- a/sc62015/pysc62015/asm.lark
+++ b/sc62015/pysc62015/asm.lark
@@ -32,7 +32,7 @@ instruction: "NOP"i -> nop
            | "SHL"i _A -> shl_a
            | "MV"i _A "," _B -> mv_a_b
            | "MV"i _B "," _A -> mv_b_a
-           | "EX"i _A "," _B -> ex_a_b
+           | ex_a_b
            | "PUSHS"i _F -> pushs_f
            | "POPS"i _F -> pops_f
            | "PUSHU"i _F -> pushu_f
@@ -67,6 +67,7 @@ instruction: "NOP"i -> nop
            | "DEC"i imem_operand -> dec_imem
            | "MV"i imem_operand "," imem_operand -> mv_imem_imem
            | "EX"i imem_operand "," imem_operand -> ex_imem_imem
+           | "EX"i reg "," reg -> ex_reg_reg
            | "EXW"i imem_operand "," imem_operand -> exw_imem_imem
            | "EXP"i imem_operand "," imem_operand -> exp_imem_imem
            | "EXL"i imem_operand "," imem_operand -> exl_imem_imem
@@ -114,6 +115,8 @@ instruction: "NOP"i -> nop
            | xor_imem_imm
            | xor_emem_imm
            | xor_imem_imem
+
+ex_a_b.2: "EX"i _A "," _B
 
 jp_reg.2: "JP"i reg
 jp_imem.2: "JP"i imem_operand

--- a/sc62015/pysc62015/asm.py
+++ b/sc62015/pysc62015/asm.py
@@ -53,6 +53,7 @@ from .instr import (
     RegB,
     RegF,
     RegIMR,
+    RegPair,
     IMemOperand,
     Imm8,
     EMemAddr,
@@ -543,6 +544,17 @@ class AsmTransformer(Transformer):
         op1, op2 = items
         return {
             "instruction": {"instr_class": EX, "instr_opts": Opts(ops=[op1, op2])}
+        }
+
+    def ex_reg_reg(self, items: List[Any]) -> InstructionNode:
+        reg1 = cast(Reg, items[0])
+        reg2 = cast(Reg, items[1])
+        rp = RegPair(size=2)
+        rp.reg1 = reg1
+        rp.reg2 = reg2
+        rp.reg_raw = (RegPair.reg_idx(reg1.reg) << 4) | RegPair.reg_idx(reg2.reg)
+        return {
+            "instruction": {"instr_class": EX, "instr_opts": Opts(ops=[rp])}
         }
 
     def exw_imem_imem(self, items: List[Any]) -> InstructionNode:

--- a/sc62015/pysc62015/test_asm.py
+++ b/sc62015/pysc62015/test_asm.py
@@ -813,6 +813,15 @@ assembler_test_cases: List[AssemblerTestCase] = [
             q
         """,
     ),
+    AssemblerTestCase(
+        test_id="ex_reg_reg_simple",
+        asm_code="EX X, Y",
+        expected_ti="""
+            @0000
+            ED 45
+            q
+        """,
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary
- support generic register-to-register `EX` forms in the assembler
- list remaining missing exchange forms in docs
- document assembler grammar and builder for new form
- test register exchange code generation

## Testing
- `ruff check`
- `MYPYPATH=stubs mypy sc62015/pysc62015`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844c136c84483318a324622b5451dd9