### PR TITLE
Fix PC masking

### DIFF
--- a/sc62015/pysc62015/constants.py
+++ b/sc62015/pysc62015/constants.py
@@ -12,3 +12,7 @@ ADDRESS_SPACE_SIZE = 0x100000 + INTERNAL_MEMORY_LENGTH
 # Address of the first byte of internal RAM.
 # The internal region occupies addresses [INTERNAL_MEMORY_START, ADDRESS_SPACE_SIZE - 1].
 INTERNAL_MEMORY_START = ADDRESS_SPACE_SIZE - INTERNAL_MEMORY_LENGTH
+
+# Mask for the program counter. Although stored in three bytes, the PC
+# only uses the lower 20 bits.
+PC_MASK = 0xFFFFF

--- a/sc62015/pysc62015/emulator.py
+++ b/sc62015/pysc62015/emulator.py
@@ -1,7 +1,9 @@
 from typing import Dict, Set, Callable, Optional, Any, cast, Tuple, TypedDict
 import enum
-from .coding import FetchDecoder
 from dataclasses import dataclass
+
+from .coding import FetchDecoder
+from .constants import PC_MASK
 
 from .instr import (
     decode,
@@ -94,7 +96,10 @@ class Registers:
 
     def get(self, reg: RegisterName) -> int:
         if reg in self.BASE:
-            return self._values[reg]
+            val = self._values[reg]
+            if reg is RegisterName.PC:
+                return val & PC_MASK
+            return val
 
         match reg:
             case RegisterName.A:
@@ -116,7 +121,10 @@ class Registers:
 
     def set(self, reg: RegisterName, value: int) -> None:
         if reg in self.BASE:
-            self._values[reg] = value & (1 << (REGISTER_SIZE[reg] * 8)) - 1
+            mask = (1 << (REGISTER_SIZE[reg] * 8)) - 1
+            if reg is RegisterName.PC:
+                mask = PC_MASK
+            self._values[reg] = value & mask
             return
 
         match reg:

--- a/sc62015/pysc62015/test_emulator.py
+++ b/sc62015/pysc62015/test_emulator.py
@@ -6,7 +6,7 @@ from .emulator import (
     Emulator,
     Memory,
 )
-from .constants import ADDRESS_SPACE_SIZE, INTERNAL_MEMORY_START
+from .constants import ADDRESS_SPACE_SIZE, INTERNAL_MEMORY_START, PC_MASK
 from .instr import IMEM_NAMES
 from .mock_llil import MockLowLevelILFunction
 from .test_instr import opcode_generator
@@ -60,6 +60,18 @@ def test_registers() -> None:
     regs.set(RegisterName.FZ, 1)
     assert regs.get(RegisterName.FZ) == 1
     assert regs.get(RegisterName.F) == 3  # FC + FZ bits set
+
+
+def test_pc_mask() -> None:
+    regs = Registers()
+
+    # Setting a value with bits above 20 should wrap around
+    regs.set(RegisterName.PC, PC_MASK + 1 + 0x12345)
+    assert regs.get(RegisterName.PC) == 0x12345
+
+    # Verify masking occurs on retrieval as well
+    regs.set(RegisterName.PC, 0x1234567)
+    assert regs.get(RegisterName.PC) == 0x34567
 
 
 def _make_cpu_and_mem(


### PR DESCRIPTION
## Summary
- mask program counter to 20 bits
- expose PC_MASK constant
- add unit test for PC masking

## Testing
- `ruff check sc62015/pysc62015/emulator.py sc62015/pysc62015/test_emulator.py`
- `MYPYPATH=stubs mypy sc62015/pysc62015/emulator.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846401221a883318a62c297dcda70ea