### PR TITLE
tests: cover masked timer wake on halt

### DIFF
--- a/pce500/tests/test_interrupts.py
+++ b/pce500/tests/test_interrupts.py
@@ -209,7 +209,7 @@ SCENARIOS: list[InterruptScenario] = [
         expect_deliver=False,
         isolate_timers=True,
     ),
-    # HALT + timers (verify timers wake and deliver when masked in IMR)
+    # HALT + timers (verify timers wake CPU and deliver only when unmasked)
     InterruptScenario(
         "halt_mti_unmasked",
         Trigger.MTI,
@@ -221,11 +221,31 @@ SCENARIOS: list[InterruptScenario] = [
         timers_enabled=True,
     ),
     InterruptScenario(
+        "halt_mti_masked",
+        Trigger.MTI,
+        0x80,
+        Program.HALT,
+        expect_deliver=False,
+        expect_halt_canceled=True,
+        isolate_timers=True,
+        timers_enabled=True,
+    ),
+    InterruptScenario(
         "halt_sti_unmasked",
         Trigger.STI,
         0x80 | 0x02,
         Program.HALT,
         expect_deliver=True,
+        expect_halt_canceled=True,
+        isolate_timers=True,
+        timers_enabled=True,
+    ),
+    InterruptScenario(
+        "halt_sti_masked",
+        Trigger.STI,
+        0x80,
+        Program.HALT,
+        expect_deliver=False,
         expect_halt_canceled=True,
         isolate_timers=True,
         timers_enabled=True,


### PR DESCRIPTION
## Summary
- extend HALT timer scenarios to cover masked cases
- verify masked timers cancel HALT without delivering an interrupt

## Testing
- `uv run ruff check .`
- `uv run pyright sc62015/pysc62015`
- `uv run pytest pce500/tests/test_interrupts.py::test_interrupts -q`


------
https://chatgpt.com/codex/tasks/task_e_68b82e222e68833194552f0c3f13b5b2