### PR TITLE
Remove redundant pyright flag

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -36,6 +36,5 @@
   "reportAttributeAccessIssue": "none",
   "reportArgumentType": "none",
   "reportInvalidTypeForm": "none",
-  "reportAssignmentType": "none",
   "reportCallIssue": "none"
 }


### PR DESCRIPTION
## Summary
- drop `reportAssignmentType` setting from `pyrightconfig.json`

## Testing
- `ruff check`
- `pytest -q`
- `pyright sc62015/pysc62015`

------
https://chatgpt.com/codex/tasks/task_e_685bacf93aec83318d406ddc15e3e76c