### PR TITLE
pce500: simplify reverse stack search

### DIFF
--- a/pce500/trace_manager.py
+++ b/pce500/trace_manager.py
@@ -251,8 +251,7 @@ class TraceManager:
                 return
 
             # Try to find matching frame
-            for i in range(len(stack) - 1, -1, -1):
-                frame = stack[i]
+            for i, frame in reversed(list(enumerate(stack))):
                 if frame.pc == pc and frame.event_sent:
                     # Remove this frame and all frames above it
                     while len(stack) > i:


### PR DESCRIPTION
## Summary
- simplify reverse call-stack search by iterating with reversed enumeration

## Testing
- `uv run ruff check .`
- `uv run python scripts/run_pyright.py`
- `uv run pytest pce500/tests --cov=pce500 --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68c131caf09483319504af593d06a5cc