### PR TITLE
Implement remaining MV assembler forms

### DIFF
--- a/MISSING_INSTRUCTIONS.md
+++ b/MISSING_INSTRUCTIONS.md
@@ -3,13 +3,10 @@
 This document catalogs classes of SC62015 instructions that are not yet recognized by the assembler grammar. The list can serve as a roadmap for implementing the remaining instruction forms.
 
 ## 1. Memory Transfer Instructions
-Only a few `MV` forms are parsed today (`MV A,B`, `MV B,A`, and `MV (imem),(imem)` which requires a `PRE` prefix). All other data movement variants remain unhandled:
-
-- **Move Immediate to Register** – e.g. `MV A, 0x42`, `MV BA, 0x1234`, `MV X, 0x56789`.
-- **Move Memory to Register** – direct internal `(n)`, direct external `[lmn]`, register indirect external `[r'3]` and variations, and memory indirect external `[(n)]`.
-- **Move Register to Memory** – direct internal, direct external, register indirect external, and memory indirect external forms.
-- **Block and Multi-byte Moves** – instructions such as `MVW`, `MVP`, `MVL`, `MVLD`.
-- **Register to Register Moves** – generic forms like `MV r2, r'2` or `MV r3, r'3`.
+All `MV` variants are now recognized by the assembler. This includes immediate
+loads into registers, register/memory transfers, external memory forms, block
+and multi-byte moves (`MVW`, `MVP`, `MVL`, `MVLD`), and generic register to
+register moves.
 
 ## 2. Arithmetic Instructions: supposedly all implemented
 

--- a/sc62015/pysc62015/asm.lark
+++ b/sc62015/pysc62015/asm.lark
@@ -36,6 +36,18 @@ instruction: "NOP"i -> nop
            | "SHL"i imem_operand -> shl_imem
            | "MV"i _A "," _B -> mv_a_b
            | "MV"i _B "," _A -> mv_b_a
+           | "MV"i reg "," reg -> mv_reg_reg
+           | "MV"i reg "," expression -> mv_reg_imm
+           | "MV"i reg "," imem_operand -> mv_reg_imem
+           | "MV"i reg "," emem_operand -> mv_reg_emem
+           | "MV"i imem_operand "," reg -> mv_imem_reg
+           | "MV"i emem_operand "," reg -> mv_emem_reg
+           | "MV"i imem_operand "," expression -> mv_imem_imm
+           | "MV"i emem_operand "," expression -> mv_emem_imm
+           | "MVW"i imem_operand "," imem_operand -> mvw_imem_imem
+           | "MVP"i imem_operand "," imem_operand -> mvp_imem_imem
+           | "MVL"i imem_operand "," imem_operand -> mvl_imem_imem
+           | "MVLD"i imem_operand "," imem_operand -> mvld_imem_imem
            | "EX"i _A "," _B -> ex_a_b
            | "PUSHS"i _F -> pushs_f
            | "POPS"i _F -> pops_f

--- a/sc62015/pysc62015/asm.py
+++ b/sc62015/pysc62015/asm.py
@@ -23,6 +23,8 @@ from .instr import (
     SHR,
     SHL,
     MV,
+    MVL,
+    MVLD,
     EX,
     EXL,
     PUSHS,
@@ -563,6 +565,104 @@ class AsmTransformer(Transformer):
         op1, op2 = items
         return {
             "instruction": {"instr_class": MV, "instr_opts": Opts(ops=[op1, op2])}
+        }
+
+    def mv_reg_reg(self, items: List[Any]) -> InstructionNode:
+        reg1 = cast(Reg, items[0])
+        reg2 = cast(Reg, items[1])
+        return {
+            "instruction": {"instr_class": MV, "instr_opts": Opts(ops=[reg1, reg2])}
+        }
+
+    def mv_reg_imm(self, items: List[Any]) -> InstructionNode:
+        reg = cast(Reg, items[0])
+        val = items[1]
+        width = reg.width()
+        if width == 1:
+            imm = Imm8()
+        elif width == 2:
+            imm = Imm16()
+        else:
+            imm = Imm20()
+        imm.value = val
+        return {
+            "instruction": {"instr_class": MV, "instr_opts": Opts(ops=[reg, imm])}
+        }
+
+    def mv_reg_imem(self, items: List[Any]) -> InstructionNode:
+        reg = cast(Reg, items[0])
+        mem = cast(IMemOperand, items[1])
+        return {
+            "instruction": {"instr_class": MV, "instr_opts": Opts(ops=[reg, mem])}
+        }
+
+    def mv_reg_emem(self, items: List[Any]) -> InstructionNode:
+        reg = cast(Reg, items[0])
+        mem = cast(EMemAddr, items[1])
+        return {
+            "instruction": {"instr_class": MV, "instr_opts": Opts(ops=[reg, mem])}
+        }
+
+    def mv_imem_reg(self, items: List[Any]) -> InstructionNode:
+        mem = cast(IMemOperand, items[0])
+        reg = cast(Reg, items[1])
+        return {
+            "instruction": {"instr_class": MV, "instr_opts": Opts(ops=[mem, reg])}
+        }
+
+    def mv_emem_reg(self, items: List[Any]) -> InstructionNode:
+        mem = cast(EMemAddr, items[0])
+        reg = cast(Reg, items[1])
+        return {
+            "instruction": {"instr_class": MV, "instr_opts": Opts(ops=[mem, reg])}
+        }
+
+    def mv_imem_imm(self, items: List[Any]) -> InstructionNode:
+        mem, val = items
+        imm = Imm8()
+        imm.value = val
+        return {
+            "instruction": {"instr_class": MV, "instr_opts": Opts(ops=[mem, imm])}
+        }
+
+    def mv_emem_imm(self, items: List[Any]) -> InstructionNode:
+        mem, val = items
+        imm = Imm8()
+        imm.value = val
+        return {
+            "instruction": {"instr_class": MV, "instr_opts": Opts(ops=[mem, imm])}
+        }
+
+    def mvw_imem_imem(self, items: List[Any]) -> InstructionNode:
+        op1, op2 = items
+        m1 = IMem16()
+        m1.value = op1.n_val
+        m2 = IMem16()
+        m2.value = op2.n_val
+        return {
+            "instruction": {"instr_class": MV, "instr_opts": Opts(name="MVW", ops=[m1, m2])}
+        }
+
+    def mvp_imem_imem(self, items: List[Any]) -> InstructionNode:
+        op1, op2 = items
+        m1 = IMem20()
+        m1.value = op1.n_val
+        m2 = IMem20()
+        m2.value = op2.n_val
+        return {
+            "instruction": {"instr_class": MV, "instr_opts": Opts(name="MVP", ops=[m1, m2])}
+        }
+
+    def mvl_imem_imem(self, items: List[Any]) -> InstructionNode:
+        op1, op2 = items
+        return {
+            "instruction": {"instr_class": MVL, "instr_opts": Opts(ops=[op1, op2])}
+        }
+
+    def mvld_imem_imem(self, items: List[Any]) -> InstructionNode:
+        op1, op2 = items
+        return {
+            "instruction": {"instr_class": MVLD, "instr_opts": Opts(ops=[op1, op2])}
         }
 
     def ex_imem_imem(self, items: List[Any]) -> InstructionNode:

--- a/sc62015/pysc62015/test_asm.py
+++ b/sc62015/pysc62015/test_asm.py
@@ -187,6 +187,87 @@ assembler_test_cases: List[AssemblerTestCase] = [
         asm_code='MV (BP+PX), (BP+PY)'
     ),
     AssemblerTestCase(
+        test_id="mv_reg_imm_8bit",
+        asm_code="MV A, 0x42",
+        expected_ti="""
+            @0000
+            08 42
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="mv_reg_imm_16bit",
+        asm_code="MV BA, 0x1234",
+        expected_ti="""
+            @0000
+            0A 34 12
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="mv_reg_imm_20bit",
+        asm_code="MV X, 0x12345",
+        expected_ti="""
+            @0000
+            0C 45 23 01
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="mv_reg_imem",
+        asm_code="MV A, (0x10)",
+        expected_ti="""
+            @0000
+            80 10
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="mv_imem_reg",
+        asm_code="MV (0x10), A",
+        expected_ti="""
+            @0000
+            A0 10
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="mv_imem_imm",
+        asm_code="MV (0x20), 0x55",
+        expected_ti="""
+            @0000
+            CC 20 55
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="mv_reg_emem",
+        asm_code="MV A, [0x12345]",
+        expected_ti="""
+            @0000
+            88 45 23 01
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="mv_emem_reg",
+        asm_code="MV [0x12345], A",
+        expected_ti="""
+            @0000
+            A8 45 23 01
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="mvw_imem_imem",
+        asm_code="MVW (0x30), (0x40)",
+        expected_ti="""
+            @0000
+            C9 30 40
+            q
+        """,
+    ),
+    AssemblerTestCase(
         test_id="and_all_forms",
         asm_code="""
             AND A, 0x55
@@ -1252,11 +1333,8 @@ def test_assembler_e2e(case: AssemblerTestCase) -> None:
 
 
 def test_assembler_fails_on_ambiguous_instruction() -> None:
-    """
-    Tests that the assembler fails to parse an instruction not in the grammar.
-    """
+    """Ensure previously ambiguous instructions now assemble."""
     assembler = Assembler()
-    # MV with an immediate value is not in the simple asm.lark grammar
     source_code = "MV A, 0x42"
-    with pytest.raises((AssemblerError, lark_exceptions.LarkError)):
-        assembler.assemble(source_code)
+    bin_file = assembler.assemble(source_code)
+    assert bin_file.as_ti_txt().strip() == "@0000\n08 42\nq"


### PR DESCRIPTION
## Summary
- implement new MV parsing rules for immediate, register, and memory forms
- support block move variants
- test assembler output for new forms and update ambiguous-instruction test
- document that MV instructions are now implemented

## Testing
- `ruff check`
- `mypy pysc62015` *(fails: Cannot find Binary Ninja stubs)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844d1dde4a88331bb6af0c3fdd24b87