### PR TITLE
Fix unreachable code in decoder helpers

### DIFF
--- a/sc62015/pysc62015/coding.py
+++ b/sc62015/pysc62015/coding.py
@@ -32,9 +32,7 @@ class Decoder:
         self.pos += size
         if len(items) == 1:
             return items[0]  # type: ignore
-        else:
-            raise ValueError("Unpacking more than one item is not supported")
-            return items
+        raise ValueError("Unpacking more than one item is not supported")
 
     def unsigned_byte(self) -> int:
         return self._unpack("B")
@@ -73,9 +71,7 @@ class FetchDecoder(Decoder):
         self.pos += size
         if len(items) == 1:
             return items[0]  # type: ignore
-        else:
-            raise ValueError("Unpacking more than one item is not supported")
-            return items
+        raise ValueError("Unpacking more than one item is not supported")
 
 
 class Encoder:


### PR DESCRIPTION
## Summary
- delete unreachable `return` statements in `coding.py`
- fail with `ValueError` when more than one item is unpacked

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684631d3ed788331a41ae2e08a58a284