### PR TITLE
Remove sys.path mutation from emulator imports

### DIFF
--- a/pce500/emulator.py
+++ b/pce500/emulator.py
@@ -1,6 +1,5 @@
 """Simplified PC-E500 emulator combining machine and emulator functionality."""
 
-import sys
 import time
 import os
 from pathlib import Path
@@ -10,7 +9,6 @@ from collections import deque
 from datetime import datetime
 
 # Import the SC62015 emulator
-sys.path.insert(0, str(Path(__file__).parent.parent))
 from sc62015.pysc62015.emulator import Emulator as SC62015Emulator, RegisterName
 from sc62015.pysc62015.instr.instructions import (
     CALL,


### PR DESCRIPTION
## Summary
- remove the manual sys.path mutation in `pce500.emulator`
- rely on standard package resolution and drop the unused `sys` import

## Testing
- uv run pytest pce500/tests/test_simplified_emulator.py::TestSimplifiedEmulator::test_reset_functionality -q

------
https://chatgpt.com/codex/tasks/task_e_68cc84ab7ac483318384d1af2945a025