### PR TITLE
tests: add OFF-state interrupt scenarios (only ONKI works)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # Repository Guidelines
 
+> Tooling: This project standardizes on `uv` for Python package management and running commands. Use `uv sync` to install dependencies and `uv run` to execute all tools and scripts. Prefer `uv` over calling `python -m ...` or tool entry points directly.
+
 ## Project Structure & Module Organization
 - `sc62015/`: Binary Ninja integration (`arch.py`, `view.py`).
 - `sc62015/pysc62015/`: SC62015 assembler/emulator core and unit tests (`test_*.py`).
@@ -13,7 +15,7 @@
 - Install all deps at once: `uv sync --extra dev --extra pce500 --extra web`  # recommended
 - Alternative: `python -m pip install -e .[dev]` (extras: `.[pce500]`, `.[web]`)
 - Lint: `uv run ruff check .` (format: `uv run ruff format .`)
-- Type check: `uv run pyright sc62015/pysc62015` or `python scripts/run_pyright.py`
+- Type check: `uv run pyright sc62015/pysc62015` or `uv run python scripts/run_pyright.py`
 - Core tests: `FORCE_BINJA_MOCK=1 uv run pytest --cov=sc62015/pysc62015 --cov-report=term-missing`
 - PCE‑500 tests: `uv run pytest pce500/tests --cov=pce500 --cov-report=term-missing`
 - Web tests: `uv run pytest web/tests --cov=web --cov-report=term-missing`

--- a/pce500/tests/test_interrupts.py
+++ b/pce500/tests/test_interrupts.py
@@ -363,10 +363,11 @@ def test_interrupts(sc: InterruptScenario) -> None:
                     for _ in range(5):
                         emu.step()
                 else:
+                    # Exceed the longest timer period to be robust to off-by-one
                     mti = int(getattr(emu, "_timer_mti_period", 500))
                     sti = int(getattr(emu, "_timer_sti_period", 5000))
                     longest = max(mti, sti)
-                    for _ in range(int(longest)):
+                    for _ in range(int(longest + 200)):
                         emu.step()
             else:
                 for _ in range(24):

--- a/pce500/tests/test_interrupts.py
+++ b/pce500/tests/test_interrupts.py
@@ -393,4 +393,6 @@ def test_interrupts(sc: InterruptScenario) -> None:
         # In OFF, ensure PC did not advance beyond OFF if no delivery
         if sc.program is Program.OFF:
             pc_now = emu.cpu.regs.get(RegisterName.PC)
-            assert pc_now == (off_pc_after_off if off_pc_after_off is not None else PROGRAM.entry)
+            assert pc_now == (
+                off_pc_after_off if off_pc_after_off is not None else PROGRAM.entry
+            )


### PR DESCRIPTION
- Add Program.OFF and ENTRY_OFF entry template
- OFF behaves like HALT but timers are disabled
- Scenarios:
  * off_on_unmasked: ONKI wakes and delivers
  * off_mti_unmasked, off_sti_unmasked: timers do not deliver in OFF
- Keep single dataclass-driven test structure

All suites pass locally.
