### PR TITLE
Split lint and test steps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,11 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-      - run: python -m pip install -e .[dev]
-      - run: ruff check
-      - run: python scripts/run_mypy.py
-      - run: pytest -q
+      - name: Install dependencies
+        run: python -m pip install -e .[dev]
+      - name: Run Ruff
+        run: ruff check
+      - name: Run Mypy
+        run: python scripts/run_mypy.py
+      - name: Run Pytest
+        run: pytest -q


### PR DESCRIPTION
## Summary
- organize lint/test steps

## Testing
- `ruff check`
- `python scripts/run_mypy.py` *(fails: Incompatible types in assignment)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844d52b0f8c8331a177845027b856a3