### PR TITLE
docs: update README development section to use uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,25 @@ Apache License 2.0.
 
 ## Development
 
-Install the package in editable mode with development dependencies and run the
-checks:
+Install dependencies using uv and run the checks:
 
 ```bash
-python -m pip install -e .[dev]
-ruff check
-pyright sc62015/pysc62015
-pytest --cov=sc62015/pysc62015 --cov-report=term-missing --cov-report=xml
+# Install uv (if not already installed)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+# or on macOS: brew install uv
+
+# Install all dependencies and create virtual environment
+uv sync --extra dev --extra pce500 --extra web
+
+# Run linting and formatting
+uv run ruff check .
+uv run ruff format .
+
+# Run type checking
+uv run pyright sc62015/pysc62015
+
+# Run tests with coverage
+FORCE_BINJA_MOCK=1 uv run pytest --cov=sc62015/pysc62015 --cov-report=term-missing --cov-report=xml
 ```
 
 The CI workflow uploads coverage results to Codecov on each commit.


### PR DESCRIPTION
## Summary
- Replace pip-based development setup with uv commands
- Add uv installation instructions
- Update all development commands to use `uv run` prefix
- Include all extra dependencies (dev, pce500, web) for full functionality

## Test plan
- [ ] Verify uv installation works on different platforms
- [ ] Test that `uv sync --extra dev --extra pce500 --extra web` installs all dependencies
- [ ] Confirm all development commands work with `uv run` prefix

🤖 Generated with [Claude Code](https://claude.ai/code)