### PR TITLE
Fix orchestrator for testing and add unit tests

### DIFF
--- a/sc62015/pysc62015/hw-test/orchestrator.py
+++ b/sc62015/pysc62015/hw-test/orchestrator.py
@@ -4,7 +4,10 @@ import json
 import time
 from typing import Any, Dict, Optional
 
-import serial
+try:
+    import serial  # type: ignore[import-untyped]
+except Exception:  # pragma: no cover - serial may not be installed in tests
+    serial = None  # type: ignore[assignment]
 from plumbum import cli  # type: ignore[import-untyped]
 
 from sc62015.pysc62015.sc_asm import Assembler
@@ -21,12 +24,17 @@ class HardwareInterface:
         port: str,
         baudrate: int = 9600,
         timeout: int = 3,
-        serial_cls: Any = serial.Serial,
+        serial_cls: Any | None = None,
     ) -> None:
         self.port = port
         self.baudrate = baudrate
         self.timeout = timeout
-        self.serial_cls = serial_cls
+        if serial_cls is not None:
+            self.serial_cls = serial_cls
+        elif serial is not None:
+            self.serial_cls = serial.Serial
+        else:
+            raise ImportError("pyserial is required for hardware communication")
         self.conn: Optional[serial.Serial] = None
 
     def __enter__(self) -> "HardwareInterface":

--- a/sc62015/pysc62015/hw-test/test_orchestrator.py
+++ b/sc62015/pysc62015/hw-test/test_orchestrator.py
@@ -6,7 +6,8 @@ import pytest
 
 # Utility to load the orchestrator module from its script path
 
-ORCH_PATH = Path(__file__).parent / "hw-test" / "orchestrator.py"
+# Path to the orchestrator script relative to this test file
+ORCH_PATH = Path(__file__).parent / "orchestrator.py"
 
 
 def import_orchestrator() -> types.ModuleType:


### PR DESCRIPTION
## Summary
- allow injecting serial class in `HardwareInterface`
- add unit tests for orchestrator using a mock serial port

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845087654cc8331bb00ffdd1a2cdc36