### PR TITLE
Fix assembler handling of MVL instructions

### DIFF
--- a/sc62015/pysc62015/asm.py
+++ b/sc62015/pysc62015/asm.py
@@ -1083,6 +1083,7 @@ class AsmTransformer(Transformer):
         # For simple, post-increment and pre-decrement modes the opcode expects
         # an ``EMemReg`` operand directly.  Only the ``+n``/``-n`` forms are
         # encoded using ``RegIMemOffset``.
+        operand: Union[RegIMemOffset, EMemReg]
         if regop.mode in (
             EMemRegMode.POSITIVE_OFFSET,
             EMemRegMode.NEGATIVE_OFFSET,
@@ -1116,6 +1117,7 @@ class AsmTransformer(Transformer):
     def mvl_ememreg_imem(self, items: List[Any]) -> InstructionNode:
         regop = cast(EMemReg, items[0])
         imem = cast(IMemOperand, items[1])
+        operand: Union[RegIMemOffset, EMemReg]
         if regop.mode in (
             EMemRegMode.POSITIVE_OFFSET,
             EMemRegMode.NEGATIVE_OFFSET,

--- a/sc62015/pysc62015/sc_asm.py
+++ b/sc62015/pysc62015/sc_asm.py
@@ -123,7 +123,8 @@ class Assembler:
                         if t_op.order != p_op.order:
                             converted_match = False
                             break
-                        if t_op.allowed_modes is not None and p_op.mode not in t_op.allowed_modes:
+                        allowed_modes = t_op.allowed_modes
+                        if allowed_modes is not None and p_op.mode not in allowed_modes:
                             converted_match = False
                             break
                         continue
@@ -139,10 +140,8 @@ class Assembler:
                         if t_mode is not None and t_mode != p_mode:
                             converted_match = False
                             break
-                        if (
-                            getattr(t_op, "allowed_modes", None) is not None
-                            and p_mode not in t_op.allowed_modes
-                        ):
+                        allowed_modes = getattr(t_op, "allowed_modes", None)
+                        if allowed_modes is not None and p_mode not in allowed_modes:
                             converted_match = False
                             break
                         continue

--- a/sc62015/pysc62015/sc_asm.py
+++ b/sc62015/pysc62015/sc_asm.py
@@ -123,6 +123,9 @@ class Assembler:
                         if t_op.order != p_op.order:
                             converted_match = False
                             break
+                        if t_op.allowed_modes is not None and p_op.mode not in t_op.allowed_modes:
+                            converted_match = False
+                            break
                         continue
                     if isinstance(t_op, EMemReg) and isinstance(p_op, EMemReg):
                         if t_op.width != p_op.width:
@@ -134,6 +137,12 @@ class Assembler:
                         t_mode = getattr(t_op, "mode", None)
                         p_mode = getattr(p_op, "mode", None)
                         if t_mode is not None and t_mode != p_mode:
+                            converted_match = False
+                            break
+                        if (
+                            getattr(t_op, "allowed_modes", None) is not None
+                            and p_mode not in t_op.allowed_modes
+                        ):
                             converted_match = False
                             break
                         continue


### PR DESCRIPTION
## Summary
- handle simple and inc/dec EMemReg forms in assembler
- check allowed addressing modes in opcode matching

## Testing
- `python -m pytest sc62015/pysc62015/test_opcode_assembly.py::test_opcode_table_roundtrip -vv -s | head -n 30`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844f20175b88331b10e6d2b4a86b91b