### PR TITLE
Fix plugin imports in Binary Ninja

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,13 @@
 import sys
 import importlib.util
+from pathlib import Path
+
+# Ensure the plugin directory is available on ``sys.path`` so that
+# absolute imports like ``binja_helpers`` work when the plugin is loaded
+# directly by Binary Ninja.
+_plugin_dir = str(Path(__file__).resolve().parent)
+if _plugin_dir not in sys.path:
+    sys.path.insert(0, _plugin_dir)
 
 def module_exists(module_name):
     if module_name in sys.modules:


### PR DESCRIPTION
## Summary
- ensure plugin directory is on `sys.path` so `binja_helpers` can be found

## Testing
- `ruff check .`
- `MYPYPATH=stubs mypy sc62015/pysc62015`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68466a4ef5c483319fb240ce23e967b3