### PR TITLE
pce500/web: ON-key IRQ + HALT wake, interrupt tests, web pause fix

### DIFF
--- a/pce500/tests/test_ocr_optimization.py
+++ b/pce500/tests/test_ocr_optimization.py
@@ -15,6 +15,7 @@ import sys
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from PIL import Image, ImageOps, ImageFilter
+import pytest
 import pytesseract
 
 
@@ -150,6 +151,7 @@ def ocr_image(
     return text, im
 
 
+@pytest.mark.timeout(300)
 def test_ocr_configurations():
     """
     Test various OCR configurations on lcd_display.png and find the best one.
@@ -350,6 +352,7 @@ def test_ocr_configurations():
                     print(f"  Line {i}: '{line}' ✓")
 
 
+@pytest.mark.timeout(60)
 def test_single_configuration():
     """Quick test with default configuration."""
     test_image = "lcd_display.png"
@@ -395,6 +398,7 @@ def test_single_configuration():
             print(f"  Recognized: '{recognized}'")
 
 
+@pytest.mark.timeout(120)
 def test_best_configurations():
     """Test only the best-performing configurations based on initial analysis."""
     # Expected text (4 lines with second line empty)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
 dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
+    "pytest-timeout>=2.2.0",
     "pyright>=1.1.0",
     "ruff>=0.1.0",
     "pyserial",  # for testing with real hardware

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,3 +6,10 @@ filterwarnings =
     ignore:Type google\._upb\._message\.MessageMapContainer.*:DeprecationWarning
     ignore:Type google\._upb\._message\.ScalarMapContainer.*:DeprecationWarning
 
+# Per-test timeout configuration (requires pytest-timeout)
+timeout = 60
+timeout_method = signal
+timeout_func_only = true
+
+# Dump traceback on global hangs as a fallback (built-in faulthandler)
+faulthandler_timeout = 120


### PR DESCRIPTION
- Add ISR.ONKI handling via KEY_ON
- Implement HALT execution stop; wake on any ISR bit and arm IRQ
- Refactor pce500 interrupt tests to use HALT and verify masks; add ON-key scenario
- Add pytest-timeout config and per-test marks for OCR heavy tests
- Fix web pause/reset deadlock by deferring joins outside lock

All test suites pass:
- FORCE_BINJA_MOCK=1 uv run pytest sc62015/pysc62015
- uv run pytest pce500/tests
- uv run pytest web/tests

]],