### PR TITLE
Fix MVW emem-imem encoding

### DIFF
--- a/sc62015/pysc62015/asm.lark
+++ b/sc62015/pysc62015/asm.lark
@@ -56,6 +56,8 @@ instruction: "NOP"i -> nop
            | "MV"i emem_operand "," imem_operand -> mv_emem_imem
            | "MVW"i imem_operand "," expression -> mvw_imem_imm
            | "MVW"i imem_operand "," imem_operand -> mvw_imem_imem
+           | "MVW"i imem_operand "," emem_imem_operand -> mvw_imem_ememimem
+           | "MVW"i emem_imem_operand "," imem_operand -> mvw_ememimem_imem
            | "MVW"i imem_operand "," emem_operand -> mvw_imem_emem
            | "MVW"i emem_operand "," imem_operand -> mvw_emem_imem
            | "MVP"i imem_operand "," expression -> mvp_imem_imm

--- a/sc62015/pysc62015/asm.py
+++ b/sc62015/pysc62015/asm.py
@@ -920,6 +920,42 @@ class AsmTransformer(Transformer):
             "instruction": {"instr_class": MV, "instr_opts": Opts(name="MVW", ops=[src, dst])}
         }
 
+    def mvw_imem_ememimem(self, items: List[Any]) -> InstructionNode:
+        imem = cast(IMemOperand, items[0])
+        src = cast(EMemIMem, items[1])
+        op = EMemIMemOffset(EMemIMemOffsetOrder.DEST_INT_MEM, width=2)
+        op.mode_imm.value = src.value
+        im1 = IMem8()
+        im1.value = int(imem.n_val, 0) if isinstance(imem.n_val, str) else imem.n_val
+        op.imem1 = im1
+        im2 = IMem8()
+        src_val = cast(IMemOperand, src.imem).n_val if isinstance(src.imem, IMemOperand) else src.imem.value
+        im2.value = int(src_val, 0) if isinstance(src_val, str) else src_val
+        op.imem2 = im2
+        op.mode = src.mode
+        op.offset = src.offset
+        return {
+            "instruction": {"instr_class": MV, "instr_opts": Opts(name="MVW", ops=[op])}
+        }
+
+    def mvw_ememimem_imem(self, items: List[Any]) -> InstructionNode:
+        src = cast(EMemIMem, items[0])
+        imem = cast(IMemOperand, items[1])
+        op = EMemIMemOffset(EMemIMemOffsetOrder.DEST_EXT_MEM, width=2)
+        op.mode_imm.value = src.value
+        im1 = IMem8()
+        src_val = cast(IMemOperand, src.imem).n_val if isinstance(src.imem, IMemOperand) else src.imem.value
+        im1.value = int(src_val, 0) if isinstance(src_val, str) else src_val
+        op.imem1 = im1
+        im2 = IMem8()
+        im2.value = int(imem.n_val, 0) if isinstance(imem.n_val, str) else imem.n_val
+        op.imem2 = im2
+        op.mode = src.mode
+        op.offset = src.offset
+        return {
+            "instruction": {"instr_class": MV, "instr_opts": Opts(name="MVW", ops=[op])}
+        }
+
     def mvp_imem_emem(self, items: List[Any]) -> InstructionNode:
         imem, emem_src = items
         dst = IMem20()

--- a/sc62015/pysc62015/instr/opcodes.py
+++ b/sc62015/pysc62015/instr/opcodes.py
@@ -1541,25 +1541,26 @@ class EMemIMemOffset(HasOperands, Operand):
     mode: Optional[EMemIMemMode]
     offset: Optional[ImmOffset] = None
 
-    def __init__(self, order: EMemIMemOffsetOrder) -> None:
+    def __init__(self, order: EMemIMemOffsetOrder, width: int = 1) -> None:
         self.order = order
+        self.width = width
         self.mode_imm = Imm8()
         self.imem1 = IMem8()
         self.imem2 = IMem8()
 
     def __repr__(self) -> str:
         return (
-            f"EMemIMemOffset(order={self.order}, mode={getattr(self, 'mode', None)},"
-            f" offset={getattr(self, 'offset', None)})"
+            f"EMemIMemOffset(order={self.order}, width={self.width}, "
+            f"mode={getattr(self, 'mode', None)}, offset={getattr(self, 'offset', None)})"
         )
 
     def operands(self) -> Generator[Operand, None, None]:
         if self.order == EMemIMemOffsetOrder.DEST_INT_MEM:
             yield self.imem1
-            op = EMemValueOffsetHelper(self.imem2, self.offset, width=1)
+            op = EMemValueOffsetHelper(self.imem2, self.offset, width=self.width)
             yield op
         else:
-            op = EMemValueOffsetHelper(self.imem1, self.offset, width=1)
+            op = EMemValueOffsetHelper(self.imem1, self.offset, width=self.width)
             yield op
             yield self.imem2
 

--- a/sc62015/pysc62015/test_asm.py
+++ b/sc62015/pysc62015/test_asm.py
@@ -349,6 +349,24 @@ assembler_test_cases: List[AssemblerTestCase] = [
         """,
     ),
     AssemblerTestCase(
+        test_id="mvw_imem_ememimem_simple",
+        asm_code="MVW (0x30), [(0x40)]",
+        expected_ti="""
+            @0000
+            F1 00 30 40
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="mvw_ememimem_imem_simple",
+        asm_code="MVW [(0x40)], (0x30)",
+        expected_ti="""
+            @0000
+            F9 00 40 30
+            q
+        """,
+    ),
+    AssemblerTestCase(
         test_id="and_all_forms",
         asm_code="""
             AND A, 0x55


### PR DESCRIPTION
## Summary
- support `MVW` with external-memory via internal-memory operands
- extend assembler grammar for new MVW forms
- set operand width for `EMemIMemOffset`
- add assembler tests for the new MVW encodings

## Testing
- `ruff check`
- `MYPYPATH=stubs mypy sc62015/pysc62015`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844e702dfd88331b964868c0902681e