### PR TITLE
Add memory shift/rotate instructions

### DIFF
--- a/MISSING_INSTRUCTIONS.md
+++ b/MISSING_INSTRUCTIONS.md
@@ -26,10 +26,7 @@ Missing variants include:
 - **Exchange**: register-to-memory combinations for `EX`, `EXW`, `EXP`, `EXL`.
 
 ## 6. Shift and Rotate Instructions
-The grammar supports the accumulator forms (`ROR A`, `ROL A`, `SHR A`, `SHL A`) but omits:
-
-- **Memory Forms**: `ROR (n)`, `ROL (n)`, `SHR (n)`, `SHL (n)`.
-- **Decimal Shifts**: *(implemented)*
+All rotate, shift, and decimal shift forms are now supported by the assembler.
 
 ## 7. Stack Instructions
 All user stack operations are now supported in the assembler.

--- a/sc62015/pysc62015/asm.lark
+++ b/sc62015/pysc62015/asm.lark
@@ -30,6 +30,10 @@ instruction: "NOP"i -> nop
            | "ROL"i _A -> rol_a
            | "SHR"i _A -> shr_a
            | "SHL"i _A -> shl_a
+           | "ROR"i imem_operand -> ror_imem
+           | "ROL"i imem_operand -> rol_imem
+           | "SHR"i imem_operand -> shr_imem
+           | "SHL"i imem_operand -> shl_imem
            | "MV"i _A "," _B -> mv_a_b
            | "MV"i _B "," _A -> mv_b_a
            | ex_a_b
@@ -188,6 +192,11 @@ dsbl_imem_a.2:    "DSBL"i imem_operand "," _A
 
 dsll_imem.1: "DSLL"i imem_operand
 dsrl_imem.1: "DSRL"i imem_operand
+
+ror_imem.1: "ROR"i imem_operand
+rol_imem.1: "ROL"i imem_operand
+shr_imem.1: "SHR"i imem_operand
+shl_imem.1: "SHL"i imem_operand
 
 pmdf_imem_imm.1: "PMDF"i imem_operand "," expression
 pmdf_imem_a.2:   "PMDF"i imem_operand "," _A

--- a/sc62015/pysc62015/asm.py
+++ b/sc62015/pysc62015/asm.py
@@ -217,6 +217,22 @@ class AsmTransformer(Transformer):
     def shl_a(self, _: List[Any]) -> InstructionNode:
         return {"instruction": {"instr_class": SHL, "instr_opts": Opts(ops=[Reg("A")])}}
 
+    def ror_imem(self, items: List[Any]) -> InstructionNode:
+        op = cast(IMemOperand, items[0])
+        return {"instruction": {"instr_class": ROR, "instr_opts": Opts(ops=[op])}}
+
+    def rol_imem(self, items: List[Any]) -> InstructionNode:
+        op = cast(IMemOperand, items[0])
+        return {"instruction": {"instr_class": ROL, "instr_opts": Opts(ops=[op])}}
+
+    def shr_imem(self, items: List[Any]) -> InstructionNode:
+        op = cast(IMemOperand, items[0])
+        return {"instruction": {"instr_class": SHR, "instr_opts": Opts(ops=[op])}}
+
+    def shl_imem(self, items: List[Any]) -> InstructionNode:
+        op = cast(IMemOperand, items[0])
+        return {"instruction": {"instr_class": SHL, "instr_opts": Opts(ops=[op])}}
+
     def mv_a_b(self, _: List[Any]) -> InstructionNode:
         return {
             "instruction": {

--- a/sc62015/pysc62015/test_asm.py
+++ b/sc62015/pysc62015/test_asm.py
@@ -494,6 +494,223 @@ assembler_test_cases: List[AssemblerTestCase] = [
             q
         """,
     ),
+    # --- ROR/ROL/SHR/SHL Memory Instruction Tests ---
+    AssemblerTestCase(
+        test_id="ror_imem_n",
+        asm_code="ROR (0x10)",
+        expected_ti="""
+            @0000
+            E5 10
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="ror_imem_bp_n",
+        asm_code="ROR (BP+0x10)",
+        expected_ti="""
+            @0000
+            E5 10
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="ror_imem_px_n",
+        asm_code="ROR (PX+0x10)",
+        expected_ti="""
+            @0000
+            E5 10
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="ror_imem_py_n",
+        asm_code="ROR (PY+0x10)",
+        expected_ti="""
+            @0000
+            E5 10
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="ror_imem_bp_px",
+        asm_code="ROR (BP+PX)",
+        expected_ti="""
+            @0000
+            E5
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="ror_imem_bp_py",
+        asm_code="ROR (BP+PY)",
+        expected_ti="""
+            @0000
+            E5
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="rol_imem_n",
+        asm_code="ROL (0x11)",
+        expected_ti="""
+            @0000
+            E7 11
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="rol_imem_bp_n",
+        asm_code="ROL (BP+0x11)",
+        expected_ti="""
+            @0000
+            E7 11
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="rol_imem_px_n",
+        asm_code="ROL (PX+0x11)",
+        expected_ti="""
+            @0000
+            E7 11
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="rol_imem_py_n",
+        asm_code="ROL (PY+0x11)",
+        expected_ti="""
+            @0000
+            E7 11
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="rol_imem_bp_px",
+        asm_code="ROL (BP+PX)",
+        expected_ti="""
+            @0000
+            E7
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="rol_imem_bp_py",
+        asm_code="ROL (BP+PY)",
+        expected_ti="""
+            @0000
+            E7
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="shr_imem_n",
+        asm_code="SHR (0x12)",
+        expected_ti="""
+            @0000
+            F5 12
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="shr_imem_bp_n",
+        asm_code="SHR (BP+0x12)",
+        expected_ti="""
+            @0000
+            F5 12
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="shr_imem_px_n",
+        asm_code="SHR (PX+0x12)",
+        expected_ti="""
+            @0000
+            F5 12
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="shr_imem_py_n",
+        asm_code="SHR (PY+0x12)",
+        expected_ti="""
+            @0000
+            F5 12
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="shr_imem_bp_px",
+        asm_code="SHR (BP+PX)",
+        expected_ti="""
+            @0000
+            F5
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="shr_imem_bp_py",
+        asm_code="SHR (BP+PY)",
+        expected_ti="""
+            @0000
+            F5
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="shl_imem_n",
+        asm_code="SHL (0x13)",
+        expected_ti="""
+            @0000
+            F7 13
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="shl_imem_bp_n",
+        asm_code="SHL (BP+0x13)",
+        expected_ti="""
+            @0000
+            F7 13
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="shl_imem_px_n",
+        asm_code="SHL (PX+0x13)",
+        expected_ti="""
+            @0000
+            F7 13
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="shl_imem_py_n",
+        asm_code="SHL (PY+0x13)",
+        expected_ti="""
+            @0000
+            F7 13
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="shl_imem_bp_px",
+        asm_code="SHL (BP+PX)",
+        expected_ti="""
+            @0000
+            F7
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="shl_imem_bp_py",
+        asm_code="SHL (BP+PY)",
+        expected_ti="""
+            @0000
+            F7
+            q
+        """,
+    ),
     # --- JP/JR Instruction Tests ---
     AssemblerTestCase(
         test_id="jp_abs",


### PR DESCRIPTION
## Summary
- implement memory forms of ROR/ROL/SHR/SHL in assembler
- document implemented support in MISSING_INSTRUCTIONS.md
- update grammar and assembler transformer
- add codegen tests covering all addressing modes

## Testing
- `ruff check`
- `python scripts/run_mypy.py`
- `pytest -vv`

------
https://chatgpt.com/codex/tasks/task_e_6844c592339c83319ef77754dbfa88c5