### PR TITLE
Fix MVL assembler opcode matching

### DIFF
--- a/sc62015/pysc62015/asm.lark
+++ b/sc62015/pysc62015/asm.lark
@@ -66,13 +66,13 @@ instruction: "NOP"i -> nop
            | "MVP"i imem_operand "," emem_operand -> mvp_imem_emem
            | "MVP"i emem_imem_operand "," imem_operand -> mvp_ememimem_imem
            | "MVP"i emem_operand "," imem_operand -> mvp_emem_imem
-           | "MVL"i imem_operand "," imem_operand -> mvl_imem_imem
-           | "MVL"i imem_operand "," emem_operand -> mvl_imem_emem
-           | "MVL"i emem_operand "," imem_operand -> mvl_emem_imem
            | "MVL"i imem_operand "," emem_reg_operand -> mvl_imem_ememreg
            | "MVL"i emem_reg_operand "," imem_operand -> mvl_ememreg_imem
            | "MVL"i imem_operand "," emem_imem_operand -> mvl_imem_ememimem
            | "MVL"i emem_imem_operand "," imem_operand -> mvl_ememimem_imem
+           | "MVL"i imem_operand "," imem_operand -> mvl_imem_imem
+           | "MVL"i imem_operand "," emem_operand -> mvl_imem_emem
+           | "MVL"i emem_operand "," imem_operand -> mvl_emem_imem
            | "MVLD"i imem_operand "," imem_operand -> mvld_imem_imem
            | "EX"i _A "," _B -> ex_a_b
            | "PUSHS"i _F -> pushs_f

--- a/sc62015/pysc62015/sc_asm.py
+++ b/sc62015/pysc62015/sc_asm.py
@@ -199,6 +199,15 @@ class Assembler:
                                 setattr(op, "value", int(getattr(op, "value"), 0))
                             except ValueError:
                                 setattr(op, "value", 0)
+                        if (
+                            hasattr(op, "offset")
+                            and isinstance(op.offset, ImmOffset)
+                            and isinstance(op.offset.value, str)
+                        ):
+                            try:
+                                op.offset.value = int(op.offset.value, 0)
+                            except ValueError:
+                                op.offset.value = 0
                         if hasattr(op, "extra_hi") and getattr(op, "value", None) is not None:
                             setattr(op, "extra_hi", (int(getattr(op, "value")) >> 16) & 0xFF)
                         if isinstance(op, Imm20) and isinstance(op.value, int):
@@ -332,6 +341,12 @@ class Assembler:
                         setattr(op, "value", val)
                     if isinstance(op, Imm20) and isinstance(val, int):
                         op.extra_hi = (val >> 16) & 0xFF
+                if (
+                    hasattr(op, "offset")
+                    and isinstance(op.offset, ImmOffset)
+                    and isinstance(op.offset.value, str)
+                ):
+                    op.offset.value = self._evaluate_operand(op.offset.value)
             encoder = Encoder()
             instr.encode(encoder, self.current_address)
             return encoder.buf


### PR DESCRIPTION
## Summary
- fix MVL parsing precedence for reg/indirect forms
- handle ImmOffset value conversion during assembly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844eca3df448331aadd5b88e8f7ae75