### PR TITLE
Add evaluation tests for eval_llil

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ checks:
 ```bash
 python -m pip install -e .[dev]
 ruff check
+export MYPYPATH=$(pwd)/stubs  # ensure Binary Ninja stubs are found
 mypy sc62015/pysc62015
 pytest --cov=sc62015/pysc62015 --cov-report=term-missing --cov-report=xml
 ```

--- a/binja_helpers/eval_llil.py
+++ b/binja_helpers/eval_llil.py
@@ -91,14 +91,22 @@ def evaluate_llil(
     current_op_name_for_eval = op_name_bare
 
     if get_flag is None:
-        def get_flag_default(name: str) -> int:
-            return regs.get_by_name(f"F{name}")
+        if hasattr(regs, "get_flag"):
+            def get_flag_default(name: str) -> int:
+                return regs.get_flag(name)
+        else:
+            def get_flag_default(name: str) -> int:
+                return regs.get_by_name(f"F{name}")
 
         get_flag = get_flag_default
 
     if set_flag is None:
-        def set_flag_default(name: str, value: int) -> None:
-            regs.set_by_name(f"F{name}", value)
+        if hasattr(regs, "set_flag"):
+            def set_flag_default(name: str, value: int) -> None:
+                regs.set_flag(name, value)
+        else:
+            def set_flag_default(name: str, value: int) -> None:
+                regs.set_by_name(f"F{name}", value)
 
         set_flag = set_flag_default
 

--- a/binja_helpers/test_eval_llil.py
+++ b/binja_helpers/test_eval_llil.py
@@ -1,0 +1,139 @@
+from binja_helpers import binja_api  # noqa: F401
+from binja_helpers.eval_llil import evaluate_llil, Memory, State
+from binja_helpers.mock_llil import mllil, mreg, MockIntrinsic
+
+
+class DummyRegisters:
+    def __init__(self) -> None:
+        self.values: dict[str, int] = {}
+
+    def get_by_name(self, name: str) -> int:
+        return self.values.get(name, 0)
+
+    def set_by_name(self, name: str, value: int) -> None:
+        self.values[name] = value & 0xFFFFFFFF
+
+    def get_flag(self, name: str) -> int:
+        return self.get_by_name(f"F{name}")
+
+    def set_flag(self, name: str, value: int) -> None:
+        self.set_by_name(f"F{name}", value & 1)
+
+
+def make_memory() -> tuple[Memory, dict[int, int]]:
+    mem: dict[int, int] = {}
+
+    def read(addr: int) -> int:
+        return mem.get(addr, 0)
+
+    def write(addr: int, value: int) -> None:
+        mem[addr] = value & 0xFF
+
+    return Memory(read, write), mem
+
+
+def test_eval_const() -> None:
+    regs = DummyRegisters()
+    memory, _ = make_memory()
+    state = State()
+
+    result, flags = evaluate_llil(mllil("CONST.w", [0x1234]), regs, memory, state)
+    assert result == 0x1234
+    assert flags is None
+
+
+def test_set_and_get_reg() -> None:
+    regs = DummyRegisters()
+    memory, _ = make_memory()
+    state = State()
+
+    evaluate_llil(
+        mllil("SET_REG.b", [mreg("A"), mllil("CONST.b", [0x56])]),
+        regs,
+        memory,
+        state,
+    )
+    result, _ = evaluate_llil(mllil("REG.b", [mreg("A")]), regs, memory, state)
+    assert result == 0x56
+
+
+def test_add_sets_flags() -> None:
+    regs = DummyRegisters()
+    memory, _ = make_memory()
+    state = State()
+
+    result, _ = evaluate_llil(
+        mllil("ADD.b{CZ}", [mllil("CONST.b", [0xFF]), mllil("CONST.b", [1])]),
+        regs,
+        memory,
+        state,
+    )
+    assert result == 0x00
+    assert regs.get_by_name("FC") == 1
+    assert regs.get_by_name("FZ") == 1
+
+
+def test_sub_sets_carry() -> None:
+    regs = DummyRegisters()
+    memory, _ = make_memory()
+    state = State()
+
+    result, _ = evaluate_llil(
+        mllil("SUB.b{CZ}", [mllil("CONST.b", [0]), mllil("CONST.b", [1])]),
+        regs,
+        memory,
+        state,
+    )
+    assert result == 0xFF
+    assert regs.get_by_name("FC") == 1
+    assert regs.get_by_name("FZ") == 0
+
+
+def test_shift_lsl() -> None:
+    regs = DummyRegisters()
+    memory, _ = make_memory()
+    state = State()
+
+    result, _ = evaluate_llil(
+        mllil("LSL.b{CZ}", [mllil("CONST.b", [0x80]), mllil("CONST.b", [1])]),
+        regs,
+        memory,
+        state,
+    )
+    assert result == 0x00
+    assert regs.get_by_name("FC") == 1
+    assert regs.get_by_name("FZ") == 1
+
+
+def test_memory_load_store() -> None:
+    regs = DummyRegisters()
+    memory, mem = make_memory()
+    state = State()
+
+    evaluate_llil(
+        mllil(
+            "STORE.b",
+            [mllil("CONST_PTR.b", [0x10]), mllil("CONST.b", [0xAB])],
+        ),
+        regs,
+        memory,
+        state,
+    )
+    assert mem[0x10] == 0xAB
+
+    result, _ = evaluate_llil(
+        mllil("LOAD.b", [mllil("CONST_PTR.b", [0x10])]),
+        regs,
+        memory,
+        state,
+    )
+    assert result == 0xAB
+
+
+def test_intrinsic_halt() -> None:
+    regs = DummyRegisters()
+    memory, _ = make_memory()
+    state = State()
+
+    evaluate_llil(MockIntrinsic("HALT", [], []), regs, memory, state)
+    assert state.halted


### PR DESCRIPTION
## Summary
- add tests for LLIL evaluation helpers covering registers, flags, memory operations and intrinsic handling

## Testing
- `ruff check .`
- `mypy sc62015/pysc62015`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846569c6d1c8331ac3d6df9fbdf5617