### PR TITLE
Document dynamic register generation

### DIFF
--- a/sc62015/pysc62015/emulator.py
+++ b/sc62015/pysc62015/emulator.py
@@ -48,7 +48,11 @@ class RegisterName(enum.Enum):
     FC = "FC"  # Carry
     FZ = "FZ"  # Zero
     F = "F"
-    # Temp Register
+    # Temp registers
+    #
+    # These are generated dynamically so new temporary registers can
+    # be added by simply adjusting ``NUM_TEMP_REGISTERS``. This keeps
+    # the enum definition DRY and avoids repeating similar lines.
     for _i in range(NUM_TEMP_REGISTERS):
         locals()[f"TEMP{_i}"] = f"TEMP{_i}"
     del _i


### PR DESCRIPTION
## Summary
- revert removal of RegisterName dynamic generation
- add comment about DRY design choice when generating temporary registers

## Testing
- `ruff check .`
- `MYPYPATH=$(pwd)/stubs mypy sc62015/pysc62015`
- `MYPYPATH=$(pwd)/stubs pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684637b4acc88331b3fa7a9bb68b36f1