### PR TITLE
Fix RegisterName import errors

### DIFF
--- a/binja_helpers/binja_api.py
+++ b/binja_helpers/binja_api.py
@@ -169,6 +169,12 @@ if not _has_binja():
     bn.architecture = arch_mod  # type: ignore [attr-defined]
     sys.modules["binaryninja.architecture"] = arch_mod
 
+    # Expose common architecture types at the module root so imports like
+    # ``from binaryninja import RegisterName`` succeed when using this mock.
+    bn.RegisterName = RegisterName  # type: ignore[attr-defined]
+    bn.IntrinsicName = IntrinsicName  # type: ignore[attr-defined]
+    bn.FlagName = FlagName  # type: ignore[attr-defined]
+
     llil_mod = types.ModuleType("binaryninja.lowlevelil")
 
     class ExpressionIndex(int):

--- a/sc62015/pysc62015/asm.py
+++ b/sc62015/pysc62015/asm.py
@@ -1,6 +1,6 @@
 from typing import Any, List, Optional, Union, cast, TypedDict, Type, Literal
 from binja_helpers import binja_api  # noqa: F401
-from binaryninja.architecture import RegisterName
+from binaryninja import RegisterName
 from lark import Lark, Transformer, Token
 from .instr import (
     Instruction,

--- a/sc62015/pysc62015/instr/opcodes.py
+++ b/sc62015/pysc62015/instr/opcodes.py
@@ -28,7 +28,7 @@ from binja_helpers import binja_api  # noqa: F401
 from binaryninja import (
     InstructionInfo,
 )
-from binaryninja.architecture import (
+from binaryninja import (
     RegisterName,
     IntrinsicName,
     FlagName,

--- a/sc62015/pysc62015/test_instr.py
+++ b/sc62015/pysc62015/test_instr.py
@@ -48,7 +48,7 @@ from binja_helpers.mock_llil import MockLowLevelILFunction, MockLLIL, MockFlag, 
 from binaryninja.lowlevelil import (
     LLIL_TEMP,
 )
-from binaryninja.architecture import RegisterName
+from binaryninja import RegisterName
 
 import os
 from pprint import pprint


### PR DESCRIPTION
## Summary
- access BinaryNinja RegisterName stubs via the module root in tests
- allow importing RegisterName/IntrinsicName/FlagName from `binaryninja`
- update imports in SC62015 package

## Testing
- `ruff check .`
- `python scripts/run_mypy.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e4c58d31c833197f528c830d277f3