### PR TITLE
Add assembler TEST instruction

### DIFF
--- a/MISSING_INSTRUCTIONS.md
+++ b/MISSING_INSTRUCTIONS.md
@@ -17,10 +17,7 @@ Only a few `MV` forms are parsed today (`MV A,B`, `MV B,A`, and `MV (imem),(imem
 All jump, call, and return instructions are now supported by the assembler.
 
 ## 4. Logical and Compare Instructions
-Logical, test, and compare instructions are still partially unimplemented:
-
-- **Test**: `TEST` in all forms.
-- **Compare**: all forms now implemented.
+All logical, test, and compare instructions are now implemented by the assembler.
 
 ## 5. Increment, Decrement, and Exchange Instructions
 `EX A,B` and memory-to-memory forms are implemented. Missing variants include:

--- a/sc62015/pysc62015/asm.lark
+++ b/sc62015/pysc62015/asm.lark
@@ -123,6 +123,10 @@ instruction: "NOP"i -> nop
            | cmpp_imem_imem
            | cmpw_imem_reg
            | cmpp_imem_reg
+           | test_a_imm
+           | test_imem_imm
+           | test_emem_imm
+           | test_imem_a
 
 jp_reg.2: "JP"i reg
 jp_imem.2: "JP"i imem_operand
@@ -203,6 +207,11 @@ cmpw_imem_imem.1: "CMPW"i imem_operand "," imem_operand
 cmpp_imem_imem.1: "CMPP"i imem_operand "," imem_operand
 cmpw_imem_reg.2: "CMPW"i imem_operand "," reg
 cmpp_imem_reg.2: "CMPP"i imem_operand "," reg
+
+test_a_imm.1: "TEST"i _A "," expression
+test_imem_imm.1: "TEST"i imem_operand "," expression
+test_emem_imm.1: "TEST"i emem_addr "," expression
+test_imem_a.2: "TEST"i imem_operand "," _A
 
 
 // --- Data Directives ---

--- a/sc62015/pysc62015/asm.py
+++ b/sc62015/pysc62015/asm.py
@@ -39,6 +39,7 @@ from .instr import (
     DADL,
     DSBL,
     PMDF,
+    TEST,
     CMP,
     CMPW,
     CMPP,
@@ -937,6 +938,35 @@ class AsmTransformer(Transformer):
         r.high4 = 0
         return {
             "instruction": {"instr_class": CMPP, "instr_opts": Opts(ops=[m, r])}
+        }
+
+    def test_a_imm(self, items: List[Any]) -> InstructionNode:
+        imm = Imm8()
+        imm.value = items[0]
+        return {
+            "instruction": {"instr_class": TEST, "instr_opts": Opts(ops=[Reg("A"), imm])}
+        }
+
+    def test_imem_imm(self, items: List[Any]) -> InstructionNode:
+        op1, val = items
+        imm = Imm8()
+        imm.value = val
+        return {
+            "instruction": {"instr_class": TEST, "instr_opts": Opts(ops=[op1, imm])}
+        }
+
+    def test_emem_imm(self, items: List[Any]) -> InstructionNode:
+        op1, val = items
+        imm = Imm8()
+        imm.value = val
+        return {
+            "instruction": {"instr_class": TEST, "instr_opts": Opts(ops=[op1, imm])}
+        }
+
+    def test_imem_a(self, items: List[Any]) -> InstructionNode:
+        op1 = items[0]
+        return {
+            "instruction": {"instr_class": TEST, "instr_opts": Opts(ops=[op1, Reg("A")])}
         }
 
     def def_arg(self, items: List[Any]) -> str:

--- a/sc62015/pysc62015/test_asm.py
+++ b/sc62015/pysc62015/test_asm.py
@@ -895,6 +895,43 @@ assembler_test_cases: List[AssemblerTestCase] = [
             q
         """,
     ),
+    # --- TEST Instruction Tests ---
+    AssemblerTestCase(
+        test_id="test_a_imm",
+        asm_code="TEST A, 0x55",
+        expected_ti="""
+            @0000
+            64 55
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="test_imem_imm",
+        asm_code="TEST (0x10), 0x01",
+        expected_ti="""
+            @0000
+            65 10 01
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="test_emem_imm",
+        asm_code="TEST [0x12345], 0x02",
+        expected_ti="""
+            @0000
+            66 45 23 01 02
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="test_imem_a",
+        asm_code="TEST (0x20), A",
+        expected_ti="""
+            @0000
+            67 20
+            q
+        """,
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary
- implement TEST instruction in asm grammar and transformer
- mark logical and compare instructions as fully implemented
- update unit tests for TEST assembler code generation

## Testing
- `ruff check`
- `mypy sc62015/pysc62015` *(fails: Cannot find module 'binaryninja')*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844c3af369883319f76bff733a1c94e