### PR TITLE
Clarify Exchange instruction availability

### DIFF
--- a/MISSING_INSTRUCTIONS.md
+++ b/MISSING_INSTRUCTIONS.md
@@ -21,9 +21,9 @@ All logical, test, and compare instructions are now implemented by the assembler
 
 ## 5. Increment, Decrement, and Exchange Instructions
 `EX A,B`, register-to-register forms, and memory-to-memory forms are implemented.
-Missing variants include:
-
-- **Exchange**: register-to-memory combinations for `EX`, `EXW`, `EXP`, `EXL`.
+Earlier versions of this document incorrectly listed "register-to-memory"
+exchange instructions as missing. The SC62015 architecture does not provide
+such opcodes, so there is nothing to implement in the assembler.
 
 ## 6. Shift and Rotate Instructions
 The grammar supports the accumulator forms (`ROR A`, `ROL A`, `SHR A`, `SHL A`) but omits:


### PR DESCRIPTION
## Summary
- document that register-to-memory Exchange opcodes do not exist

## Testing
- `ruff check`
- `mypy sc62015/pysc62015` *(fails: Cannot find module 'binaryninja')*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844c5a1620c83319b8f3df047f23c65