### PR TITLE
Fix attribute access warnings

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -33,7 +33,6 @@
   "reportUnknownArgumentType": "none",
   "reportUnknownLambdaType": "none",
   "reportUnknownParameterType": "none",
-  "reportAttributeAccessIssue": "none",
   "reportArgumentType": "none",
   "reportInvalidTypeForm": "none",
   "reportAssignmentType": "none",

--- a/sc62015/pysc62015/asm.py
+++ b/sc62015/pysc62015/asm.py
@@ -671,7 +671,7 @@ class AsmTransformer(Transformer):
 
     def mv_reg_emem(self, items: List[Any]) -> InstructionNode:
         reg = cast(Reg, items[0])
-        mem = cast(EMemAddr, items[1])
+        mem = cast(EMemAddr | EMemReg, items[1])
         # The grammar for ``emem_operand`` also matches ``emem_reg_operand`` which
         # results in this handler receiving ``EMemReg`` instances as ``mem``.
         # For ``MV`` instructions the width of the external memory operand is
@@ -691,7 +691,7 @@ class AsmTransformer(Transformer):
         }
 
     def mv_emem_reg(self, items: List[Any]) -> InstructionNode:
-        mem = cast(EMemAddr, items[0])
+        mem = cast(EMemAddr | EMemReg, items[0])
         reg = cast(Reg, items[1])
         if isinstance(mem, EMemReg):
             mem.width = reg.width()

--- a/sc62015/pysc62015/sc_asm.py
+++ b/sc62015/pysc62015/sc_asm.py
@@ -261,15 +261,15 @@ class Assembler:
                                 setattr(op, "value", int(getattr(op, "value"), 0))
                             except ValueError:
                                 setattr(op, "value", 0)
+                        offset = getattr(op, "offset", None)
                         if (
-                            hasattr(op, "offset")
-                            and isinstance(op.offset, ImmOffset)
-                            and isinstance(op.offset.value, str)
+                            isinstance(offset, ImmOffset)
+                            and isinstance(offset.value, str)
                         ):
                             try:
-                                op.offset.value = int(op.offset.value, 0)
+                                offset.value = int(offset.value, 0)
                             except ValueError:
-                                op.offset.value = 0
+                                offset.value = 0
                         if hasattr(op, "extra_hi") and getattr(op, "value", None) is not None:
                             setattr(op, "extra_hi", (int(getattr(op, "value")) >> 16) & 0xFF)
                         if isinstance(op, Imm20) and isinstance(op.value, int):
@@ -404,12 +404,12 @@ class Assembler:
                         setattr(op, "value", val)
                     if isinstance(op, Imm20) and isinstance(val, int):
                         op.extra_hi = (val >> 16) & 0xFF
+                offset = getattr(op, "offset", None)
                 if (
-                    hasattr(op, "offset")
-                    and isinstance(op.offset, ImmOffset)
-                    and isinstance(op.offset.value, str)
+                    isinstance(offset, ImmOffset)
+                    and isinstance(offset.value, str)
                 ):
-                    op.offset.value = self._evaluate_operand(op.offset.value)
+                    offset.value = self._evaluate_operand(offset.value)
             encoder = Encoder()
             instr.encode(encoder, self.current_address)
             return encoder.buf


### PR DESCRIPTION
## Summary
- remove suppressed `reportAttributeAccessIssue` from pyright config
- adjust casts for external memory operands
- handle optional offsets more safely

## Testing
- `ruff check .`
- `pyright sc62015/pysc62015`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bad1a212883318daea37a10c63fa4