### PR TITLE
Add pyproject for binja_helpers

### DIFF
--- a/binja_helpers/pyproject.toml
+++ b/binja_helpers/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "binja-helpers"
+version = "0.1.0"
+description = "Utility helpers for developing Binary Ninja plugins without an installed Binary Ninja."
+readme = "README.md"
+requires-python = ">=3.11"
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pytest-cov",
+    "mypy",
+    "ruff",
+]
+
+[tool.setuptools]
+packages = ["binja_helpers"]
+package-dir = {"binja_helpers" = "."}
+
+[tool.coverage.run]
+source = ["binja_helpers"]


### PR DESCRIPTION
## Summary
- add standalone `pyproject.toml` for the `binja_helpers` package
- adjust packaging settings so it can be built from within the subdirectory

## Testing
- `ruff check .`
- `MYPYPATH=$(pwd)/stubs mypy sc62015/pysc62015`
- `pytest --maxfail=1 -q`

------
https://chatgpt.com/codex/tasks/task_e_684654daecac83319246a9e21e25bfa7