### PR TITLE
Implement missing external memory moves

### DIFF
--- a/sc62015/pysc62015/asm.lark
+++ b/sc62015/pysc62015/asm.lark
@@ -48,11 +48,27 @@ instruction: "NOP"i -> nop
            | "MV"i emem_operand "," reg -> mv_emem_reg
            | "MV"i imem_operand "," expression -> mv_imem_imm
            | "MV"i emem_operand "," expression -> mv_emem_imm
+           | "MV"i imem_operand "," emem_reg_operand -> mv_imem_ememreg
+           | "MV"i emem_reg_operand "," imem_operand -> mv_ememreg_imem
+           | "MV"i imem_operand "," emem_imem_operand -> mv_imem_ememimem
+           | "MV"i emem_imem_operand "," imem_operand -> mv_ememimem_imem
+           | "MV"i imem_operand "," emem_operand -> mv_imem_emem
+           | "MV"i emem_operand "," imem_operand -> mv_emem_imem
            | "MVW"i imem_operand "," expression -> mvw_imem_imm
            | "MVW"i imem_operand "," imem_operand -> mvw_imem_imem
+           | "MVW"i imem_operand "," emem_operand -> mvw_imem_emem
+           | "MVW"i emem_operand "," imem_operand -> mvw_emem_imem
            | "MVP"i imem_operand "," expression -> mvp_imem_imm
            | "MVP"i imem_operand "," imem_operand -> mvp_imem_imem
+           | "MVP"i imem_operand "," emem_operand -> mvp_imem_emem
+           | "MVP"i emem_operand "," imem_operand -> mvp_emem_imem
            | "MVL"i imem_operand "," imem_operand -> mvl_imem_imem
+           | "MVL"i imem_operand "," emem_operand -> mvl_imem_emem
+           | "MVL"i emem_operand "," imem_operand -> mvl_emem_imem
+           | "MVL"i imem_operand "," emem_reg_operand -> mvl_imem_ememreg
+           | "MVL"i emem_reg_operand "," imem_operand -> mvl_ememreg_imem
+           | "MVL"i imem_operand "," emem_imem_operand -> mvl_imem_ememimem
+           | "MVL"i emem_imem_operand "," imem_operand -> mvl_ememimem_imem
            | "MVLD"i imem_operand "," imem_operand -> mvld_imem_imem
            | "EX"i _A "," _B -> ex_a_b
            | "PUSHS"i _F -> pushs_f

--- a/sc62015/pysc62015/asm.py
+++ b/sc62015/pysc62015/asm.py
@@ -794,7 +794,7 @@ class AsmTransformer(Transformer):
         regop = cast(EMemReg, items[1])
         op = RegIMemOffset(order=RegIMemOffsetOrder.DEST_IMEM)
         im = IMem8()
-        im.value = imem.n_val
+        im.value = int(imem.n_val, 0) if isinstance(imem.n_val, str) else imem.n_val
         op.imem = im
         op.reg = regop.reg
         op.mode = regop.mode
@@ -806,7 +806,7 @@ class AsmTransformer(Transformer):
         imem = cast(IMemOperand, items[1])
         op = RegIMemOffset(order=RegIMemOffsetOrder.DEST_REG_OFFSET)
         im = IMem8()
-        im.value = imem.n_val
+        im.value = int(imem.n_val, 0) if isinstance(imem.n_val, str) else imem.n_val
         op.imem = im
         op.reg = regop.reg
         op.mode = regop.mode
@@ -938,7 +938,7 @@ class AsmTransformer(Transformer):
         regop = cast(EMemReg, items[1])
         op = RegIMemOffset(order=RegIMemOffsetOrder.DEST_IMEM)
         im = IMem8()
-        im.value = imem.n_val
+        im.value = int(imem.n_val, 0) if isinstance(imem.n_val, str) else imem.n_val
         op.imem = im
         op.reg = regop.reg
         op.mode = regop.mode
@@ -950,7 +950,7 @@ class AsmTransformer(Transformer):
         imem = cast(IMemOperand, items[1])
         op = RegIMemOffset(order=RegIMemOffsetOrder.DEST_REG_OFFSET)
         im = IMem8()
-        im.value = imem.n_val
+        im.value = int(imem.n_val, 0) if isinstance(imem.n_val, str) else imem.n_val
         op.imem = im
         op.reg = regop.reg
         op.mode = regop.mode
@@ -963,10 +963,11 @@ class AsmTransformer(Transformer):
         op = EMemIMemOffset(EMemIMemOffsetOrder.DEST_INT_MEM)
         op.mode_imm.value = src.value
         im1 = IMem8()
-        im1.value = imem.n_val
+        im1.value = int(imem.n_val, 0) if isinstance(imem.n_val, str) else imem.n_val
         op.imem1 = im1
         im2 = IMem8()
-        im2.value = cast(IMemOperand, src.imem).n_val if isinstance(src.imem, IMemOperand) else src.imem.value
+        src_val = cast(IMemOperand, src.imem).n_val if isinstance(src.imem, IMemOperand) else src.imem.value
+        im2.value = int(src_val, 0) if isinstance(src_val, str) else src_val
         op.imem2 = im2
         op.mode = src.mode
         op.offset = src.offset
@@ -978,10 +979,11 @@ class AsmTransformer(Transformer):
         op = EMemIMemOffset(EMemIMemOffsetOrder.DEST_EXT_MEM)
         op.mode_imm.value = src.value
         im1 = IMem8()
-        im1.value = cast(IMemOperand, src.imem).n_val if isinstance(src.imem, IMemOperand) else src.imem.value
+        src_val = cast(IMemOperand, src.imem).n_val if isinstance(src.imem, IMemOperand) else src.imem.value
+        im1.value = int(src_val, 0) if isinstance(src_val, str) else src_val
         op.imem1 = im1
         im2 = IMem8()
-        im2.value = imem.n_val
+        im2.value = int(imem.n_val, 0) if isinstance(imem.n_val, str) else imem.n_val
         op.imem2 = im2
         op.mode = src.mode
         op.offset = src.offset

--- a/sc62015/pysc62015/instr/opcodes.py
+++ b/sc62015/pysc62015/instr/opcodes.py
@@ -1379,6 +1379,12 @@ class RegIMemOffset(HasOperands, Operand):
         self.order = order
         self.allowed_modes = allowed_modes
 
+    def __repr__(self) -> str:
+        return (
+            f"RegIMemOffset(order={self.order}, mode={getattr(self, 'mode', None)},"
+            f" offset={getattr(self, 'offset', None)})"
+        )
+
     def operands(self) -> Generator[Operand, None, None]:
         assert self.reg is not None, "Register not set"
         assert self.imem is not None, "IMem not set"
@@ -1540,6 +1546,12 @@ class EMemIMemOffset(HasOperands, Operand):
         self.mode_imm = Imm8()
         self.imem1 = IMem8()
         self.imem2 = IMem8()
+
+    def __repr__(self) -> str:
+        return (
+            f"EMemIMemOffset(order={self.order}, mode={getattr(self, 'mode', None)},"
+            f" offset={getattr(self, 'offset', None)})"
+        )
 
     def operands(self) -> Generator[Operand, None, None]:
         if self.order == EMemIMemOffsetOrder.DEST_INT_MEM:

--- a/sc62015/pysc62015/sc_asm.py
+++ b/sc62015/pysc62015/sc_asm.py
@@ -18,6 +18,8 @@ from .instr import (
     ImmOperand,
     Imm20,
     ImmOffset,
+    RegIMemOffset,
+    EMemIMemOffset,
     Reg3,
     REVERSE_PRE_TABLE,
     SINGLE_OPERAND_PRE_LOOKUP,
@@ -112,6 +114,16 @@ class Assembler:
                         continue
                     if isinstance(t_op, ImmOffset) and isinstance(p_op, ImmOffset):
                         if t_op.sign != p_op.sign:
+                            converted_match = False
+                            break
+                        continue
+                    if isinstance(t_op, RegIMemOffset) and isinstance(p_op, RegIMemOffset):
+                        if t_op.order != p_op.order:
+                            converted_match = False
+                            break
+                        continue
+                    if isinstance(t_op, EMemIMemOffset) and isinstance(p_op, EMemIMemOffset):
+                        if t_op.order != p_op.order:
                             converted_match = False
                             break
                         continue

--- a/sc62015/pysc62015/test_asm.py
+++ b/sc62015/pysc62015/test_asm.py
@@ -286,6 +286,69 @@ assembler_test_cases: List[AssemblerTestCase] = [
         """,
     ),
     AssemblerTestCase(
+        test_id="mv_imem_emem_abs",
+        asm_code="MV (0x10), [0x12345]",
+        expected_ti="""
+            @0000
+            D0 10 45 23 01
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="mv_emem_abs_imem",
+        asm_code="MV [0x12345], (0x20)",
+        expected_ti="""
+            @0000
+            D8 45 23 01 20
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="mvw_imem_emem_abs",
+        asm_code="MVW (0x30), [0x12345]",
+        expected_ti="""
+            @0000
+            D1 30 45 23 01
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="mv_imem_ememreg_simple",
+        asm_code="MV (0x20), [X]",
+        expected_ti="""
+            @0000
+            E0 04 20
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="mv_ememreg_imem_simple",
+        asm_code="MV [X], (0x20)",
+        expected_ti="""
+            @0000
+            E8 04 20
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="mv_imem_ememimem_simple",
+        asm_code="MV (0x30), [(0x40)]",
+        expected_ti="""
+            @0000
+            F0 00 30 40
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="mv_ememimem_imem_simple",
+        asm_code="MV [(0x40)], (0x30)",
+        expected_ti="""
+            @0000
+            F8 00 40 30
+            q
+        """,
+    ),
+    AssemblerTestCase(
         test_id="and_all_forms",
         asm_code="""
             AND A, 0x55


### PR DESCRIPTION
## Summary
- support external absolute, register, and indirect moves
- add assembler logic for RegIMemOffset/EMemIMemOffset
- handle PRE byte operand matching for new instructions
- test assembler with new move forms

## Testing
- `ruff check`
- `mypy sc62015/pysc62015` *(fails: Cannot find implementation or library stub for module named "binaryninja" etc.)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844db6e236c8331933663f054685d92