### PR TITLE
Use Binary Ninja logging for type parsing errors

### DIFF
--- a/sc62015/view.py
+++ b/sc62015/view.py
@@ -5,6 +5,7 @@ from binaryninja.binaryview import BinaryView
 from binaryninja.architecture import Architecture
 from binaryninja.enums import SegmentFlag, SectionSemantics, SymbolType, Endianness
 from binaryninja.types import Symbol
+from binaryninja.log import log_warn
 
 # Import architecture-specific constants
 from .pysc62015.constants import (
@@ -134,7 +135,7 @@ class SC62015BaseView(BinaryView):
                     self.define_user_type(name, type_obj)
         except Exception as e:
             # Log error but don't fail initialization
-            print(f"Warning: Failed to define types: {e}")
+            log_warn(f"Failed to define types: {e}")
 
     def perform_get_address_size(self) -> int:
         return 3


### PR DESCRIPTION
## Summary
- Use Binary Ninja's log_warn instead of print in SC62015 BinaryView

## Testing
- `uv run ruff check .`
- `uv run pyright sc62015/pysc62015`
- `FORCE_BINJA_MOCK=1 uv run pytest --cov=sc62015/pysc62015 --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_68c209863af08331aec366dd3913659e