### PR TITLE
pce500: deduplicate IMEM access tracking

### DIFF
--- a/pce500/memory.py
+++ b/pce500/memory.py
@@ -5,7 +5,7 @@ including memory overlays for ROM, RAM expansions, and memory-mapped I/O.
 """
 
 from dataclasses import dataclass
-from typing import Optional, List, Callable, Dict, Tuple
+from typing import Optional, List, Callable, Dict, Tuple, Literal
 
 from sc62015.pysc62015.instr.opcodes import IMEMRegisters
 
@@ -15,6 +15,11 @@ from .tracing.perfetto_tracing import perf_trace
 # Import constants for accessing internal memory registers
 # Define locally to avoid circular imports
 INTERNAL_MEMORY_START = 0x100000
+
+
+IMEM_OFFSET_TO_NAME: Dict[int, str] = {
+    reg.value: name for name, reg in IMEMRegisters.__members__.items()
+}
 
 
 @dataclass
@@ -83,6 +88,44 @@ class PCE500Memory:
         """
         self._imem_access_callback = callback
 
+    def _track_imem_access(
+        self,
+        offset: int,
+        access_type: Literal["read", "write"],
+        value: int,
+        effective_pc: Optional[int],
+    ) -> Optional[str]:
+        """Record IMEM register access counts and notify listeners."""
+
+        if effective_pc is None:
+            return None
+
+        reg_name = IMEM_OFFSET_TO_NAME.get(offset)
+        if reg_name is None:
+            return None
+
+        tracking = self.imem_access_tracking.setdefault(
+            reg_name, {"reads": [], "writes": []}
+        )
+        access_list = tracking["reads" if access_type == "read" else "writes"]
+
+        if access_list and access_list[-1][0] == effective_pc:
+            access_list[-1] = (effective_pc, access_list[-1][1] + 1)
+        else:
+            access_list.append((effective_pc, 1))
+            if len(access_list) > 10:
+                access_list.pop(0)
+
+        if self._imem_access_callback:
+            self._imem_access_callback(
+                effective_pc,
+                reg_name,
+                access_type,
+                value,
+            )
+
+        return reg_name
+
     @perf_trace("Memory", sample_rate=100)
     def read_byte(self, address: int, cpu_pc: Optional[int] = None) -> int:
         """Read a byte from memory.
@@ -124,32 +167,7 @@ class PCE500Memory:
                     effective_pc = (
                         cpu_pc if cpu_pc is not None else self._get_current_pc()
                     )
-                    if effective_pc is not None:
-                        for reg_name in IMEMRegisters.__members__:
-                            if IMEMRegisters[reg_name].value == offset:
-                                if reg_name not in self.imem_access_tracking:
-                                    self.imem_access_tracking[reg_name] = {
-                                        "reads": [],
-                                        "writes": [],
-                                    }
-                                reads_list = self.imem_access_tracking[reg_name][
-                                    "reads"
-                                ]
-                                if reads_list and reads_list[-1][0] == effective_pc:
-                                    reads_list[-1] = (
-                                        effective_pc,
-                                        reads_list[-1][1] + 1,
-                                    )
-                                else:
-                                    reads_list.append((effective_pc, 1))
-                                    if len(reads_list) > 10:
-                                        reads_list.pop(0)
-                                # Notify callback if set (for disasm trace)
-                                if self._imem_access_callback:
-                                    self._imem_access_callback(
-                                        effective_pc, reg_name, "read", value
-                                    )
-                                break
+                    self._track_imem_access(offset, "read", value, effective_pc)
                     return value
 
                 # Normal internal memory access (most common case)
@@ -159,31 +177,7 @@ class PCE500Memory:
                 # Track IMEMRegisters reads
                 # Get PC from CPU if not provided
                 effective_pc = cpu_pc if cpu_pc is not None else self._get_current_pc()
-                if effective_pc is not None:
-                    for reg_name in IMEMRegisters.__members__:
-                        if IMEMRegisters[reg_name].value == offset:
-                            if reg_name not in self.imem_access_tracking:
-                                self.imem_access_tracking[reg_name] = {
-                                    "reads": [],
-                                    "writes": [],
-                                }
-                            # Keep only last 10 accesses with counts
-                            reads_list = self.imem_access_tracking[reg_name]["reads"]
-                            if reads_list and reads_list[-1][0] == effective_pc:
-                                # Increment count for same PC
-                                reads_list[-1] = (effective_pc, reads_list[-1][1] + 1)
-                            else:
-                                # Add new PC with count 1
-                                reads_list.append((effective_pc, 1))
-                                if len(reads_list) > 10:
-                                    reads_list.pop(0)
-
-                            # Notify callback if set (for disasm trace)
-                            if self._imem_access_callback:
-                                self._imem_access_callback(
-                                    effective_pc, reg_name, "read", value
-                                )
-                            break
+                self._track_imem_access(offset, "read", value, effective_pc)
 
                 return value
             raise ValueError(
@@ -237,38 +231,7 @@ class PCE500Memory:
                         effective_pc = (
                             cpu_pc if cpu_pc is not None else self._get_current_pc()
                         )
-                        if effective_pc is not None:
-                            for reg_name in IMEMRegisters.__members__:
-                                if IMEMRegisters[reg_name].value == offset:
-                                    if reg_name not in self.imem_access_tracking:
-                                        self.imem_access_tracking[reg_name] = {
-                                            "reads": [],
-                                            "writes": [],
-                                        }
-                                    writes_list = self.imem_access_tracking[reg_name][
-                                        "writes"
-                                    ]
-                                    if (
-                                        writes_list
-                                        and writes_list[-1][0] == effective_pc
-                                    ):
-                                        writes_list[-1] = (
-                                            effective_pc,
-                                            writes_list[-1][1] + 1,
-                                        )
-                                    else:
-                                        writes_list.append((effective_pc, 1))
-                                        if len(writes_list) > 10:
-                                            writes_list.pop(0)
-                                    # Notify callback if set (for disasm trace)
-                                    if self._imem_access_callback:
-                                        self._imem_access_callback(
-                                            effective_pc,
-                                            reg_name,
-                                            "write",
-                                            value & 0xFF,
-                                        )
-                                    break
+                        self._track_imem_access(offset, "write", value, effective_pc)
                         # Add tracing for write_handler overlays
                         if self.perfetto_enabled:
                             trace_data = {
@@ -303,50 +266,26 @@ class PCE500Memory:
                 # Track IMEMRegisters writes
                 # Get PC from CPU if not provided
                 effective_pc = cpu_pc if cpu_pc is not None else self._get_current_pc()
-                if effective_pc is not None:
-                    for reg_name in IMEMRegisters.__members__:
-                        if IMEMRegisters[reg_name].value == offset:
-                            if reg_name not in self.imem_access_tracking:
-                                self.imem_access_tracking[reg_name] = {
-                                    "reads": [],
-                                    "writes": [],
-                                }
-                            # Keep only last 10 accesses with counts
-                            writes_list = self.imem_access_tracking[reg_name]["writes"]
-                            if writes_list and writes_list[-1][0] == effective_pc:
-                                # Increment count for same PC
-                                writes_list[-1] = (effective_pc, writes_list[-1][1] + 1)
-                            else:
-                                # Add new PC with count 1
-                                writes_list.append((effective_pc, 1))
-                                if len(writes_list) > 10:
-                                    writes_list.pop(0)
+                reg_name = self._track_imem_access(
+                    offset, "write", value, effective_pc
+                )
 
-                            # Interrupt bit watch for IMR/ISR
-                            if reg_name in ("IMR", "ISR"):
-                                try:
-                                    if (
-                                        self._emulator
-                                        and hasattr(
-                                            self._emulator, "_record_irq_bit_watch"
-                                        )
-                                        and effective_pc is not None
-                                    ):
-                                        self._emulator._record_irq_bit_watch(
-                                            reg_name,
-                                            prev_val & 0xFF,
-                                            value & 0xFF,
-                                            int(effective_pc),
-                                        )
-                                except Exception:
-                                    pass
-
-                            # Notify callback if set (for disasm trace)
-                            if self._imem_access_callback:
-                                self._imem_access_callback(
-                                    effective_pc, reg_name, "write", value
-                                )
-                            break
+                # Interrupt bit watch for IMR/ISR
+                if reg_name in ("IMR", "ISR"):
+                    try:
+                        if (
+                            self._emulator
+                            and hasattr(self._emulator, "_record_irq_bit_watch")
+                            and effective_pc is not None
+                        ):
+                            self._emulator._record_irq_bit_watch(
+                                reg_name,
+                                prev_val & 0xFF,
+                                value & 0xFF,
+                                int(effective_pc),
+                            )
+                    except Exception:
+                        pass
 
                 if self.perfetto_enabled:
                     # Get current BP value from internal memory if CPU is available
@@ -359,11 +298,7 @@ class PCE500Memory:
                             bp_value = "N/A"
 
                     # Check if this offset corresponds to a known internal memory register
-                    imem_name = "N/A"
-                    for reg_name in IMEMRegisters.__members__:
-                        if IMEMRegisters[reg_name].value == offset:
-                            imem_name = reg_name
-                            break
+                    imem_name = IMEM_OFFSET_TO_NAME.get(offset, "N/A")
 
                     g_tracer.trace_instant(
                         "Memory_Internal",


### PR DESCRIPTION
## Summary
- add a shared lookup for IMEM register offsets and reuse it across the memory subsystem
- consolidate IMEM register read/write tracking into a helper to remove duplicated logic

## Testing
- uv run ruff check .
- uv run pyright sc62015/pysc62015
- FORCE_BINJA_MOCK=1 uv run pytest --cov=sc62015/pysc62015 --cov-report=term-missing
- uv run pytest pce500/tests --cov=pce500 --cov-report=term-missing
- uv run pytest web/tests --cov=web --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68cb39bdbe7883319494968da1519422