### PR TITLE
Fix FIXME on unused TAddr token

### DIFF
--- a/sc62015/pysc62015/instr/opcodes.py
+++ b/sc62015/pysc62015/instr/opcodes.py
@@ -1,5 +1,16 @@
 # based on https://github.com/whitequark/binja-avnera/blob/main/mc/instr.py
-from ..tokens import Token, TInstr, TText, TSep, TInt, TReg, TBegMem, TEndMem, MemType
+from ..tokens import (
+    Token,
+    TInstr,
+    TText,
+    TSep,
+    TInt,
+    TReg,
+    TBegMem,
+    TEndMem,
+    TAddr,
+    MemType,
+)
 from ..coding import Decoder, Encoder, BufferTooShort
 
 from ..mock_llil import MockLLIL
@@ -1232,7 +1243,12 @@ class EMemAddr(Imm20, Pointer):
         return EMemHelper
 
     def render(self, pre: Optional[AddressingMode] = None) -> List[Token]:
-        return [TBegMem(MemType.EXTERNAL), TInt(f"{self.value:05X}"), TEndMem(MemType.EXTERNAL)]
+        assert self.value is not None, "Value not set"
+        return [
+            TBegMem(MemType.EXTERNAL),
+            TAddr(self.value),
+            TEndMem(MemType.EXTERNAL),
+        ]
 
     def lift(self, il: LowLevelILFunction, pre: Optional[AddressingMode] = None, side_effects: bool = True) -> ExpressionIndex:
         assert self.value is not None, "Value not set"

--- a/sc62015/pysc62015/tokens.py
+++ b/sc62015/pysc62015/tokens.py
@@ -122,7 +122,6 @@ class TEndMem(Token):
     def binja(self) -> Tuple[InstructionTextTokenType, str]:
         return (InstructionTextTokenType.EndMemoryOperandToken, self.__str__())
 
-# FIXME: unused
 class TAddr(Token):
     def __init__(self, value: int) -> None:
         self.value = value
@@ -131,10 +130,10 @@ class TAddr(Token):
         return f"TAddr({self.value})"
 
     def __str__(self) -> str:
-        return str(self.value)
+        return f"{self.value:05X}"
 
     def binja(self) -> Tuple[InstructionTextTokenType, str]:
-        return (InstructionTextTokenType.PossibleAddressToken, str(self.value))
+        return (InstructionTextTokenType.PossibleAddressToken, f"{self.value:05X}")
 
 class TReg(Token):
     def __init__(self, reg: str) -> None:


### PR DESCRIPTION
## Summary
- use the `TAddr` token when rendering external memory addresses
- format `TAddr` output as a zero‑padded address

## Testing
- `ruff check .`
- `mypy sc62015/pysc62015`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846224aa5e08331b97dbdba38ae91de