### PR TITLE
web: show Instruction History by enabling lightweight tracing

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -87,8 +87,10 @@ def initialize_emulator():
     # Create emulator instance
     with emulator_lock:
         # Use compat keyboard implementation
+        # Enable lightweight opcode/disassembly tracing so Instruction History populates
+        # (emulator maintains a bounded deque, so overhead remains reasonable)
         emulator = PCE500Emulator(
-            trace_enabled=False,
+            trace_enabled=True,
             perfetto_trace=False,
             save_lcd_on_exit=False,
         )


### PR DESCRIPTION
Problem
- The Instruction History panel in the web UI remained empty because the emulator was created with trace_enabled=False.
- The emulator only appends instruction entries when trace is active (self.trace is not None).

Change
- Initialize PCE500Emulator with trace_enabled=True in web/app.py::initialize_emulator().
- This populates the bounded instruction_history deque with {pc, disassembly} entries that the UI already renders.

Impact
- Minimal runtime overhead (bounded history; short disassembly rendering).
- No API or UI shape changes; only enables the existing feature.

Test plan
- Start the web app: PC-E500 emulator initialized successfully
Starting web server at http://localhost:8080
 * Serving Flask app 'app'
 * Debug mode: on.
- Click Run or Step.
- Observe the Instruction History panel populating with addresses and disassembly.

Notes
- Perfetto tracing remains off unless started via UI; this change only enables the lightweight opcode/disassembly list.