### PR TITLE
Add MockLLIL doc warning

### DIFF
--- a/binja_helpers/mock_llil.py
+++ b/binja_helpers/mock_llil.py
@@ -46,6 +46,13 @@ class MockHandle:
 
 @dataclass
 class MockLLIL:
+    """Simplified stand-in for Binary Ninja's LLIL expression.
+
+    WARNING: On a real Binary Ninja instance these expressions are
+    represented by ``ExpressionIndex`` integers.  This class exists only
+    for testing and should not be confused with the real API.
+    """
+
     op: str
     ops: List[Any]
 


### PR DESCRIPTION
## Summary
- document that `MockLLIL` is an object where Binary Ninja uses an `ExpressionIndex` integer

## Testing
- `ruff check .`
- `mypy sc62015/pysc62015`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68466d79be0883318a62f54438c56f42