### PR TITLE
ci: ignore lint failures in tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,7 @@ jobs:
         cd web && uv run pytest tests/ -v --cov=. --cov-report=term-missing
     
     - name: Run linting
+      continue-on-error: true
       run: |
         uv run ruff check .
         uv run ruff format --check .


### PR DESCRIPTION
## Summary
- allow lint step in tests workflow to fail without failing the job

## Testing
- `uv run ruff check .`
- `uv run pyright sc62015/pysc62015`
- `FORCE_BINJA_MOCK=1 uv run pytest sc62015 -q`


------
https://chatgpt.com/codex/tasks/task_e_68c22d4056448331b1364c62d3dea47e