### PR TITLE
Fix mutable default argument

### DIFF
--- a/sc62015/pysc62015/mock_llil.py
+++ b/sc62015/pysc62015/mock_llil.py
@@ -78,7 +78,9 @@ def mreg(name: str) -> MockReg:
     return MockReg(name)
 
 
-def mllil(op: str, ops: List[object] = []) -> MockLLIL:
+def mllil(op: str, ops: Optional[List[object]] = None) -> MockLLIL:
+    if ops is None:
+        ops = []
     return MockLLIL(op, ops)
 
 


### PR DESCRIPTION
## Summary
- fix a nasty code smell in `mllil` by avoiding a mutable default parameter

## Testing
- `ruff check .`
- `mypy .` *(fails: Cannot find implementation or library stub for module named "binaryninja")*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684633fe254c8331a1a2113e45e17e2b