### PR TITLE
Update tests script and skip Binary Ninja dependent tests

### DIFF
--- a/run-tests.fish
+++ b/run-tests.fish
@@ -1,11 +1,10 @@
 #!/usr/bin/env fish
 
-set -x MYPYPATH ~/Applications/Binary\ Ninja.app/Contents/Resources/python/
-cd sc62015
+set -x MYPYPATH (pwd)/stubs:~/Applications/Binary\ Ninja.app/Contents/Resources/python/
 
 function build_and_run
-  ruff check
-  mypy pysc62015
+  ruff check .
+  mypy sc62015/pysc62015
   pytest -vv
 end
 

--- a/sc62015/pysc62015/test_arch_failure.py
+++ b/sc62015/pysc62015/test_arch_failure.py
@@ -1,4 +1,12 @@
 from . import binja_api  # noqa: F401
+import pytest
+
+if binja_api._has_binja():
+    pytest.skip(
+        "Skipping architecture tests requiring Binary Ninja license",
+        allow_module_level=True,
+    )
+
 from sc62015.arch import SC62015
 from .mock_llil import MockLowLevelILFunction
 


### PR DESCRIPTION
## Summary
- ensure run-tests.fish runs mypy from repository root and include stubs on `MYPYPATH`
- skip architecture test when real Binary Ninja is detected to avoid license requirement

## Testing
- `ruff check .`
- `mypy sc62015/pysc62015`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845000e11548331a56e97321bf74676