### PR TITLE
Fix MVW/MVP assembler for emem reg ops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 Session.vim
+binja_esr.egg-info/

--- a/sc62015/pysc62015/asm.lark
+++ b/sc62015/pysc62015/asm.lark
@@ -56,6 +56,8 @@ instruction: "NOP"i -> nop
            | "MV"i emem_operand "," imem_operand -> mv_emem_imem
            | "MVW"i imem_operand "," expression -> mvw_imem_imm
            | "MVW"i imem_operand "," imem_operand -> mvw_imem_imem
+           | "MVW"i imem_operand "," emem_reg_operand -> mvw_imem_ememreg
+           | "MVW"i emem_reg_operand "," imem_operand -> mvw_ememreg_imem
            | "MVW"i imem_operand "," emem_imem_operand -> mvw_imem_ememimem
            | "MVW"i emem_imem_operand "," imem_operand -> mvw_ememimem_imem
            | "MVW"i imem_operand "," emem_operand -> mvw_imem_emem
@@ -63,6 +65,8 @@ instruction: "NOP"i -> nop
            | "MVP"i imem_operand "," expression -> mvp_imem_imm
            | "MVP"i imem_operand "," imem_operand -> mvp_imem_imem
            | "MVP"i imem_operand "," emem_imem_operand -> mvp_imem_ememimem
+           | "MVP"i imem_operand "," emem_reg_operand -> mvp_imem_ememreg
+           | "MVP"i emem_reg_operand "," imem_operand -> mvp_ememreg_imem
            | "MVP"i imem_operand "," emem_operand -> mvp_imem_emem
            | "MVP"i emem_imem_operand "," imem_operand -> mvp_ememimem_imem
            | "MVP"i emem_operand "," imem_operand -> mvp_emem_imem

--- a/sc62015/pysc62015/asm.py
+++ b/sc62015/pysc62015/asm.py
@@ -920,6 +920,30 @@ class AsmTransformer(Transformer):
             "instruction": {"instr_class": MV, "instr_opts": Opts(name="MVW", ops=[src, dst])}
         }
 
+    def mvw_imem_ememreg(self, items: List[Any]) -> InstructionNode:
+        imem = cast(IMemOperand, items[0])
+        regop = cast(EMemReg, items[1])
+        op = RegIMemOffset(order=RegIMemOffsetOrder.DEST_IMEM)
+        im = IMem8()
+        im.value = int(imem.n_val, 0) if isinstance(imem.n_val, str) else imem.n_val
+        op.imem = im
+        op.reg = regop.reg
+        op.mode = regop.mode
+        op.offset = regop.offset
+        return {"instruction": {"instr_class": MV, "instr_opts": Opts(name="MVW", ops=[op])}}
+
+    def mvw_ememreg_imem(self, items: List[Any]) -> InstructionNode:
+        regop = cast(EMemReg, items[0])
+        imem = cast(IMemOperand, items[1])
+        op = RegIMemOffset(order=RegIMemOffsetOrder.DEST_REG_OFFSET)
+        im = IMem8()
+        im.value = int(imem.n_val, 0) if isinstance(imem.n_val, str) else imem.n_val
+        op.imem = im
+        op.reg = regop.reg
+        op.mode = regop.mode
+        op.offset = regop.offset
+        return {"instruction": {"instr_class": MV, "instr_opts": Opts(name="MVW", ops=[op])}}
+
     def mvw_imem_ememimem(self, items: List[Any]) -> InstructionNode:
         imem = cast(IMemOperand, items[0])
         src = cast(EMemIMem, items[1])
@@ -975,6 +999,30 @@ class AsmTransformer(Transformer):
         return {
             "instruction": {"instr_class": MV, "instr_opts": Opts(name="MVP", ops=[src, dst])}
         }
+
+    def mvp_imem_ememreg(self, items: List[Any]) -> InstructionNode:
+        imem = cast(IMemOperand, items[0])
+        regop = cast(EMemReg, items[1])
+        op = RegIMemOffset(order=RegIMemOffsetOrder.DEST_IMEM)
+        im = IMem8()
+        im.value = int(imem.n_val, 0) if isinstance(imem.n_val, str) else imem.n_val
+        op.imem = im
+        op.reg = regop.reg
+        op.mode = regop.mode
+        op.offset = regop.offset
+        return {"instruction": {"instr_class": MV, "instr_opts": Opts(name="MVP", ops=[op])}}
+
+    def mvp_ememreg_imem(self, items: List[Any]) -> InstructionNode:
+        regop = cast(EMemReg, items[0])
+        imem = cast(IMemOperand, items[1])
+        op = RegIMemOffset(order=RegIMemOffsetOrder.DEST_REG_OFFSET)
+        im = IMem8()
+        im.value = int(imem.n_val, 0) if isinstance(imem.n_val, str) else imem.n_val
+        op.imem = im
+        op.reg = regop.reg
+        op.mode = regop.mode
+        op.offset = regop.offset
+        return {"instruction": {"instr_class": MV, "instr_opts": Opts(name="MVP", ops=[op])}}
 
     def mvp_imem_ememimem(self, items: List[Any]) -> InstructionNode:
         imem = cast(IMemOperand, items[0])

--- a/sc62015/pysc62015/test_asm.py
+++ b/sc62015/pysc62015/test_asm.py
@@ -331,6 +331,42 @@ assembler_test_cases: List[AssemblerTestCase] = [
         """,
     ),
     AssemblerTestCase(
+        test_id="mvw_imem_ememreg_simple",
+        asm_code="MVW (0x20), [X]",
+        expected_ti="""
+            @0000
+            E1 04 20
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="mvw_ememreg_imem_simple",
+        asm_code="MVW [X], (0x20)",
+        expected_ti="""
+            @0000
+            E9 04 20
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="mvp_imem_ememreg_simple",
+        asm_code="MVP (0x20), [X]",
+        expected_ti="""
+            @0000
+            E2 04 20
+            q
+        """,
+    ),
+    AssemblerTestCase(
+        test_id="mvp_ememreg_imem_simple",
+        asm_code="MVP [X], (0x20)",
+        expected_ti="""
+            @0000
+            EA 04 20
+            q
+        """,
+    ),
+    AssemblerTestCase(
         test_id="mv_imem_ememimem_simple",
         asm_code="MV (0x30), [(0x40)]",
         expected_ti="""


### PR DESCRIPTION
## Summary
- support EMemReg operands for MVW and MVP instructions
- cover new forms in the grammar and assembler logic
- add regression tests
- ignore generated egg-info directory

## Testing
- `ruff check`
- `MYPYPATH=stubs mypy sc62015/pysc62015`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844efde84848331b13f172bdcf4a754