### PR TITLE
Fix MV instructions using EMemReg operands

### DIFF
--- a/sc62015/pysc62015/asm.py
+++ b/sc62015/pysc62015/asm.py
@@ -726,6 +726,13 @@ class AsmTransformer(Transformer):
     def mv_reg_emem(self, items: List[Any]) -> InstructionNode:
         reg = cast(Reg, items[0])
         mem = cast(EMemAddr, items[1])
+        # The grammar for ``emem_operand`` also matches ``emem_reg_operand`` which
+        # results in this handler receiving ``EMemReg`` instances as ``mem``.
+        # For ``MV`` instructions the width of the external memory operand is
+        # defined by the destination register width, so adjust it here to avoid
+        # mismatches during opcode lookup.
+        if isinstance(mem, EMemReg):
+            mem.width = reg.width()
         return {
             "instruction": {"instr_class": MV, "instr_opts": Opts(ops=[reg, mem])}
         }
@@ -740,6 +747,8 @@ class AsmTransformer(Transformer):
     def mv_emem_reg(self, items: List[Any]) -> InstructionNode:
         mem = cast(EMemAddr, items[0])
         reg = cast(Reg, items[1])
+        if isinstance(mem, EMemReg):
+            mem.width = reg.width()
         return {
             "instruction": {"instr_class": MV, "instr_opts": Opts(ops=[mem, reg])}
         }

--- a/sc62015/pysc62015/sc_asm.py
+++ b/sc62015/pysc62015/sc_asm.py
@@ -18,6 +18,7 @@ from .instr import (
     ImmOperand,
     Imm20,
     ImmOffset,
+    EMemReg,
     RegIMemOffset,
     EMemIMemOffset,
     Reg3,
@@ -120,6 +121,19 @@ class Assembler:
                         continue
                     if isinstance(t_op, RegIMemOffset) and isinstance(p_op, RegIMemOffset):
                         if t_op.order != p_op.order:
+                            converted_match = False
+                            break
+                        continue
+                    if isinstance(t_op, EMemReg) and isinstance(p_op, EMemReg):
+                        if t_op.width != p_op.width:
+                            converted_match = False
+                            break
+                        # Template does not specify the addressing mode, so any
+                        # provided mode should be accepted when ``t_op.mode`` is
+                        # ``None``.
+                        t_mode = getattr(t_op, "mode", None)
+                        p_mode = getattr(p_op, "mode", None)
+                        if t_mode is not None and t_mode != p_mode:
                             converted_match = False
                             break
                         continue


### PR DESCRIPTION
## Summary
- adjust assembler rules for MV when emem operands are passed as EMemReg
- handle EMemReg comparison when matching instructions

## Testing
- `ruff check`
- `MYPYPATH=stubs mypy sc62015/pysc62015`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844efca34388331bfa5973dc21b1417