### PR TITLE
Unify SECTION and ORG parsing

### DIFF
--- a/sc62015/pysc62015/asm.lark
+++ b/sc62015/pysc62015/asm.lark
@@ -2,21 +2,20 @@ start: (line | NEWLINE)*
 
 line: (label? statement?)
 
-?statement: section_decl
-          | org_directive
+?statement: location_directive
           | data_directive
           | instruction
 
 label: CNAME ":"
 
-section_decl: "SECTION"i CNAME
+location_directive: "SECTION"i CNAME -> section_decl
+                  | _ORG expression  -> org_directive
 data_directive: "defb"i def_arg ("," def_arg)* -> defb_directive
                | "defw"i def_arg ("," def_arg)* -> defw_directive
                | "defl"i def_arg ("," def_arg)* -> defl_directive
                | "defs"i NUMBER -> defs_directive
                | "defm"i string_literal -> defm_directive
 
-org_directive: _ORG expression
 
 instruction: "NOP"i -> nop
            | "RETI"i -> reti


### PR DESCRIPTION
## Summary
- unify location directives in `asm.lark`
- adjust grammar so `SECTION` and `.ORG` share one rule

## Testing
- `ruff check`
- `MYPYPATH=stubs mypy sc62015/pysc62015`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68461db5a7b08331b6008e0b344ea5c4