### PR TITLE
Restore lint-format.yml workflow

### DIFF
--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -1,0 +1,61 @@
+name: Lint & Format
+
+on:
+  push:
+    branches: [ main, master, fast ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  ruff-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+
+      - name: Install dependencies
+        run: |
+          uv sync --extra dev
+
+      - name: Ruff lint
+        run: |
+          uv run ruff check .
+
+  ruff-format:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+
+      - name: Install dependencies
+        run: |
+          uv sync --extra dev
+
+      - name: Ruff format check
+        run: |
+          uv run ruff format --check .


### PR DESCRIPTION
## Summary
Restores the `lint-format.yml` workflow that was accidentally deleted in commit 5240644be2ee57ccf5ba3041c7b6cb30653311fd.

## Background
The workflow was deleted in commit 5240644 during keyboard IRQ delivery changes. This caused PRs to miss important code quality checks.

## Changes
- Restores `.github/workflows/lint-format.yml` from the commit before its deletion
- Includes both `ruff-lint` and `ruff-format` jobs
- `ruff-format` job uses `continue-on-error: true` to make formatting non-blocking

## Workflow Features
- **ruff-lint job**: Runs `uv run ruff check .` to catch linting issues (blocking)
- **ruff-format job**: Runs `uv run ruff format --check .` to check formatting (non-blocking)
- Triggers on pushes to `main`, `master`, `fast` branches and all pull requests
- Uses Python 3.11 and uv for dependency management

## Test plan
- [x] File restored from correct commit
- [x] Workflow syntax is valid
- [x] PR should now show lint-format checks running

🤖 Generated with [Claude Code](https://claude.ai/code)