### PR TITLE
Fix exception swallowing in instruction handlers

### DIFF
--- a/sc62015/arch.py
+++ b/sc62015/arch.py
@@ -68,7 +68,7 @@ class SC62015(Architecture):
                 return info
         except Exception as exc:
             log_error(f"SC62015.get_instruction_info() failed at {addr:#x}: {exc}")
-            pass
+            raise
 
     def get_instruction_text(self, data, addr):
         try:
@@ -84,6 +84,7 @@ class SC62015(Architecture):
                 return asm(decoded.render()), decoded.length()
         except Exception as exc:
             log_error(f"SC62015.get_instruction_text() failed at {addr:#x}: {exc}")
+            raise
 
     def get_instruction_low_level_il(self, data, addr, il):
         # try:


### PR DESCRIPTION
## Summary
- raise exceptions after logging failures in SC62015 instruction handlers

## Testing
- `ruff check .`
- `mypy sc62015/pysc62015`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846357aed9c83319b6af26cf184955f