### PR TITLE
Modularize memory bus and overlay manager

### DIFF
--- a/pce500/memory_bus.py
+++ b/pce500/memory_bus.py
@@ -1,0 +1,181 @@
+"""Overlay-aware memory bus for the PC-E500 emulator."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Deque, Iterable, List, Literal, Optional, Tuple
+from collections import deque
+
+ReadHandler = Callable[[int, Optional[int]], int]
+WriteHandler = Callable[[int, int, Optional[int]], None]
+
+
+@dataclass
+class MemoryOverlay:
+    """Descriptor for a memory-mapped overlay."""
+
+    start: int
+    end: int
+    name: str
+    data: Optional[bytearray] = None
+    read_only: bool = True
+    read_handler: Optional[ReadHandler] = None
+    write_handler: Optional[WriteHandler] = None
+    perfetto_thread: str = "Memory"
+
+    def contains(self, address: int) -> bool:
+        return self.start <= address <= self.end
+
+
+@dataclass
+class MemoryAccessLog:
+    kind: Literal["read", "write"]
+    address: int
+    value: int
+    overlay: str
+    pc: Optional[int]
+    previous: Optional[int] = None
+
+
+@dataclass
+class ReadResult:
+    value: int
+    overlay: MemoryOverlay
+
+
+@dataclass
+class WriteResult:
+    overlay: MemoryOverlay
+    value: int
+    previous: Optional[int]
+
+
+class MemoryBus:
+    """Overlay resolver with lightweight access logging."""
+
+    def __init__(self, *, log_limit: int = 256) -> None:
+        self._overlays: List[MemoryOverlay] = []
+        self._read_log: Deque[MemoryAccessLog] = deque(maxlen=log_limit)
+        self._write_log: Deque[MemoryAccessLog] = deque(maxlen=log_limit)
+
+    def add_overlay(self, overlay: MemoryOverlay) -> None:
+        self._overlays.append(overlay)
+        self._overlays.sort(key=lambda ov: (ov.start, ov.end, ov.name))
+
+    def remove_overlay(self, name: str) -> None:
+        self._overlays = [ov for ov in self._overlays if ov.name != name]
+
+    def iter_overlays(self) -> Iterable[MemoryOverlay]:
+        return tuple(self._overlays)
+
+    def overlay_count(self) -> int:
+        return len(self._overlays)
+
+    def read_log(self) -> Tuple[MemoryAccessLog, ...]:
+        return tuple(self._read_log)
+
+    def write_log(self) -> Tuple[MemoryAccessLog, ...]:
+        return tuple(self._write_log)
+
+    def clear_logs(self) -> None:
+        self._read_log.clear()
+        self._write_log.clear()
+
+    def read(self, address: int, cpu_pc: Optional[int] = None) -> Optional[ReadResult]:
+        for overlay in self._overlays:
+            if not overlay.contains(address):
+                continue
+
+            value = self._read_from_overlay(overlay, address, cpu_pc)
+            if value is None:
+                continue
+
+            value &= 0xFF
+            self._read_log.append(
+                MemoryAccessLog(
+                    kind="read",
+                    address=address,
+                    value=value,
+                    overlay=overlay.name,
+                    pc=cpu_pc,
+                )
+            )
+            return ReadResult(value=value, overlay=overlay)
+
+        return None
+
+    def write(
+        self,
+        address: int,
+        value: int,
+        cpu_pc: Optional[int] = None,
+    ) -> Optional[WriteResult]:
+        value &= 0xFF
+
+        for overlay in self._overlays:
+            if not overlay.contains(address):
+                continue
+
+            handled, previous = self._write_to_overlay(overlay, address, value, cpu_pc)
+            if not handled:
+                continue
+
+            self._write_log.append(
+                MemoryAccessLog(
+                    kind="write",
+                    address=address,
+                    value=value,
+                    overlay=overlay.name,
+                    pc=cpu_pc,
+                    previous=previous,
+                )
+            )
+            return WriteResult(overlay=overlay, value=value, previous=previous)
+
+        return None
+
+    @staticmethod
+    def _read_from_overlay(
+        overlay: MemoryOverlay, address: int, cpu_pc: Optional[int]
+    ) -> Optional[int]:
+        if overlay.read_handler is not None:
+            return overlay.read_handler(address, cpu_pc) & 0xFF
+
+        if overlay.data is not None:
+            offset = address - overlay.start
+            if 0 <= offset < len(overlay.data):
+                return overlay.data[offset]
+
+        return None
+
+    @staticmethod
+    def _write_to_overlay(
+        overlay: MemoryOverlay,
+        address: int,
+        value: int,
+        cpu_pc: Optional[int],
+    ) -> Tuple[bool, Optional[int]]:
+        if overlay.write_handler is not None:
+            overlay.write_handler(address, value, cpu_pc)
+            return True, None
+
+        if overlay.data is not None and not overlay.read_only:
+            offset = address - overlay.start
+            if 0 <= offset < len(overlay.data):
+                previous = overlay.data[offset]
+                overlay.data[offset] = value
+                return True, previous
+
+        if overlay.read_only:
+            return True, None
+
+        return False, None
+
+
+__all__ = [
+    "MemoryBus",
+    "MemoryOverlay",
+    "MemoryAccessLog",
+    "ReadResult",
+    "WriteResult",
+]

--- a/pce500/tests/test_memory_bus.py
+++ b/pce500/tests/test_memory_bus.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from pce500.memory_bus import MemoryBus, MemoryOverlay
+
+
+def test_memory_bus_reads_data_overlay() -> None:
+    bus = MemoryBus()
+    data = bytearray([0xAA, 0xBB])
+    bus.add_overlay(
+        MemoryOverlay(start=0x2000, end=0x2001, name="rom", data=data, read_only=True)
+    )
+
+    result = bus.read(0x2000)
+
+    assert result is not None
+    assert result.value == 0xAA
+    assert result.overlay.name == "rom"
+    log = bus.read_log()
+    assert len(log) == 1 and log[0].value == 0xAA
+
+
+def test_memory_bus_write_mutable_overlay_updates_data() -> None:
+    bus = MemoryBus()
+    data = bytearray([0x10])
+    bus.add_overlay(
+        MemoryOverlay(
+            start=0x4000,
+            end=0x4000,
+            name="ram",
+            data=data,
+            read_only=False,
+        )
+    )
+
+    write_result = bus.write(0x4000, 0x5A)
+
+    assert write_result is not None
+    assert data[0] == 0x5A
+    write_log = bus.write_log()
+    assert len(write_log) == 1
+    assert write_log[0].value == 0x5A
+    assert write_log[0].previous == 0x10
+
+
+def test_memory_bus_invokes_read_handler() -> None:
+    captured: list[int] = []
+
+    def handler(address: int, pc: int | None) -> int:
+        captured.append(address)
+        assert pc == 0x123456
+        return 0x42
+
+    bus = MemoryBus()
+    bus.add_overlay(
+        MemoryOverlay(
+            start=0x6000,
+            end=0x6000,
+            name="handler",
+            read_handler=handler,
+        )
+    )
+
+    result = bus.read(0x6000, cpu_pc=0x123456)
+
+    assert captured == [0x6000]
+    assert result is not None and result.value == 0x42
+
+
+def test_memory_bus_write_handler_invoked_for_overlay() -> None:
+    writes: list[tuple[int, int, int | None]] = []
+
+    def handler(address: int, value: int, pc: int | None) -> None:
+        writes.append((address, value, pc))
+
+    bus = MemoryBus()
+    bus.add_overlay(
+        MemoryOverlay(
+            start=0x7000,
+            end=0x7000,
+            name="io",
+            write_handler=handler,
+            read_only=False,
+        )
+    )
+
+    result = bus.write(0x7000, 0x3C, cpu_pc=0x777)
+
+    assert result is not None
+    assert writes == [(0x7000, 0x3C, 0x777)]


### PR DESCRIPTION
## Summary
- introduce `MemoryBus` with overlay descriptors, deterministic read/write resolution, and access logs
- refactor `PCE500Memory` to delegate overlay handling to the new bus while keeping IMEM tracking intact
- add unit tests covering overlay reads, writes, and handler invocation via snapshot-friendly fixtures

## Testing
- uv run pytest pce500/tests/test_memory_bus.py
- uv run ruff check pce500/memory_bus.py pce500/tests/test_memory_bus.py pce500/memory.py

Closes #75
