### PR TITLE
pce500: compare UUID using is None

### DIFF
--- a/pce500/tools/perfetto_trace_compare.py
+++ b/pce500/tools/perfetto_trace_compare.py
@@ -85,7 +85,7 @@ class PerfettoTraceComparator:
                 break
 
         # If not found by name, try to find by event content
-        if not execution_uuid:
+        if execution_uuid is None:
             # Sample events from each track to find Exec@ events
             track_samples = {}
             for packet in trace.packet:
@@ -107,7 +107,7 @@ class PerfettoTraceComparator:
                     )
                     break
 
-        if not execution_uuid:
+        if execution_uuid is None:
             raise ValueError("No 'Execution' thread or Exec@ events found in trace")
 
         # Extract events from the Execution thread


### PR DESCRIPTION
## Summary
- avoid treating track UUID 0 as missing when comparing Perfetto traces

## Testing
- `uv run ruff check .`
- `uv run pyright sc62015/pysc62015`
- `FORCE_BINJA_MOCK=1 uv run pytest --cov=sc62015/pysc62015 --cov-report=term-missing`
- `uv run pytest pce500/tests --cov=pce500 --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68b8293314048331add984e0248a3f19