### PR TITLE
Fix mypy error in assembler

### DIFF
--- a/sc62015/pysc62015/asm.py
+++ b/sc62015/pysc62015/asm.py
@@ -66,6 +66,7 @@ from .instr import (
     RegIMR,
     RegPair,
     IMemOperand,
+    ImmOperand,
     Imm8,
     EMemAddr,
     AddressingMode,
@@ -578,6 +579,7 @@ class AsmTransformer(Transformer):
         reg = cast(Reg, items[0])
         val = items[1]
         width = reg.width()
+        imm: ImmOperand
         if width == 1:
             imm = Imm8()
         elif width == 2:


### PR DESCRIPTION
## Summary
- annotate `mv_reg_imm` to allow any immediate width
- import `ImmOperand`

## Testing
- `ruff check`
- `python scripts/run_mypy.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844d49e53888331972ed7f86a1fc9f8