### PR TITLE
Use shared IMEM base constant in web app

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -18,7 +18,7 @@ from flask import (
 )
 from flask_cors import CORS
 from sc62015.pysc62015.instr.opcodes import IMEMRegisters
-from sc62015.pysc62015.constants import IMRFlag
+from sc62015.pysc62015.constants import IMRFlag, INTERNAL_MEMORY_START
 from PIL import Image, ImageOps
 
 # Add parent directory to path for imports
@@ -189,7 +189,6 @@ def update_emulator_state():
     # Enrich interrupts with IMR/ISR flag info
     try:
         ints = emulator_state.get("interrupts") or {}
-        INTERNAL_MEMORY_START = 0x100000
         imr_val = (
             emulator.memory.read_byte(INTERNAL_MEMORY_START + IMEMRegisters.IMR) & 0xFF
         )

--- a/web/tests/test_keyboard_web_flow.py
+++ b/web/tests/test_keyboard_web_flow.py
@@ -15,7 +15,7 @@ from typing import Any
 import app as webapp
 from sc62015.pysc62015.emulator import RegisterName
 from sc62015.pysc62015.instr.opcodes import IMEMRegisters
-from sc62015.pysc62015.constants import IMRFlag
+from sc62015.pysc62015.constants import IMRFlag, INTERNAL_MEMORY_START
 
 
 def _get_json(client, path: str) -> dict[str, Any]:
@@ -48,7 +48,6 @@ def test_web_keyboard_triggers_key_interrupt() -> None:
     with webapp.emulator_lock:
         emu = webapp.emulator
         assert emu is not None
-        INTERNAL_MEMORY_START = 0x100000
         # Disable timers to avoid background IRQs in this test
         try:
             setattr(emu, "_timer_enabled", False)
@@ -92,7 +91,6 @@ def test_web_keyboard_triggers_key_interrupt() -> None:
     with webapp.emulator_lock:
         emu = webapp.emulator
         assert emu is not None
-        INTERNAL_MEMORY_START = 0x100000
         emu.memory.write_byte(
             INTERNAL_MEMORY_START + IMEMRegisters.IMR,
             int(IMRFlag.IRM | IMRFlag.KEYM),


### PR DESCRIPTION
## Summary
- reuse the shared INTERNAL_MEMORY_START constant when enriching web emulator state to avoid magic numbers
- update the web keyboard integration test to use the shared constant instead of redefining it locally

## Testing
- uv run pytest web/tests/test_keyboard_web_flow.py
- uv run ruff check web/app.py web/tests/test_keyboard_web_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68cfc1fd53c8833186ade4eab1f6630b