### PR TITLE
Drop token __all__ exports

### DIFF
--- a/binja_helpers/README.md
+++ b/binja_helpers/README.md
@@ -1,0 +1,74 @@
+# binja_helpers
+
+Utility modules for developing and testing Binary Ninja plugins without requiring
+Binary Ninja itself.  Importing ``binja_helpers.binja_api`` provides a minimal
+stub of the ``binaryninja`` Python API when Binary Ninja is not installed.
+
+## Usage
+
+1. **Import the stub helper**
+
+   Import ``binja_helpers.binja_api`` before any ``binaryninja`` imports.  The
+   module attempts to locate a local Binary Ninja installation and installs a
+   lightweight stub when none is found.  This makes unit tests runnable on
+   systems without a Binary Ninja license.
+
+2. **Construct mock LLIL**
+
+   ``mock_llil`` implements ``MockLowLevelILFunction`` and helper constructors
+   like ``mllil`` and ``mreg``.  They mirror the real LLIL API closely enough to
+   let tests build and inspect instructions.  Example from the SC62015
+   architecture tests:
+
+   ```python
+   from binja_helpers import binja_api  # noqa: F401
+   from binja_helpers.mock_llil import MockLowLevelILFunction
+   from sc62015.arch import SC62015
+
+   def test_get_instruction_low_level_il_with_bytes() -> None:
+       arch = SC62015()
+       il = MockLowLevelILFunction()
+       length = arch.get_instruction_low_level_il(b"\x00", 0, il)
+       assert length == 1
+       assert il.ils[0].op == "NOP"
+   ```
+
+3. **Verify analysis information**
+
+   ``mock_analysis.MockAnalysisInfo`` mimics ``InstructionInfo`` so branch
+   targets and instruction lengths can be checked offline:
+
+   ```python
+   info = MockAnalysisInfo()
+   instr.analyze(info, 0x1000)
+   assert info.mybranches == [(BranchType.FalseBranch, 0x1002)]
+   ```
+
+4. **Evaluate LLIL**
+
+   ``eval_llil`` contains a small interpreter for mock LLIL expressions.  It is
+   useful for emulator-style tests:
+
+   ```python
+   from binja_helpers.eval_llil import evaluate_llil, Memory, State
+
+   result, flags = evaluate_llil(il_expr, regs, Memory(read_mem, write_mem), State())
+   ```
+
+5. **Compare disassembly**
+
+   Use ``asm_str`` to convert token lists returned by ``render()`` into plain
+   strings for assertions.  This mirrors how the SC62015 tests verify
+   decoding results:
+
+   ```python
+   from binja_helpers.tokens import asm_str  # noqa: F401
+
+   instr = arch.decode_instruction(0x00)
+   assert asm_str(instr.render()) == "NOP"
+   ```
+
+The SC62015 plugin in this repository uses these helpers extensively to test its
+instruction lifter and emulator logic without depending on a Binary Ninja
+install.  New plugins can adopt the same approach to keep their unit tests fast
+and self-contained.

--- a/binja_helpers/tokens.py
+++ b/binja_helpers/tokens.py
@@ -1,22 +1,26 @@
+"""Utility helpers for working with Binary Ninja instruction tokens."""
+
 # based on https://github.com/whitequark/binja-avnera/blob/main/mc/tokens.py
-from binja_helpers import binja_api  # noqa: F401
+
+
+from . import binja_api  # noqa: F401 -- make sure Binary Ninja stubs are loaded
 from binaryninja import InstructionTextToken
 from binaryninja.enums import InstructionTextTokenType
 
 import enum
-from typing import List, Tuple
-
-
+from typing import Iterable, Any, List, Tuple
 
 
 class Token:
+    """Base class for all renderable tokens."""
+
     def __eq__(self, other: object) -> bool:
         if type(self) is not type(other):
             return False
         return self.__dict__ == getattr(other, "__dict__", {})
 
-    def binja(self) -> tuple[InstructionTextTokenType, str]:
-        raise NotImplementedError("binja() not implemented for {}".format(type(self)))
+    def binja(self) -> Tuple[InstructionTextTokenType, str]:
+        raise NotImplementedError(f"binja() not implemented for {type(self)}")
 
     def to_binja(self) -> InstructionTextToken:
         kind, data = self.binja()
@@ -24,11 +28,14 @@ class Token:
 
 
 def asm(parts: List[Token]) -> List[InstructionTextToken]:
-    # map all tokens using to_binja()
+    """Convert tokens to Binary Ninja ``InstructionTextToken`` objects."""
+
     return [part.to_binja() for part in parts]
 
 
-def asm_str(parts: List[Token]) -> str:
+def asm_str(parts: Iterable[Any]) -> str:
+    """Return a human readable assembly string for a sequence of tokens."""
+
     return "".join(str(part) for part in parts)
 
 
@@ -124,6 +131,7 @@ class TEndMem(Token):
     def binja(self) -> Tuple[InstructionTextTokenType, str]:
         return (InstructionTextTokenType.EndMemoryOperandToken, self.__str__())
 
+
 class TAddr(Token):
     def __init__(self, value: int) -> None:
         self.value = value
@@ -149,3 +157,4 @@ class TReg(Token):
 
     def binja(self) -> Tuple[InstructionTextTokenType, str]:
         return (InstructionTextTokenType.RegisterToken, self.reg)
+

--- a/sc62015/arch.py
+++ b/sc62015/arch.py
@@ -9,7 +9,7 @@ from binaryninja.enums import Endianness, FlagRole
 from binaryninja.log import log_error
 
 from .pysc62015.instr import decode, encode, OPCODES
-from .pysc62015.tokens import asm
+from binja_helpers.tokens import asm
 
 
 class SC62015(Architecture):

--- a/sc62015/pysc62015/instr/opcodes.py
+++ b/sc62015/pysc62015/instr/opcodes.py
@@ -1,5 +1,5 @@
 # based on https://github.com/whitequark/binja-avnera/blob/main/mc/instr.py
-from ..tokens import (
+from binja_helpers.tokens import (
     Token,
     TInstr,
     TText,

--- a/sc62015/pysc62015/test_emulator.py
+++ b/sc62015/pysc62015/test_emulator.py
@@ -11,7 +11,7 @@ from .instr import IMEM_NAMES
 from binja_helpers.mock_llil import MockLowLevelILFunction
 from .test_instr import opcode_generator
 from typing import Dict, Tuple, List, NamedTuple, Optional
-from .tokens import asm_str
+from binja_helpers.tokens import asm_str
 from dataclasses import dataclass, field
 import pytest
 

--- a/sc62015/pysc62015/test_instr.py
+++ b/sc62015/pysc62015/test_instr.py
@@ -30,18 +30,18 @@ from .instr import (
 )
 from .instr import decode as decode_instr
 from .constants import INTERNAL_MEMORY_START
-from .tokens import (
+from binja_helpers.tokens import (
     Token,
     TInstr,
     TSep,
     TText,
     TInt,
-    asm_str,
     TBegMem,
     TEndMem,
     MemType,
     TReg,
 )
+from binja_helpers.tokens import asm_str
 from .coding import Decoder, Encoder
 from binja_helpers.mock_analysis import MockAnalysisInfo
 from binja_helpers.mock_llil import MockLowLevelILFunction, MockLLIL, MockFlag, mllil, mreg


### PR DESCRIPTION
## Summary
- remove exported names in `binja_helpers.__init__` and `tokens.py`
- import tokens from the submodule throughout the SC62015 plugin
- document using `asm_str` from `binja_helpers.tokens`
- cleanup: drop unnecessary `__future__` import

## Testing
- `ruff check .`
- `MYPYPATH=stubs mypy sc62015/pysc62015`
- `pytest --cov=sc62015/pysc62015 --cov-report=term-missing --cov-report=xml -q`

------
https://chatgpt.com/codex/tasks/task_e_68464a4e42fc83319e907d591bc105a3