### PR TITLE
Fix ORG directive grammar

### DIFF
--- a/sc62015/pysc62015/asm.lark
+++ b/sc62015/pysc62015/asm.lark
@@ -9,7 +9,7 @@ line: (label? statement?)
 label: CNAME ":"
 
 location_directive: "SECTION"i CNAME -> section_decl
-                  | _ORG expression  -> org_directive
+                  | ".ORG"i expression  -> org_directive
 data_directive: "defb"i def_arg ("," def_arg)* -> defb_directive
                | "defw"i def_arg ("," def_arg)* -> defw_directive
                | "defl"i def_arg ("," def_arg)* -> defl_directive
@@ -242,7 +242,6 @@ _IMR.2: "IMR"i
 _BP.2: "BP"i
 _PX.2: "PX"i
 _PY.2: "PY"i
-_ORG.2: ".ORG"i
 
 // --- Common Terminals ---
 NUMBER: /0x[0-9a-fA-F]+/i | /[0-9]+/


### PR DESCRIPTION
## Summary
- inline the `.ORG` directive in the grammar

## Testing
- `ruff check .`
- `mypy sc62015/pysc62015` *(fails: Cannot find implementation or library stub for module named `binaryninja`)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68461f20789883319542bd47b37d7b9c