### PR TITLE
Fix MVL assembler handling

### DIFF
--- a/sc62015/pysc62015/asm.py
+++ b/sc62015/pysc62015/asm.py
@@ -1019,26 +1019,44 @@ class AsmTransformer(Transformer):
     def mvl_imem_ememreg(self, items: List[Any]) -> InstructionNode:
         imem = cast(IMemOperand, items[0])
         regop = cast(EMemReg, items[1])
-        op = RegIMemOffset(order=RegIMemOffsetOrder.DEST_IMEM)
-        im = IMem8()
-        im.value = int(imem.n_val, 0) if isinstance(imem.n_val, str) else imem.n_val
-        op.imem = im
-        op.reg = regop.reg
-        op.mode = regop.mode
-        op.offset = regop.offset
-        return {"instruction": {"instr_class": MVL, "instr_opts": Opts(ops=[op])}}
+        # For post-increment/pre-decrement/simple modes use the direct
+        # EMemReg operand so that the assembler can match the correct
+        # opcode variants (e.g. 0xE3/0xEB).  Only offset based modes use the
+        # RegIMemOffset helper which encodes the offset byte.
+        if regop.mode in (
+            EMemRegMode.POSITIVE_OFFSET,
+            EMemRegMode.NEGATIVE_OFFSET,
+        ):
+            op = RegIMemOffset(order=RegIMemOffsetOrder.DEST_IMEM)
+            im = IMem8()
+            im.value = int(imem.n_val, 0) if isinstance(imem.n_val, str) else imem.n_val
+            op.imem = im
+            op.reg = regop.reg
+            op.mode = regop.mode
+            op.offset = regop.offset
+            ops = [op]
+        else:
+            ops = [imem, regop]
+        return {"instruction": {"instr_class": MVL, "instr_opts": Opts(ops=ops)}}
 
     def mvl_ememreg_imem(self, items: List[Any]) -> InstructionNode:
         regop = cast(EMemReg, items[0])
         imem = cast(IMemOperand, items[1])
-        op = RegIMemOffset(order=RegIMemOffsetOrder.DEST_REG_OFFSET)
-        im = IMem8()
-        im.value = int(imem.n_val, 0) if isinstance(imem.n_val, str) else imem.n_val
-        op.imem = im
-        op.reg = regop.reg
-        op.mode = regop.mode
-        op.offset = regop.offset
-        return {"instruction": {"instr_class": MVL, "instr_opts": Opts(ops=[op])}}
+        if regop.mode in (
+            EMemRegMode.POSITIVE_OFFSET,
+            EMemRegMode.NEGATIVE_OFFSET,
+        ):
+            op = RegIMemOffset(order=RegIMemOffsetOrder.DEST_REG_OFFSET)
+            im = IMem8()
+            im.value = int(imem.n_val, 0) if isinstance(imem.n_val, str) else imem.n_val
+            op.imem = im
+            op.reg = regop.reg
+            op.mode = regop.mode
+            op.offset = regop.offset
+            ops = [op]
+        else:
+            ops = [regop, imem]
+        return {"instruction": {"instr_class": MVL, "instr_opts": Opts(ops=ops)}}
 
     def mvl_imem_ememimem(self, items: List[Any]) -> InstructionNode:
         imem = cast(IMemOperand, items[0])

--- a/sc62015/pysc62015/sc_asm.py
+++ b/sc62015/pysc62015/sc_asm.py
@@ -19,6 +19,7 @@ from .instr import (
     Imm20,
     ImmOffset,
     RegIMemOffset,
+    EMemReg,
     EMemIMemOffset,
     Reg3,
     RegPair,
@@ -122,9 +123,23 @@ class Assembler:
                         if t_op.order != p_op.order:
                             converted_match = False
                             break
+                        if (
+                            getattr(t_op, "allowed_modes", None) is not None
+                            and p_op.mode not in t_op.allowed_modes
+                        ):
+                            converted_match = False
+                            break
                         continue
                     if isinstance(t_op, EMemIMemOffset) and isinstance(p_op, EMemIMemOffset):
                         if t_op.order != p_op.order:
+                            converted_match = False
+                            break
+                        continue
+                    if isinstance(t_op, EMemReg) and isinstance(p_op, EMemReg):
+                        if (
+                            getattr(t_op, "allowed_modes", None) is not None
+                            and p_op.mode not in t_op.allowed_modes
+                        ):
                             converted_match = False
                             break
                         continue


### PR DESCRIPTION
## Summary
- handle non-offset modes for `MVL` involving EMemReg operands
- tighten opcode matching for `EMemReg` and `RegIMemOffset`

## Testing
- `ruff check`
- `mypy sc62015/pysc62015` *(fails: Cannot find module 'binaryninja' and other type issues)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844efeb0588833198f6d8752a37e355