### PR TITLE
Fix assembler constant detection in opcode roundtrip test

### DIFF
--- a/sc62015/pysc62015/test_opcode_assembly.py
+++ b/sc62015/pysc62015/test_opcode_assembly.py
@@ -37,9 +37,13 @@ def _transform(instr: str) -> str:
             # ``token`` may look like a register name but occasionally represents
             # a numeric constant inside addressing modes, e.g. ``[(BA)]`` or
             # ``[(CD)+BA]``. When preceded by "(", "+" or "-" treat it as a
-            # constant rather than a register.
+            # constant rather than a register. ``match.start()`` points to the
+            # beginning of the whole match, which may include the ``+`` or ``-``
+            # sign. ``token_start`` tracks the actual token location so we can
+            # inspect the character immediately before it.
             start = match.start()
-            prev = rest[start - 1] if start > 0 else ""
+            token_start = start + len(sign)
+            prev = rest[token_start - 1] if token_start > 0 else ""
             if token in REGS and prev not in {"(", "+", "-"}:
                 return match.group(0)
             if token == "FCDAB":
@@ -96,6 +100,6 @@ def test_opcode_table_roundtrip() -> None:
 
     if mismatches:
         print("\n".join(mismatches))
-        pytest.xfail(
+        pytest.fail(
             f"Opcode table divergence detected. {len(mismatches)} mismatches found."
         )


### PR DESCRIPTION
## Summary
- improve regex token prefix insertion for constants
- fail opcode roundtrip test when mismatches occur

## Testing
- `ruff check`
- `mypy sc62015/pysc62015` *(fails: Cannot find implementation or library stub for module named 'binaryninja')*
- `pytest -vv`

------
https://chatgpt.com/codex/tasks/task_e_6844f9611f5883318d000867d7ad5f0e