### PR TITLE
Fix timer scheduling after emulator reset

### DIFF
--- a/pce500/emulator.py
+++ b/pce500/emulator.py
@@ -225,6 +225,18 @@ class PCE500Emulator:
             self.trace.clear()
         self.instruction_history.clear()
         self.memory.clear_imem_access_tracking()
+        # Reset timer schedule and pending interrupt bookkeeping
+        try:
+            self._timer_next_mti = int(self._timer_mti_period)
+            self._timer_next_sti = int(self._timer_sti_period)
+        except AttributeError:
+            pass
+        try:
+            self._irq_pending = False
+            self._irq_source = None
+            self._in_interrupt = False
+        except AttributeError:
+            pass
         # Reset interrupt accounting
         try:
             self.irq_counts.update({"total": 0, "KEY": 0, "MTI": 0, "STI": 0})

--- a/pce500/tests/test_timer_reset.py
+++ b/pce500/tests/test_timer_reset.py
@@ -1,0 +1,24 @@
+"""Regression tests for timer state handling in the PC-E500 emulator."""
+
+from pce500 import PCE500Emulator
+
+
+def test_reset_reinitializes_timer_schedule() -> None:
+    """Reset should restore timer targets and clear stale IRQ state."""
+
+    emu = PCE500Emulator(perfetto_trace=False, save_lcd_on_exit=False)
+
+    # Advance cycle count beyond both timer thresholds and force a tick.
+    threshold = max(emu._timer_next_mti, emu._timer_next_sti)  # type: ignore[attr-defined]
+    emu.cycle_count = threshold + 123  # type: ignore[attr-defined]
+    emu._tick_timers()  # type: ignore[attr-defined]
+
+    assert emu._timer_next_mti > emu._timer_mti_period  # type: ignore[attr-defined]
+    assert emu._timer_next_sti > emu._timer_sti_period  # type: ignore[attr-defined]
+
+    emu.reset()
+
+    assert emu._timer_next_mti == emu._timer_mti_period  # type: ignore[attr-defined]
+    assert emu._timer_next_sti == emu._timer_sti_period  # type: ignore[attr-defined]
+    assert not emu._irq_pending  # type: ignore[attr-defined]
+    assert emu._irq_source is None  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
- reset the PC-E500 emulator's timer schedule and pending IRQ state when `reset()` is called so timers fire immediately after a reset
- add a regression test that reproduces the stale timer bug and verifies the reset behaviour

## Testing
- uv run pytest pce500/tests

------
https://chatgpt.com/codex/tasks/task_e_68c9e7f8accc8331810ab402489e16b2