### PR TITLE
Support register-based ADD/SUB

### DIFF
--- a/sc62015/pysc62015/asm.lark
+++ b/sc62015/pysc62015/asm.lark
@@ -97,18 +97,22 @@ instruction: "NOP"i -> nop
            | "AND"i imem_operand "," expression -> and_imem_imm
            | "AND"i emem_addr "," expression -> and_emem_imm
            | "AND"i imem_operand "," imem_operand -> and_imem_imem
+           | "ADD"i _A "," reg -> add_reg_reg
            | "ADD"i _A "," expression -> add_a_imm
            | "ADD"i imem_operand "," expression -> add_imem_imm
            | "ADD"i _A "," imem_operand -> add_a_imem
            | "ADD"i imem_operand "," _A -> add_imem_a
+           | "ADD"i reg "," reg -> add_reg_reg
            | "ADC"i _A "," expression -> adc_a_imm
            | "ADC"i imem_operand "," expression -> adc_imem_imm
            | "ADC"i _A "," imem_operand -> adc_a_imem
            | "ADC"i imem_operand "," _A -> adc_imem_a
+           | "SUB"i _A "," reg -> sub_reg_reg
            | "SUB"i _A "," expression -> sub_a_imm
            | "SUB"i imem_operand "," expression -> sub_imem_imm
            | "SUB"i _A "," imem_operand -> sub_a_imem
            | "SUB"i imem_operand "," _A -> sub_imem_a
+           | "SUB"i reg "," reg -> sub_reg_reg
            | "SBC"i _A "," expression -> sbc_a_imm
            | "SBC"i imem_operand "," expression -> sbc_imem_imm
            | "SBC"i _A "," imem_operand -> sbc_a_imem

--- a/sc62015/pysc62015/asm.py
+++ b/sc62015/pysc62015/asm.py
@@ -516,6 +516,21 @@ class AsmTransformer(Transformer):
             return RegB()
         return Reg(reg_name)
 
+    def _make_reg_pair(self, reg1: Reg, reg2: Reg) -> RegPair:
+        rp = RegPair()
+        rp.reg1 = reg1
+        rp.reg2 = reg2
+        rp.reg_raw = (RegPair.reg_idx(reg1.reg) << 4) | RegPair.reg_idx(reg2.reg)
+
+        if reg1.width() >= 3:
+            rp.size = 3
+        else:
+            if reg1.width() == reg2.width():
+                rp.size = reg1.width()
+            else:
+                rp.size = reg1.width()
+        return rp
+
     def atom(self, items: List[Any]) -> str:
         # This will return a number as a string, or a symbol name.
         # The assembler will resolve it later.
@@ -905,6 +920,16 @@ class AsmTransformer(Transformer):
             "instruction": {"instr_class": ADD, "instr_opts": Opts(ops=[op1, Reg("A")])}
         }
 
+    def add_reg_reg(self, items: List[Any]) -> InstructionNode:
+        if len(items) == 1:
+            reg1 = Reg("A")
+            reg2 = cast(Reg, items[0])
+        else:
+            reg1 = cast(Reg, items[0])
+            reg2 = cast(Reg, items[1])
+        rp = self._make_reg_pair(reg1, reg2)
+        return {"instruction": {"instr_class": ADD, "instr_opts": Opts(ops=[rp])}}
+
     def adc_a_imm(self, items: List[Any]) -> InstructionNode:
         imm = Imm8()
         imm.value = items[0]
@@ -958,6 +983,16 @@ class AsmTransformer(Transformer):
         return {
             "instruction": {"instr_class": SUB, "instr_opts": Opts(ops=[op1, Reg("A")])}
         }
+
+    def sub_reg_reg(self, items: List[Any]) -> InstructionNode:
+        if len(items) == 1:
+            reg1 = Reg("A")
+            reg2 = cast(Reg, items[0])
+        else:
+            reg1 = cast(Reg, items[0])
+            reg2 = cast(Reg, items[1])
+        rp = self._make_reg_pair(reg1, reg2)
+        return {"instruction": {"instr_class": SUB, "instr_opts": Opts(ops=[rp])}}
 
     def sbc_a_imm(self, items: List[Any]) -> InstructionNode:
         imm = Imm8()

--- a/sc62015/pysc62015/sc_asm.py
+++ b/sc62015/pysc62015/sc_asm.py
@@ -19,6 +19,7 @@ from .instr import (
     Imm20,
     ImmOffset,
     Reg3,
+    RegPair,
     REVERSE_PRE_TABLE,
     SINGLE_OPERAND_PRE_LOOKUP,
     AddressingMode,
@@ -122,6 +123,15 @@ class Assembler:
                     ):
                         if type(p_op) is type(t_op):
                             continue
+                    if isinstance(t_op, RegPair) and isinstance(p_op, RegPair):
+                        if (
+                            t_op.size is not None
+                            and p_op.size is not None
+                            and t_op.size != p_op.size
+                        ):
+                            converted_match = False
+                            break
+                        continue
                     if isinstance(t_op, Reg3) and isinstance(p_op, Reg3):
                         continue
                     if repr(p_op) != repr(t_op):

--- a/sc62015/pysc62015/test_asm.py
+++ b/sc62015/pysc62015/test_asm.py
@@ -387,6 +387,33 @@ assembler_test_cases: List[AssemblerTestCase] = [
             q
         """,
     ),
+    AssemblerTestCase(
+        test_id="add_reg_r1",
+        asm_code="ADD A, IL",
+        expected_ti="""
+            @0000
+            46 01
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="add_reg_r2",
+        asm_code="ADD BA, I",
+        expected_ti="""
+            @0000
+            44 23
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="add_reg_r3",
+        asm_code="ADD X, Y",
+        expected_ti="""
+            @0000
+            45 45
+            q
+        """,
+    ),
     # --- SUB Instruction Tests ---
     AssemblerTestCase(
         test_id="sub_a_imm",
@@ -421,6 +448,33 @@ assembler_test_cases: List[AssemblerTestCase] = [
         expected_ti="""
             @0000
             4B 30
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="sub_reg_r1",
+        asm_code="SUB A, IL",
+        expected_ti="""
+            @0000
+            4E 01
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="sub_reg_r2",
+        asm_code="SUB BA, I",
+        expected_ti="""
+            @0000
+            4C 23
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="sub_reg_r3",
+        asm_code="SUB X, Y",
+        expected_ti="""
+            @0000
+            4D 45
             q
         """,
     ),


### PR DESCRIPTION
## Summary
- add RegPair handling in opcode matching
- parse ADD/SUB register-register forms
- implement assembler helpers for RegPair
- test new ADD/SUB variants

## Testing
- `ruff check`
- `mypy sc62015/pysc62015` *(fails: Cannot find binaryninja stubs)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844d99bc9b08331a4dad145fa0f0dbc