### PR TITLE
Fix assembler register memory operand parsing

### DIFF
--- a/sc62015/pysc62015/asm.lark
+++ b/sc62015/pysc62015/asm.lark
@@ -231,9 +231,9 @@ emem_imem_simple: "[" imem_operand "]"
 emem_imem_plus: "[" imem_operand "+" expression "]"
 emem_imem_minus: "[" imem_operand "-" expression "]"
 
-emem_operand: emem_addr
-            | emem_reg_operand
+emem_operand: emem_reg_operand
             | emem_imem_operand
+            | emem_addr
 
 
 // --- Terminals with higher priority ---


### PR DESCRIPTION
## Summary
- fix ambiguous grammar rule so `[X]` and similar parse as register-based
  memory operands instead of absolute addresses

## Testing
- `ruff check`
- `python3 scripts/run_mypy.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844ec924888833181151bfb96e25d77