### PR TITLE
pce500: remove unused memory_reads variable

### DIFF
--- a/pce500/tools/trace_memory.py
+++ b/pce500/tools/trace_memory.py
@@ -11,9 +11,6 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 from pce500 import PCE500Emulator
 from sc62015.pysc62015.emulator import RegisterName
 
-# Keep track of all memory reads
-memory_reads = []
-
 
 class MemoryTracer:
     def __init__(self, original_read):


### PR DESCRIPTION
## Summary
- remove unused memory_reads list from trace_memory tool

## Testing
- `uv run ruff check .`
- `uv run pyright sc62015/pysc62015`
- `FORCE_BINJA_MOCK=1 uv run pytest --cov=sc62015/pysc62015 --cov-report=term-missing`
- `uv run pytest pce500/tests --cov=pce500 --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68b828972c348331a89db7f1bb620f24