### PR TITLE
Extract deterministic timer scheduler

### DIFF
--- a/pce500/memory.py
+++ b/pce500/memory.py
@@ -1,7 +1,7 @@
 """PC-E500 memory system implementation with overlay bus integration."""
 
 from collections import deque
-from typing import Optional, Callable, Dict, Tuple, Literal, Deque
+from typing import Optional, Callable, Dict, Tuple, Literal, Deque, Any
 
 from sc62015.pysc62015.instr.opcodes import IMEMRegisters
 
@@ -34,6 +34,7 @@ class PCE500Memory:
 
         # Track keyboard overlay for optimization
         self._keyboard_overlay: Optional[MemoryOverlay] = None
+        self._emulator: Optional[Any] = None
 
         # Perfetto tracing
         self.perfetto_enabled = False

--- a/pce500/scheduler.py
+++ b/pce500/scheduler.py
@@ -1,0 +1,74 @@
+"""Timer and interrupt scheduler for the PC-E500 emulator."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import Iterable, List
+
+
+class TimerSource(Enum):
+    """Supported hardware timer sources."""
+
+    MTI = auto()
+    STI = auto()
+
+
+@dataclass
+class TimerScheduler:
+    """Deterministic timer scheduler used by the emulator."""
+
+    mti_period: int
+    sti_period: int
+    enabled: bool = True
+
+    def __post_init__(self) -> None:
+        self.mti_period = int(self.mti_period)
+        self.sti_period = int(self.sti_period)
+        self._next_mti = self.mti_period
+        self._next_sti = self.sti_period
+
+    def reset(self, *, cycle_base: int = 0) -> None:
+        """Reset timer state to default offsets."""
+
+        self._next_mti = cycle_base + self.mti_period
+        self._next_sti = cycle_base + self.sti_period
+
+    def advance(self, cycle_count: int) -> Iterable[TimerSource]:
+        """Advance timers to ``cycle_count`` and yield fired sources."""
+
+        if not self.enabled:
+            return []
+
+        fired: List[TimerSource] = []
+
+        if cycle_count >= self._next_mti and self.mti_period > 0:
+            while cycle_count >= self._next_mti:
+                self._next_mti += self.mti_period
+            fired.append(TimerSource.MTI)
+
+        if cycle_count >= self._next_sti and self.sti_period > 0:
+            while cycle_count >= self._next_sti:
+                self._next_sti += self.sti_period
+            fired.append(TimerSource.STI)
+
+        return fired
+
+    @property
+    def next_mti(self) -> int:
+        return self._next_mti
+
+    @next_mti.setter
+    def next_mti(self, value: int) -> None:
+        self._next_mti = int(value)
+
+    @property
+    def next_sti(self) -> int:
+        return self._next_sti
+
+    @next_sti.setter
+    def next_sti(self, value: int) -> None:
+        self._next_sti = int(value)
+
+
+__all__ = ["TimerScheduler", "TimerSource"]

--- a/pce500/tests/test_scheduler.py
+++ b/pce500/tests/test_scheduler.py
@@ -1,0 +1,24 @@
+from pce500.scheduler import TimerScheduler, TimerSource
+
+
+def test_scheduler_fires_mti_and_sti() -> None:
+    sched = TimerScheduler(mti_period=5, sti_period=8)
+
+    assert list(sched.advance(0)) == []
+    assert list(sched.advance(5)) == [TimerSource.MTI]
+
+    fired = list(sched.advance(8))
+    assert TimerSource.STI in fired
+
+
+def test_scheduler_respects_enable_flag() -> None:
+    sched = TimerScheduler(mti_period=3, sti_period=7)
+    sched.enabled = False
+    assert list(sched.advance(10)) == []
+
+
+def test_scheduler_reset_uses_cycle_base() -> None:
+    sched = TimerScheduler(mti_period=4, sti_period=6)
+    sched.next_mti = 100
+    sched.reset(cycle_base=10)
+    assert sched.next_mti == 14


### PR DESCRIPTION
## Summary
- add `TimerScheduler` and `TimerSource` modules to encapsulate timer periods, next-fire cycles, and enable flags
- refactor `PCE500Emulator` to delegate timer state and `_tick_timers` logic to the scheduler while preserving legacy attribute access
- add unit coverage for scheduler advance, enable toggling, and reset behaviour

## Testing
- uv run pytest pce500/tests/test_scheduler.py
- uv run pytest pce500/tests/test_interrupts.py
- uv run pytest

Closes #76
