### PR TITLE
Fix LCD controller low window overlay

### DIFF
--- a/pce500/memory.py
+++ b/pce500/memory.py
@@ -521,7 +521,18 @@ class PCE500Memory:
         # Pass CPU reference to LCD controller if available
         if self.cpu and hasattr(lcd_controller, "set_cpu"):
             lcd_controller.set_cpu(self.cpu)
-        # LCD controllers at 0xA000-0xAFFF
+        # LCD controllers at 0x2000 and 0xA000
+        self.add_overlay(
+            MemoryOverlay(
+                start=0x2000,
+                end=0x200F,
+                name="lcd_controller_low",
+                read_only=False,
+                read_handler=lambda addr, pc: lcd_controller.read(addr, pc),
+                write_handler=lambda addr, val, pc: lcd_controller.write(addr, val, pc),
+                perfetto_thread="Display",
+            )
+        )
         self.add_overlay(
             MemoryOverlay(
                 start=0xA000,

--- a/pce500/tests/test_simplified_emulator.py
+++ b/pce500/tests/test_simplified_emulator.py
@@ -159,6 +159,7 @@ class TestSimplifiedEmulator:
         # Updated format from new memory implementation
         assert "internal_rom: 0xC0000-0xFFFFF (262144 bytes, R/O)" in info
         assert "Base: 1MB external memory (0x00000-0xFFFFF)" in info
+        assert "lcd_controller_low: 0x02000-0x0200F (16 bytes, R/W)" in info
         assert "lcd_controller: 0x0A000-0x0AFFF (4096 bytes, R/W)" in info
 
     def test_performance_stats(self):


### PR DESCRIPTION
## Summary
- add an overlay for the 0x2000 LCD window so emulator matches the hardware map
- update the memory info test to assert the new overlay is reported

## Testing
- uv run pytest pce500/tests/test_simplified_emulator.py
