### PR TITLE
Implement MVW/MVP immediate forms

### DIFF
--- a/sc62015/pysc62015/asm.lark
+++ b/sc62015/pysc62015/asm.lark
@@ -48,7 +48,9 @@ instruction: "NOP"i -> nop
            | "MV"i emem_operand "," reg -> mv_emem_reg
            | "MV"i imem_operand "," expression -> mv_imem_imm
            | "MV"i emem_operand "," expression -> mv_emem_imm
+           | "MVW"i imem_operand "," expression -> mvw_imem_imm
            | "MVW"i imem_operand "," imem_operand -> mvw_imem_imem
+           | "MVP"i imem_operand "," expression -> mvp_imem_imm
            | "MVP"i imem_operand "," imem_operand -> mvp_imem_imem
            | "MVL"i imem_operand "," imem_operand -> mvl_imem_imem
            | "MVLD"i imem_operand "," imem_operand -> mvld_imem_imem

--- a/sc62015/pysc62015/asm.py
+++ b/sc62015/pysc62015/asm.py
@@ -780,6 +780,16 @@ class AsmTransformer(Transformer):
             "instruction": {"instr_class": MV, "instr_opts": Opts(name="MVW", ops=[m1, m2])}
         }
 
+    def mvw_imem_imm(self, items: List[Any]) -> InstructionNode:
+        mem, val = items
+        dst = IMem16()
+        dst.value = mem.n_val
+        imm = Imm16()
+        imm.value = val
+        return {
+            "instruction": {"instr_class": MV, "instr_opts": Opts(name="MVW", ops=[dst, imm])}
+        }
+
     def mvp_imem_imem(self, items: List[Any]) -> InstructionNode:
         op1, op2 = items
         m1 = IMem20()
@@ -788,6 +798,16 @@ class AsmTransformer(Transformer):
         m2.value = op2.n_val
         return {
             "instruction": {"instr_class": MV, "instr_opts": Opts(name="MVP", ops=[m1, m2])}
+        }
+
+    def mvp_imem_imm(self, items: List[Any]) -> InstructionNode:
+        mem, val = items
+        dst = IMem20()
+        dst.value = mem.n_val
+        imm = Imm20()
+        imm.value = val
+        return {
+            "instruction": {"instr_class": MV, "instr_opts": Opts(name="MVP", ops=[dst, imm])}
         }
 
     def mvl_imem_imem(self, items: List[Any]) -> InstructionNode:

--- a/sc62015/pysc62015/test_asm.py
+++ b/sc62015/pysc62015/test_asm.py
@@ -268,6 +268,24 @@ assembler_test_cases: List[AssemblerTestCase] = [
         """,
     ),
     AssemblerTestCase(
+        test_id="mvw_imem_imm",
+        asm_code="MVW (0x30), 0x1122",
+        expected_ti="""
+            @0000
+            CD 30 22 11
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="mvp_imem_imm",
+        asm_code="MVP (0x20), 0x112233",
+        expected_ti="""
+            @0000
+            DC 20 33 22 11
+            q
+        """,
+    ),
+    AssemblerTestCase(
         test_id="and_all_forms",
         asm_code="""
             AND A, 0x55


### PR DESCRIPTION
## Summary
- support `MVW (l), mn` 16-bit immediate moves
- support `MVP (k), lmn` 24-bit immediate moves
- add assembler tests for these opcodes

## Testing
- `ruff check . --fix`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844d9dc2c848331922be8f3f328d5d6