### PR TITLE
Add coverage reporting to CI

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,11 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  status:
+    project:
+      default:
+        target: 80
+    patch:
+      default:
+        target: 80

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,5 +21,7 @@ jobs:
         run: ruff check
       - name: Run Mypy
         run: python scripts/run_mypy.py
-      - name: Run Pytest
-        run: pytest -q
+      - name: Run Pytest with coverage
+        run: pytest --cov=sc62015/pysc62015 --cov-report=xml --cov-report=term
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 __pycache__
 Session.vim
 binja_esr.egg-info/
+.coverage
+coverage.xml
+htmlcov/

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ checks:
 python -m pip install -e .[dev]
 ruff check
 mypy sc62015/pysc62015
-pytest -q
+pytest --cov=sc62015/pysc62015 --cov-report=term-missing --cov-report=xml
 ```
+
+The CI workflow uploads coverage results to Codecov on each commit.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = ["lark", "bincopy", "plumbum"]
 [project.optional-dependencies]
 dev = [
     "pytest",
+    "pytest-cov",
     "mypy",
     "ruff",
     "serial",  # for testing with real hardware
@@ -21,3 +22,6 @@ dev = [
 [tool.setuptools.packages.find]
 where = ["."]
 exclude = ["sc62015/pysc62015/test*"]
+
+[tool.coverage.run]
+source = ["sc62015/pysc62015"]

--- a/run-tests.fish
+++ b/run-tests.fish
@@ -6,7 +6,7 @@ function build_and_run
   ruff check .
   mypy sc62015/pysc62015
   # pytest -vv
-  pytest -q
+  pytest --cov=sc62015/pysc62015 --cov-report=term-missing
 end
 
 build_and_run


### PR DESCRIPTION
## Summary
- add pytest-cov and coverage config
- document coverage in README
- enable Codecov uploads in CI
- include coverage reporting in test helper script
- ignore coverage files in git

## Testing
- `ruff check .`
- `python scripts/run_mypy.py`
- `pytest --cov=sc62015/pysc62015 --cov-report=term-missing --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_68463bd9e48c83318e52597709fb1401