### PR TITLE
Fix token equality check

### DIFF
--- a/sc62015/pysc62015/tokens.py
+++ b/sc62015/pysc62015/tokens.py
@@ -11,7 +11,9 @@ from typing import List, Tuple
 
 class Token:
     def __eq__(self, other: object) -> bool:
-        return repr(self) == repr(other)
+        if type(self) is not type(other):
+            return False
+        return self.__dict__ == getattr(other, "__dict__", {})
 
     def binja(self) -> tuple[InstructionTextTokenType, str]:
         raise NotImplementedError("binja() not implemented for {}".format(type(self)))


### PR DESCRIPTION
## Summary
- avoid using `repr()` for equality in `Token`

## Testing
- `ruff check`
- `MYPYPATH=stubs mypy sc62015/pysc62015`
- `pytest --cov=sc62015/pysc62015 --cov-report=term-missing --cov-report=xml`


------
https://chatgpt.com/codex/tasks/task_e_68463ffe68b48331a4a429bb21647ad5