### PR TITLE
Fix RegisterName stub and usage

### DIFF
--- a/sc62015/pysc62015/asm.py
+++ b/sc62015/pysc62015/asm.py
@@ -1,4 +1,6 @@
 from typing import Any, List, Optional, Union, cast, TypedDict, Type
+from . import binja_api  # noqa: F401
+from binaryninja.architecture import RegisterName
 from lark import Lark, Transformer, Token
 from .instr import (
     Instruction,
@@ -947,7 +949,7 @@ class AsmTransformer(Transformer):
         m.value = op1.n_val
         r = Reg3()
         r.reg = cast(Reg, reg).reg
-        r.reg_raw = Reg3.reg_idx(cast(str, r.reg))
+        r.reg_raw = Reg3.reg_idx(cast(RegisterName, r.reg))
         r.high4 = 0
         return {
             "instruction": {"instr_class": CMPW, "instr_opts": Opts(ops=[m, r])}
@@ -959,7 +961,7 @@ class AsmTransformer(Transformer):
         m.value = op1.n_val
         r = Reg3()
         r.reg = cast(Reg, reg).reg
-        r.reg_raw = Reg3.reg_idx(cast(str, r.reg))
+        r.reg_raw = Reg3.reg_idx(cast(RegisterName, r.reg))
         r.high4 = 0
         return {
             "instruction": {"instr_class": CMPP, "instr_opts": Opts(ops=[m, r])}

--- a/stubs/binaryninja/architecture.pyi
+++ b/stubs/binaryninja/architecture.pyi
@@ -4,6 +4,14 @@ class Architecture:
     def __getitem__(self, name: str) -> "Architecture":
         ...
 
-RegisterName = str
-IntrinsicName = str
-FlagName = str
+
+class RegisterName(str):
+    ...
+
+
+class IntrinsicName(str):
+    ...
+
+
+class FlagName(str):
+    ...


### PR DESCRIPTION
## Summary
- update Binary Ninja stubs to model RegisterName/IntrinsicName/FlagName as classes
- ensure Binary Ninja mock API is loaded in `asm.py`
- fix type usage in CMPW/CMPP assembler handlers

## Testing
- `ruff check`
- `mypy sc62015/pysc62015`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844c5080b7883319574fe05b0556a3a