### PR TITLE
Fix broad exception handling

### DIFF
--- a/sc62015/pysc62015/binja_api.py
+++ b/sc62015/pysc62015/binja_api.py
@@ -28,7 +28,7 @@ def _has_binja() -> bool:
         import binaryninja  # noqa: F401
 
         return True
-    except Exception:
+    except ImportError:
         return False
 
 

--- a/sc62015/pysc62015/hw-test/orchestrator.py
+++ b/sc62015/pysc62015/hw-test/orchestrator.py
@@ -6,7 +6,7 @@ from typing import Dict, Any, Optional
 
 try:
     import serial  # type: ignore[import-untyped]
-except Exception:  # pragma: no cover - serial may not be installed in tests
+except ImportError:  # pragma: no cover - serial may not be installed in tests
     serial = None  # type: ignore[assignment]
 from plumbum import cli  # type: ignore[import-untyped]
 

--- a/scripts/run_mypy.py
+++ b/scripts/run_mypy.py
@@ -15,7 +15,7 @@ if os.path.isdir(bn_path) and bn_path not in sys.path:
 try:
     import binaryninja  # noqa: F401
     has_binja = True
-except Exception:
+except ImportError:
     has_binja = False
 
 if not has_binja:


### PR DESCRIPTION
## Summary
- use `ImportError` when checking for Binary Ninja
- narrow exception handling for optional serial dependency

## Testing
- `ruff check .`
- `mypy sc62015/pysc62015` *(fails: Cannot find stubs for binaryninja)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684637392b9c83318d6d12d7d2ef978d