### PR TITLE
Refactor eval LLIL tests with dataclass

### DIFF
--- a/binja_helpers/test_eval_llil.py
+++ b/binja_helpers/test_eval_llil.py
@@ -1,6 +1,10 @@
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
 from binja_helpers import binja_api  # noqa: F401
 from binja_helpers.eval_llil import evaluate_llil, Memory, State
-from binja_helpers.mock_llil import mllil, mreg, MockFlag
+from binja_helpers.mock_llil import MockLLIL, MockFlag, mllil, mreg
+import pytest
 
 class SimpleRegs:
     def __init__(self):
@@ -23,85 +27,131 @@ def make_mem(size=0x100):
     )
 
 
-def test_add_sets_flags() -> None:
+@dataclass
+class LlilEvalTestCase:
+    """Container for a single LLIL evaluation test case."""
+
+    test_id: str
+    llil_expr: MockLLIL
+    initial_regs: Dict[str, int] = field(default_factory=dict)
+    initial_mem: Dict[int, int] = field(default_factory=dict)
+    expected_result: Optional[int] = None
+    expected_regs: Dict[str, int] = field(default_factory=dict)
+    expected_mem_writes: Dict[int, int] = field(default_factory=dict)
+    expected_flags_in_f: Optional[int] = None
+
+
+eval_llil_test_cases = [
+    LlilEvalTestCase(
+        test_id="add_byte_sets_carry_and_zero_flags",
+        llil_expr=mllil(
+            "ADD.b{CZ}",
+            [mllil("CONST.b", [0x01]), mllil("CONST.b", [0xFF])],
+        ),
+        expected_result=0x00,
+        expected_flags_in_f=0b11,
+    ),
+    LlilEvalTestCase(
+        test_id="set_reg_updates_register",
+        llil_expr=mllil(
+            "SET_REG.b",
+            [mreg("A"), mllil("CONST.b", [0x42])],
+        ),
+        expected_regs={"A": 0x42},
+    ),
+    LlilEvalTestCase(
+        test_id="reg_returns_value",
+        llil_expr=mllil("REG", [mreg("A")]),
+        initial_regs={"A": 0x42},
+        expected_result=0x42,
+    ),
+    LlilEvalTestCase(
+        test_id="push_byte_decrements_sp_and_writes_memory",
+        llil_expr=mllil("PUSH.b", [mllil("CONST.b", [0xAA])]),
+        initial_regs={"S": 0x10},
+        expected_regs={"S": 0x0F},
+        expected_mem_writes={0x0F: 0xAA},
+    ),
+    LlilEvalTestCase(
+        test_id="pop_byte_restores_sp_and_returns_value",
+        llil_expr=mllil("POP.b"),
+        initial_regs={"S": 0x0F},
+        initial_mem={0x0F: 0xAA},
+        expected_result=0xAA,
+        expected_regs={"S": 0x10},
+    ),
+    LlilEvalTestCase(
+        test_id="load_byte_reads_memory",
+        llil_expr=mllil("LOAD.b", [mllil("CONST_PTR", [0x20])]),
+        initial_mem={0x20: 0x77},
+        expected_result=0x77,
+    ),
+    LlilEvalTestCase(
+        test_id="store_byte_writes_memory",
+        llil_expr=mllil(
+            "STORE.b",
+            [mllil("CONST_PTR", [0x21]), mllil("CONST.b", [0x99])],
+        ),
+        expected_mem_writes={0x21: 0x99},
+    ),
+    LlilEvalTestCase(
+        test_id="set_flag_sets_bit",
+        llil_expr=mllil("SET_FLAG", [MockFlag("C"), mllil("CONST.b", [1])]),
+        expected_flags_in_f=0b1,
+    ),
+    LlilEvalTestCase(
+        test_id="flag_returns_value",
+        llil_expr=mllil("FLAG", [MockFlag("C")]),
+        initial_regs={"F": 0b1},
+        expected_result=1,
+    ),
+    LlilEvalTestCase(
+        test_id="lsl_sets_carry_and_zero_flags",
+        llil_expr=mllil(
+            "LSL.b{CZ}",
+            [mllil("CONST.b", [0x80]), mllil("CONST.b", [1])],
+        ),
+        expected_result=0x00,
+        expected_flags_in_f=0b11,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "case",
+    eval_llil_test_cases,
+    ids=[c.test_id for c in eval_llil_test_cases],
+)
+def test_llil_evaluation(case: LlilEvalTestCase) -> None:
     regs = SimpleRegs()
-    mem, read_mem, write_mem = make_mem()
+    for name, value in case.initial_regs.items():
+        regs.set_by_name(name, value)
+
+    buf = bytearray(256)
+    for addr, value in case.initial_mem.items():
+        buf[addr] = value
+
+    def read_mem(addr: int) -> int:
+        return buf[addr]
+
+    def write_mem(addr: int, val: int) -> None:
+        buf[addr] = val & 0xFF
+        if addr in case.expected_mem_writes:
+            assert val == case.expected_mem_writes[addr]
+
+    memory = Memory(read_mem, write_mem)
     state = State()
-    expr = mllil(
-        "ADD.b{CZ}",
-        [mllil("CONST.b", [0x01]), mllil("CONST.b", [0xFF])],
-    )
-    result, flags = evaluate_llil(expr, regs, Memory(read_mem, write_mem), state)
-    assert result == 0x00
-    assert flags == {"C": 1, "Z": 1}
-    assert regs.get_by_name("F") == 0b11
 
+    result, _flags = evaluate_llil(case.llil_expr, regs, memory, state)
 
-def test_set_and_get_reg() -> None:
-    regs = SimpleRegs()
-    mem, read_mem, write_mem = make_mem()
-    state = State()
-    expr_set = mllil(
-        "SET_REG.b",
-        [mreg("A"), mllil("CONST.b", [0x42])],
-    )
-    evaluate_llil(expr_set, regs, Memory(read_mem, write_mem), state)
-    expr_get = mllil("REG", [mreg("A")])
-    val, _ = evaluate_llil(expr_get, regs, Memory(read_mem, write_mem), state)
-    assert val == 0x42
+    if case.expected_result is not None:
+        assert result == case.expected_result
 
+    for name, value in case.expected_regs.items():
+        assert regs.get_by_name(name) == value
 
-def test_push_and_pop() -> None:
-    regs = SimpleRegs()
-    regs.set_by_name("S", 0x10)
-    mem, read_mem, write_mem = make_mem()
-    state = State()
-    expr_push = mllil("PUSH.b", [mllil("CONST.b", [0xAA])])
-    evaluate_llil(expr_push, regs, Memory(read_mem, write_mem), state)
-    assert regs.get_by_name("S") == 0x0F
-    assert mem[0x0F] == 0xAA
-    expr_pop = mllil("POP.b")
-    val, _ = evaluate_llil(expr_pop, regs, Memory(read_mem, write_mem), state)
-    assert val == 0xAA
-    assert regs.get_by_name("S") == 0x10
+    if case.expected_flags_in_f is not None:
+        assert regs.get_by_name("F") == case.expected_flags_in_f
 
-
-def test_load_and_store() -> None:
-    regs = SimpleRegs()
-    mem, read_mem, write_mem = make_mem()
-    mem[0x20] = 0x77
-    state = State()
-    expr_load = mllil("LOAD.b", [mllil("CONST_PTR", [0x20])])
-    val, _ = evaluate_llil(expr_load, regs, Memory(read_mem, write_mem), state)
-    assert val == 0x77
-    expr_store = mllil(
-        "STORE.b",
-        [mllil("CONST_PTR", [0x21]), mllil("CONST.b", [0x99])],
-    )
-    evaluate_llil(expr_store, regs, Memory(read_mem, write_mem), state)
-    assert mem[0x21] == 0x99
-
-
-def test_set_and_read_flag() -> None:
-    regs = SimpleRegs()
-    mem, read_mem, write_mem = make_mem()
-    state = State()
-    expr_set = mllil("SET_FLAG", [MockFlag("C"), mllil("CONST.b", [1])])
-    evaluate_llil(expr_set, regs, Memory(read_mem, write_mem), state)
-    assert regs.get_by_name("F") & 1 == 1
-    expr_get = mllil("FLAG", [MockFlag("C")])
-    val, _ = evaluate_llil(expr_get, regs, Memory(read_mem, write_mem), state)
-    assert val == 1
-
-
-def test_lsl_flag_behavior() -> None:
-    regs = SimpleRegs()
-    mem, read_mem, write_mem = make_mem()
-    state = State()
-    expr = mllil(
-        "LSL.b{CZ}",
-        [mllil("CONST.b", [0x80]), mllil("CONST.b", [1])],
-    )
-    result, _ = evaluate_llil(expr, regs, Memory(read_mem, write_mem), state)
-    assert result == 0x00
-    assert regs.get_by_name("F") == 0b11
+    for addr, value in case.expected_mem_writes.items():
+        assert buf[addr] == value


### PR DESCRIPTION
## Summary
- restructure `test_eval_llil.py` around a dataclass
- consolidate individual tests into a single parametrized test using `pytest.mark.parametrize`

## Testing
- `ruff check .`
- `MYPYPATH=stubs mypy sc62015/pysc62015`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68465ec42bec8331b7725c91f130a0eb