### PR TITLE
Fix MVP ext->int encoding

### DIFF
--- a/sc62015/pysc62015/asm.lark
+++ b/sc62015/pysc62015/asm.lark
@@ -60,7 +60,9 @@ instruction: "NOP"i -> nop
            | "MVW"i emem_operand "," imem_operand -> mvw_emem_imem
            | "MVP"i imem_operand "," expression -> mvp_imem_imm
            | "MVP"i imem_operand "," imem_operand -> mvp_imem_imem
+           | "MVP"i imem_operand "," emem_imem_operand -> mvp_imem_ememimem
            | "MVP"i imem_operand "," emem_operand -> mvp_imem_emem
+           | "MVP"i emem_imem_operand "," imem_operand -> mvp_ememimem_imem
            | "MVP"i emem_operand "," imem_operand -> mvp_emem_imem
            | "MVL"i imem_operand "," imem_operand -> mvl_imem_imem
            | "MVL"i imem_operand "," emem_operand -> mvl_imem_emem

--- a/sc62015/pysc62015/asm.py
+++ b/sc62015/pysc62015/asm.py
@@ -940,6 +940,38 @@ class AsmTransformer(Transformer):
             "instruction": {"instr_class": MV, "instr_opts": Opts(name="MVP", ops=[src, dst])}
         }
 
+    def mvp_imem_ememimem(self, items: List[Any]) -> InstructionNode:
+        imem = cast(IMemOperand, items[0])
+        src = cast(EMemIMem, items[1])
+        op = EMemIMemOffset(EMemIMemOffsetOrder.DEST_INT_MEM)
+        op.mode_imm.value = src.value
+        im1 = IMem8()
+        im1.value = int(imem.n_val, 0) if isinstance(imem.n_val, str) else imem.n_val
+        op.imem1 = im1
+        im2 = IMem8()
+        src_val = cast(IMemOperand, src.imem).n_val if isinstance(src.imem, IMemOperand) else src.imem.value
+        im2.value = int(src_val, 0) if isinstance(src_val, str) else src_val
+        op.imem2 = im2
+        op.mode = src.mode
+        op.offset = src.offset
+        return {"instruction": {"instr_class": MV, "instr_opts": Opts(name="MVP", ops=[op])}}
+
+    def mvp_ememimem_imem(self, items: List[Any]) -> InstructionNode:
+        src = cast(EMemIMem, items[0])
+        imem = cast(IMemOperand, items[1])
+        op = EMemIMemOffset(EMemIMemOffsetOrder.DEST_EXT_MEM)
+        op.mode_imm.value = src.value
+        im1 = IMem8()
+        src_val = cast(IMemOperand, src.imem).n_val if isinstance(src.imem, IMemOperand) else src.imem.value
+        im1.value = int(src_val, 0) if isinstance(src_val, str) else src_val
+        op.imem1 = im1
+        im2 = IMem8()
+        im2.value = int(imem.n_val, 0) if isinstance(imem.n_val, str) else imem.n_val
+        op.imem2 = im2
+        op.mode = src.mode
+        op.offset = src.offset
+        return {"instruction": {"instr_class": MV, "instr_opts": Opts(name="MVP", ops=[op])}}
+
     def mvl_imem_emem(self, items: List[Any]) -> InstructionNode:
         imem, emem_src = items
         return {"instruction": {"instr_class": MVL, "instr_opts": Opts(ops=[imem, emem_src])}}


### PR DESCRIPTION
## Summary
- add specialized parser rules for MVP with `[imem]` operands
- encode MVP with external memory via internal memory correctly

## Testing
- `ruff check`
- `mypy pysc62015` *(fails: Cannot find implementation or library stub for module named `binaryninja`)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844e796ca808331bb6370c700d1be57