### PR TITLE
pce500: expand interrupt tests

### DIFF
--- a/pce500/tests/test_interrupts.py
+++ b/pce500/tests/test_interrupts.py
@@ -49,6 +49,13 @@ TRIGGER_MASK = {
     Trigger.KEY_ON: 0x08,
 }
 
+EXPECTED_IRQ_SRC = {
+    Trigger.MTI: "MTI",
+    Trigger.STI: "STI",
+    Trigger.KEY_F1: "KEY",
+    Trigger.KEY_ON: "ONK",
+}
+
 
 @dataclass(frozen=True)
 class ProgramConfig:
@@ -142,6 +149,14 @@ SCENARIOS: list[InterruptScenario] = [
         "on_masked",
         Trigger.KEY_ON,
         0x80,
+        Program.HALT,
+        expect_deliver=False,
+        expect_halt_canceled=True,
+    ),
+    InterruptScenario(
+        "key_global_mask_off",
+        Trigger.KEY_F1,
+        0x04,  # KEYM set, global mask cleared
         Program.HALT,
         expect_deliver=False,
         expect_halt_canceled=True,
@@ -433,7 +448,8 @@ def test_interrupts(sc: InterruptScenario) -> None:
         mask = TRIGGER_MASK.get(sc.trigger, 0)
         assert (emu.memory.read_byte(u_after) & mask) == mask
         assert emu.memory.read_byte(u_after + 1) == PROGRAM.marker
-        assert emu.last_irq.get("src") is not None
+        expected_src = EXPECTED_IRQ_SRC.get(sc.trigger)
+        assert emu.last_irq.get("src") == expected_src
     else:
         assert emu.last_irq.get("src") in (None, "")
         # In OFF, ensure PC did not advance beyond OFF if no delivery
@@ -442,3 +458,12 @@ def test_interrupts(sc: InterruptScenario) -> None:
             assert pc_now == (
                 off_pc_after_off if off_pc_after_off is not None else PROGRAM.entry
             )
+
+    # Verify ISR state after execution
+    isr_final = emu.memory.read_byte(INTERNAL_MEMORY_START + IMEMRegisters.ISR)
+    expected_isr = 0
+    if sc.trigger in TRIGGER_MASK and not (
+        sc.program is Program.WAIT and (sc.wait_delta or 0) < 0
+    ):
+        expected_isr = TRIGGER_MASK[sc.trigger]
+    assert isr_final == expected_isr


### PR DESCRIPTION
## Summary
- expand interrupt coverage with global mask scenario
- assert expected interrupt source and ISR state after each scenario

## Testing
- `uv run ruff check pce500/tests/test_interrupts.py`
- `uv run pyright sc62015/pysc62015`
- `FORCE_BINJA_MOCK=1 uv run pytest pce500/tests --cov=pce500 --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68b82e222e68833194552f0c3f13b5b2