### PR TITLE
Make FetchDecoder address space mandatory

### DIFF
--- a/binja_helpers/test_coding.py
+++ b/binja_helpers/test_coding.py
@@ -1,4 +1,5 @@
-from binja_helpers.coding import Decoder, Encoder, FetchDecoder, BufferTooShort, ADDRESS_SPACE_SIZE
+from binja_helpers.coding import Decoder, Encoder, FetchDecoder, BufferTooShort
+from sc62015.pysc62015.constants import ADDRESS_SPACE_SIZE
 import pytest
 
 
@@ -21,7 +22,7 @@ def test_fetchdecoder() -> None:
             return memory[addr]
         raise IndexError("Address out of bounds")
 
-    decoder = FetchDecoder(read_mem)
+    decoder = FetchDecoder(read_mem, ADDRESS_SPACE_SIZE)
 
     assert decoder.peek(0) == 0x01
     assert decoder.peek(1) == 0x02
@@ -41,7 +42,7 @@ def test_fetchdecoder_bounds() -> None:
             return memory[addr]
         raise IndexError("Address out of bounds")
 
-    decoder = FetchDecoder(read_mem)
+    decoder = FetchDecoder(read_mem, ADDRESS_SPACE_SIZE)
 
     decoder.pos = ADDRESS_SPACE_SIZE - 1
     assert decoder.peek(0) == memory[-1]

--- a/sc62015/pysc62015/coding.py
+++ b/sc62015/pysc62015/coding.py
@@ -3,8 +3,8 @@ from binja_helpers.coding import (
     FetchDecoder as _FetchDecoder,
     Encoder as _Encoder,
     BufferTooShort as _BufferTooShort,
-    ADDRESS_SPACE_SIZE as ADDRESS_SPACE_SIZE,
 )
+from .constants import ADDRESS_SPACE_SIZE  # noqa: F401 - re-export
 
 # Re-export the generic helpers to maintain compatibility with existing imports
 Decoder = _Decoder

--- a/sc62015/pysc62015/emulator.py
+++ b/sc62015/pysc62015/emulator.py
@@ -1,7 +1,7 @@
 from typing import Dict, Set, Optional, Any, cast, Tuple
 import enum
 from binja_helpers.coding import FetchDecoder
-from .constants import PC_MASK
+from .constants import PC_MASK, ADDRESS_SPACE_SIZE
 
 from .instr import (
     decode,
@@ -196,7 +196,7 @@ class Emulator:
         def fecher(offset: int) -> int:
             return self.memory.read_byte(address + offset)
 
-        decoder = FetchDecoder(fecher)
+        decoder = FetchDecoder(fecher, ADDRESS_SPACE_SIZE)
         return decode(decoder, address, OPCODES)  # type: ignore
 
     def execute_instruction(self, address: int) -> None:


### PR DESCRIPTION
## Summary
- drop ADDRESS_SPACE_SIZE constant from `binja_helpers.coding`
- require callers to pass `address_space_size` to `FetchDecoder`
- update emulator and coding helpers
- fix tests for new requirement
- clean up redundant comment

## Testing
- `ruff check .`
- `MYPYPATH=stubs mypy sc62015/pysc62015`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68465ae511b88331a2e5ebcf1a690c50