### PR TITLE
Add DSLL/DSRL assembler support and tests

### DIFF
--- a/MISSING_INSTRUCTIONS.md
+++ b/MISSING_INSTRUCTIONS.md
@@ -32,7 +32,7 @@ Logical, test, and compare instructions are still partially unimplemented:
 The grammar supports the accumulator forms (`ROR A`, `ROL A`, `SHR A`, `SHL A`) but omits:
 
 - **Memory Forms**: `ROR (n)`, `ROL (n)`, `SHR (n)`, `SHL (n)`.
-- **Decimal Shifts**: `DSRL`, `DSLL`.
+- **Decimal Shifts**: *(implemented)*
 
 ## 7. Stack Instructions
 All user stack operations are now supported in the assembler.

--- a/sc62015/pysc62015/asm.lark
+++ b/sc62015/pysc62015/asm.lark
@@ -100,6 +100,8 @@ instruction: "NOP"i -> nop
            | dadl_imem_a
            | dsbl_imem_imem
            | dsbl_imem_a
+           | dsll_imem
+           | dsrl_imem
            | pmdf_imem_imm
            | pmdf_imem_a
            | or_imem_a
@@ -176,6 +178,9 @@ dadl_imem_imem.2: "DADL"i imem_operand "," imem_operand
 dadl_imem_a.2:    "DADL"i imem_operand "," _A
 dsbl_imem_imem.2: "DSBL"i imem_operand "," imem_operand
 dsbl_imem_a.2:    "DSBL"i imem_operand "," _A
+
+dsll_imem.1: "DSLL"i imem_operand
+dsrl_imem.1: "DSRL"i imem_operand
 
 pmdf_imem_imm.1: "PMDF"i imem_operand "," expression
 pmdf_imem_a.2:   "PMDF"i imem_operand "," _A

--- a/sc62015/pysc62015/asm.py
+++ b/sc62015/pysc62015/asm.py
@@ -38,6 +38,8 @@ from .instr import (
     SBCL,
     DADL,
     DSBL,
+    DSLL,
+    DSRL,
     PMDF,
     CMP,
     CMPW,
@@ -762,6 +764,18 @@ class AsmTransformer(Transformer):
         op1 = items[0]
         return {
             "instruction": {"instr_class": DSBL, "instr_opts": Opts(ops=[op1, Reg("A")])}
+        }
+
+    def dsll_imem(self, items: List[Any]) -> InstructionNode:
+        op = cast(IMemOperand, items[0])
+        return {
+            "instruction": {"instr_class": DSLL, "instr_opts": Opts(ops=[op])}
+        }
+
+    def dsrl_imem(self, items: List[Any]) -> InstructionNode:
+        op = cast(IMemOperand, items[0])
+        return {
+            "instruction": {"instr_class": DSRL, "instr_opts": Opts(ops=[op])}
         }
 
     def pmdf_imem_imm(self, items: List[Any]) -> InstructionNode:

--- a/sc62015/pysc62015/test_asm.py
+++ b/sc62015/pysc62015/test_asm.py
@@ -475,6 +475,25 @@ assembler_test_cases: List[AssemblerTestCase] = [
             q
         """,
     ),
+    # --- DSLL/DSRL Instruction Tests ---
+    AssemblerTestCase(
+        test_id="dsll_imem_direct",
+        asm_code="DSLL (0x10)",
+        expected_ti="""
+            @0000
+            EC 10
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="dsrl_imem_direct",
+        asm_code="DSRL (0x20)",
+        expected_ti="""
+            @0000
+            FC 20
+            q
+        """,
+    ),
     # --- JP/JR Instruction Tests ---
     AssemblerTestCase(
         test_id="jp_abs",


### PR DESCRIPTION
## Summary
- implement DSLL and DSRL instruction parsing in `asm.lark`
- add DSLL/DSRL handling in `AsmTransformer`
- mark decimal shifts as implemented in `MISSING_INSTRUCTIONS.md`
- create assembler unit tests for DSLL and DSRL

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844c28d3a088331a9d8b8a54bee34ab