### PR TITLE
Prevent debug keyboard queries from mutating debounce state

### DIFF
--- a/pce500/keyboard.py
+++ b/pce500/keyboard.py
@@ -61,5 +61,16 @@ class PCE500KeyboardHandler(_CompatHandler):
 
         return result & 0xFF
 
+    def peek_keyboard_input(self) -> int:  # type: ignore[override]
+        """Preview KIL without affecting debounce/queue state."""
+
+        result = 0x00
+
+        for queued_key in self.key_queue:
+            if queued_key.matches_output(self._last_kol, self._last_koh):
+                result |= (1 << queued_key.row) & 0xFF
+
+        return result & 0xFF
+
 
 __all__ = ["PCE500KeyboardHandler", "DEFAULT_DEBOUNCE_READS"]

--- a/web/app.py
+++ b/web/app.py
@@ -447,7 +447,7 @@ def get_key_queue():
         keyboard_state = {
             "kol": f"0x{emulator.keyboard._last_kol:02X}",
             "koh": f"0x{emulator.keyboard._last_koh:02X}",
-            "kil": f"0x{emulator.keyboard._read_keyboard_input():02X}",
+            "kil": f"0x{emulator.keyboard.peek_keyboard_input():02X}",
         }
 
         return jsonify({"queue": queue_info, "registers": keyboard_state})


### PR DESCRIPTION
## Summary
- add a `peek_keyboard_input` helper on the compat keyboard that reports the pending KIL value without touching debounce counters and store the last real read
- override the helper in the legacy keyboard shim to preserve its immediate row visibility semantics
- switch the debug API to the read-only helper so polling no longer alters queued key timing

## Testing
- uv run pytest pce500/tests
- uv run ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68cdd892a6208331a6f26328f3a6db34