### PR TITLE
Fix EMemAddr.lift_assign compatibility for real Binary Ninja

### DIFF
--- a/sc62015/pysc62015/instr/opcodes.py
+++ b/sc62015/pysc62015/instr/opcodes.py
@@ -1253,9 +1253,9 @@ class EMemAddr(Imm20, Pointer):
     def lift_assign(self, il: LowLevelILFunction, value: ExpressionIndex, pre:
                     Optional[AddressingMode] = None) -> None:
         assert self.value is not None, "Value not set"
-        assert isinstance(value, HasWidth), f"Expected HasWidth, got {type(value)}"
+        assert isinstance(value, (MockLLIL, int)), f"Expected MockLLIL or int, got {type(value)}"
         il.append(
-            il.store(value.width(), il.const_pointer(3, self.value), value)
+            il.store(self.width(), il.const_pointer(3, self.value), value)
         )
 
 


### PR DESCRIPTION
## Summary
- allow real Binary Ninja `ExpressionIndex` in EMemAddr.lift_assign
- store using the operand width instead of value width

## Testing
- `ruff check .`
- `mypy sc62015/pysc62015`
- `pytest --cov=sc62015/pysc62015 --cov-report=term-missing --cov-report=xml`


------
https://chatgpt.com/codex/tasks/task_e_68466bfd3ab88331bdd0b2ab9c00fea7