### PR TITLE
Add generic decode helpers

### DIFF
--- a/binja_helpers/README.md
+++ b/binja_helpers/README.md
@@ -4,6 +4,8 @@ Utility modules for developing and testing Binary Ninja plugins without requirin
 Binary Ninja itself.  Importing ``binja_helpers.binja_api`` provides a minimal
 stub of the ``binaryninja`` Python API when Binary Ninja is not installed.
 
+These helpers operate on instruction objects that have already been decoded from binary input. The decoding logic was inspired by whitequark's [avnera](https://github.com/whitequark/binja-avnera) project.
+
 ## Usage
 
 1. **Import the stub helper**

--- a/binja_helpers/coding.py
+++ b/binja_helpers/coding.py
@@ -1,0 +1,88 @@
+# based on https://github.com/whitequark/binja-avnera/blob/main/mc/coding.py
+"""Binary decoding helpers used by multiple modules."""
+
+import struct
+from typing import Callable
+
+# Default addressable space used by FetchDecoder when bounds checking
+ADDRESS_SPACE_SIZE = 0x100100
+
+
+class BufferTooShort(Exception):
+    """Raised when attempting to read past the end of the buffer."""
+
+
+class Decoder:
+    def __init__(self, buf: bytearray) -> None:
+        self.buf, self.pos = buf, 0
+
+    def get_pos(self) -> int:
+        return self.pos
+
+    def peek(self, offset: int) -> int:
+        if len(self.buf) - self.pos <= offset:
+            raise BufferTooShort
+        return self.buf[self.pos + offset]
+
+    def _unpack(self, fmt: str) -> int:
+        size = struct.calcsize(fmt)
+        if len(self.buf) - self.pos < size:
+            raise BufferTooShort
+        fmt = "<" + fmt if fmt[0] != ">" else fmt
+        items = struct.unpack_from(fmt, self.buf, self.pos)
+        self.pos += size
+        if len(items) == 1:
+            return items[0]  # type: ignore
+        raise ValueError("Unpacking more than one item is not supported")
+
+    def unsigned_byte(self) -> int:
+        return self._unpack("B")
+
+    def unsigned_word_le(self) -> int:
+        return self._unpack("H")
+
+
+class FetchDecoder(Decoder):
+    """Decoder that fetches bytes using a callable instead of a buffer."""
+
+    def __init__(self, read_mem: Callable[[int], int]) -> None:
+        self.read_mem = read_mem
+        self.pos = 0
+
+    def get_pos(self) -> int:
+        return self.pos
+
+    def peek(self, offset: int) -> int:
+        if self.pos + offset >= ADDRESS_SPACE_SIZE:
+            raise BufferTooShort
+        return self.read_mem(self.pos + offset)
+
+    def _unpack(self, fmt: str) -> int:
+        size = struct.calcsize(fmt)
+        if self.pos + size > ADDRESS_SPACE_SIZE:
+            raise BufferTooShort
+        fmt = "<" + fmt if fmt[0] != ">" else fmt
+        items = struct.unpack_from(
+            fmt, bytearray(self.read_mem(self.pos + i) for i in range(size))
+        )
+        self.pos += size
+        if len(items) == 1:
+            return items[0]  # type: ignore
+        raise ValueError("Unpacking more than one item is not supported")
+
+
+class Encoder:
+    def __init__(self) -> None:
+        self.buf = bytearray()
+
+    def _pack(self, fmt: str, item: int) -> None:
+        offset = len(self.buf)
+        self.buf += b"\x00" * struct.calcsize(fmt)
+        fmt = "<" + fmt if fmt[0] != ">" else fmt
+        struct.pack_into(fmt, self.buf, offset, item)
+
+    def unsigned_byte(self, value: int) -> None:
+        self._pack("B", value)
+
+    def unsigned_word_le(self, value: int) -> None:
+        self._pack("H", value)

--- a/binja_helpers/test_coding.py
+++ b/binja_helpers/test_coding.py
@@ -1,24 +1,20 @@
-from .coding import Decoder, Encoder, FetchDecoder, BufferTooShort
-from .constants import ADDRESS_SPACE_SIZE
+from binja_helpers.coding import Decoder, Encoder, FetchDecoder, BufferTooShort, ADDRESS_SPACE_SIZE
 import pytest
 
 
 def test_decoder() -> None:
-    # Test decoding unsigned byte
     decoder = Decoder(bytearray([0x01, 0x02, 0x03, 0x00]))
     assert decoder.unsigned_byte() == 0x01
     assert decoder.unsigned_byte() == 0x02
     assert decoder.unsigned_byte() == 0x03
     assert decoder.unsigned_byte() == 0x00
 
-    # Test decoding unsigned word
     decoder = Decoder(bytearray([0xAA, 0xBB, 0xCC, 0xDD]))
     assert decoder.unsigned_word_le() == 0xBBAA
     assert decoder.unsigned_word_le() == 0xDDCC
 
 
 def test_fetchdecoder() -> None:
-    # Mock read_mem function
     def read_mem(addr: int) -> int:
         memory = bytearray([0x01, 0x02, 0x03, 0x04, 0x05, 0x06])
         if addr < len(memory):
@@ -27,17 +23,13 @@ def test_fetchdecoder() -> None:
 
     decoder = FetchDecoder(read_mem)
 
-    # Test fetching bytes
     assert decoder.peek(0) == 0x01
     assert decoder.peek(1) == 0x02
     assert decoder.peek(2) == 0x03
     assert decoder.peek(3) == 0x04
 
-    # Test decoding unsigned byte
     assert decoder.unsigned_byte() == 0x01
     assert decoder.unsigned_byte() == 0x02
-
-    # Test decoding unsigned word
     assert decoder.unsigned_word_le() == 0x0403
 
 
@@ -51,7 +43,6 @@ def test_fetchdecoder_bounds() -> None:
 
     decoder = FetchDecoder(read_mem)
 
-    # reading last byte succeeds
     decoder.pos = ADDRESS_SPACE_SIZE - 1
     assert decoder.peek(0) == memory[-1]
     with pytest.raises(BufferTooShort):
@@ -60,7 +51,6 @@ def test_fetchdecoder_bounds() -> None:
     decoder.pos = ADDRESS_SPACE_SIZE - 1
     assert decoder.unsigned_byte() == memory[-1]
     decoder.pos = ADDRESS_SPACE_SIZE - 2
-    # word read exactly at boundary succeeds
     assert decoder.unsigned_word_le() == int.from_bytes(memory[-2:], "little")
     decoder.pos = ADDRESS_SPACE_SIZE - 1
     with pytest.raises(BufferTooShort):
@@ -68,7 +58,6 @@ def test_fetchdecoder_bounds() -> None:
 
 
 def test_encoder() -> None:
-    # Test encoding unsigned byte
     encoder = Encoder()
     encoder.unsigned_byte(0x01)
     encoder.unsigned_byte(0x02)
@@ -76,9 +65,7 @@ def test_encoder() -> None:
     encoder.unsigned_byte(0x00)
     assert encoder.buf == bytearray([0x01, 0x02, 0x03, 0x00])
 
-    # Test encoding unsigned word
     encoder = Encoder()
     encoder.unsigned_word_le(0xBBAA)
     encoder.unsigned_word_le(0xDDCC)
     assert encoder.buf == bytearray([0xAA, 0xBB, 0xCC, 0xDD])
-

--- a/sc62015/pysc62015/coding.py
+++ b/sc62015/pysc62015/coding.py
@@ -1,91 +1,13 @@
-# based on https://github.com/whitequark/binja-avnera/blob/main/mc/coding.py
-import struct
-from typing import Callable
+from binja_helpers.coding import (
+    Decoder as _Decoder,
+    FetchDecoder as _FetchDecoder,
+    Encoder as _Encoder,
+    BufferTooShort as _BufferTooShort,
+    ADDRESS_SPACE_SIZE as ADDRESS_SPACE_SIZE,
+)
 
-from .constants import ADDRESS_SPACE_SIZE
-
-
-class BufferTooShort(Exception):
-    pass
-
-
-class Decoder:
-    def __init__(self, buf: bytearray) -> None:
-        self.buf, self.pos = buf, 0
-
-    def get_pos(self) -> int:
-        return self.pos
-
-    def peek(self, offset: int) -> int:
-        if len(self.buf) - self.pos <= offset:
-            raise BufferTooShort
-
-        return self.buf[self.pos + offset]
-
-    def _unpack(self, fmt: str) -> int:
-        size = struct.calcsize(fmt)
-        if len(self.buf) - self.pos < size:
-            raise BufferTooShort
-
-        fmt = "<" + fmt if fmt[0] != ">" else fmt
-        items = struct.unpack_from(fmt, self.buf, self.pos)
-        self.pos += size
-        if len(items) == 1:
-            return items[0]  # type: ignore
-        raise ValueError("Unpacking more than one item is not supported")
-
-    def unsigned_byte(self) -> int:
-        return self._unpack("B")
-
-    def unsigned_word_le(self) -> int:
-        return self._unpack("H")
-
-
-
-# FetchDecoder is similar to Decoder but uses a read_mem function to fetch memory
-
-
-class FetchDecoder(Decoder):
-
-    def __init__(self, read_mem: Callable[[int], int]) -> None:
-        self.read_mem = read_mem
-        self.pos = 0
-
-    def get_pos(self) -> int:
-        return self.pos
-
-    def peek(self, offset: int) -> int:
-        if self.pos + offset >= ADDRESS_SPACE_SIZE:
-            raise BufferTooShort
-        return self.read_mem(self.pos + offset)
-
-    def _unpack(self, fmt: str) -> int:
-        size = struct.calcsize(fmt)
-        if self.pos + size > ADDRESS_SPACE_SIZE:
-            raise BufferTooShort
-
-        fmt = "<" + fmt if fmt[0] != ">" else fmt
-        items = struct.unpack_from(
-            fmt, bytearray(self.read_mem(self.pos + i) for i in range(size))
-        )
-        self.pos += size
-        if len(items) == 1:
-            return items[0]  # type: ignore
-        raise ValueError("Unpacking more than one item is not supported")
-
-
-class Encoder:
-    def __init__(self) -> None:
-        self.buf = bytearray()
-
-    def _pack(self, fmt: str, item: int) -> None:
-        offset = len(self.buf)
-        self.buf += b"\x00" * struct.calcsize(fmt)
-        fmt = "<" + fmt if fmt[0] != ">" else fmt
-        struct.pack_into(fmt, self.buf, offset, item)
-
-    def unsigned_byte(self, value: int) -> None:
-        self._pack("B", value)
-
-    def unsigned_word_le(self, value: int) -> None:
-        self._pack("H", value)
+# Re-export the generic helpers to maintain compatibility with existing imports
+Decoder = _Decoder
+FetchDecoder = _FetchDecoder
+Encoder = _Encoder
+BufferTooShort = _BufferTooShort

--- a/sc62015/pysc62015/emulator.py
+++ b/sc62015/pysc62015/emulator.py
@@ -1,6 +1,6 @@
 from typing import Dict, Set, Optional, Any, cast, Tuple
 import enum
-from .coding import FetchDecoder
+from binja_helpers.coding import FetchDecoder
 from .constants import PC_MASK
 
 from .instr import (

--- a/sc62015/pysc62015/instr/opcodes.py
+++ b/sc62015/pysc62015/instr/opcodes.py
@@ -11,7 +11,7 @@ from binja_helpers.tokens import (
     TAddr,
     MemType,
 )
-from ..coding import Decoder, Encoder, BufferTooShort
+from binja_helpers.coding import Decoder, Encoder, BufferTooShort
 
 from binja_helpers.mock_llil import MockLLIL
 from ..constants import INTERNAL_MEMORY_START

--- a/sc62015/pysc62015/sc_asm.py
+++ b/sc62015/pysc62015/sc_asm.py
@@ -8,7 +8,7 @@ from plumbum import cli  # type: ignore[import-untyped]
 
 # Assuming the provided library files are in a package named 'sc62015'
 from .asm import AsmTransformer, asm_parser, ParsedInstruction
-from .coding import Encoder
+from binja_helpers.coding import Encoder
 from .instr import (
     Instruction,
     OPCODES,

--- a/sc62015/pysc62015/test_instr.py
+++ b/sc62015/pysc62015/test_instr.py
@@ -42,7 +42,7 @@ from binja_helpers.tokens import (
     TReg,
 )
 from binja_helpers.tokens import asm_str
-from .coding import Decoder, Encoder
+from binja_helpers.coding import Decoder, Encoder
 from binja_helpers.mock_analysis import MockAnalysisInfo
 from binja_helpers.mock_llil import MockLowLevelILFunction, MockLLIL, MockFlag, mllil, mreg
 from binaryninja.lowlevelil import (


### PR DESCRIPTION
## Summary
- document that helpers expect instructions to already be decoded
- share decoding helpers between architectures
- include unit tests for the shared helpers
- import shared coding helpers directly from binja_helpers

## Testing
- `ruff check .`
- `MYPYPATH=stubs mypy sc62015/pysc62015`
- `pytest --cov=sc62015/pysc62015 --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_68465688c1608331a1264ed75a4a205f