### PR TITLE
Add ROM-backed LCD text decoder

### DIFF
--- a/pce500/display/__init__.py
+++ b/pce500/display/__init__.py
@@ -18,6 +18,7 @@ from .controller_wrapper import HD61202Controller
 
 # Import visualization functionality
 from .lcd_visualization import generate_lcd_image_from_trace
+from .text_decoder import decode_display_text
 
 __all__ = [
     # Controller for emulator
@@ -38,4 +39,6 @@ __all__ = [
     "render_combined_image",
     # Visualization
     "generate_lcd_image_from_trace",
+    # Text decoding
+    "decode_display_text",
 ]

--- a/pce500/display/test_controller_wrapper.py
+++ b/pce500/display/test_controller_wrapper.py
@@ -71,14 +71,19 @@ class TestHD61202Controller:
         controller.chips[0].state.on = True
         controller.chips[1].state.on = True
 
-        # Write test pattern
-        controller.chips[0].vram[0][0] = 0x01  # First pixel (bit 0 set)
-        controller.chips[1].vram[0][0] = 0x01  # First pixel of right chip (bit 0 set)
+        # Write test pattern touching each display segment.
+        controller.chips[1].vram[0][0] = 0x01  # Right chip, top half -> column 0
+        controller.chips[0].vram[0][0] = 0x01  # Left chip, top half -> column 64
+        controller.chips[0].vram[4][55] = 0x01  # Left chip, bottom half -> column 120
+        controller.chips[1].vram[4][0] = 0x01  # Right chip, bottom half -> column 239
 
         buffer = controller.get_display_buffer()
         assert buffer.shape == (32, 240)
-        assert buffer[0, 0] == 0  # Left chip pixel (inverted - bit set means black)
-        assert buffer[0, 120] == 0  # Right chip pixel (inverted - bit set means black)
+        # Bit set in VRAM corresponds to a dark pixel (value 0) in the buffer.
+        assert buffer[0, 0] == 0
+        assert buffer[0, 64] == 0
+        assert buffer[0, 120] == 0
+        assert buffer[0, 239] == 0
 
     def test_get_combined_display(self):
         """Test combined display image generation."""

--- a/pce500/display/test_text_decoder.py
+++ b/pce500/display/test_text_decoder.py
@@ -1,0 +1,40 @@
+"""Tests for the LCD text decoder."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pce500 import PCE500Emulator
+from pce500.display.text_decoder import decode_display_text
+
+
+def _load_rom() -> bytes:
+    rom_path = Path(__file__).resolve().parent.parent.parent / "data" / "pc-e500.bin"
+    if not rom_path.exists():
+        pytest.skip(f"ROM image missing at {rom_path}")
+    data = rom_path.read_bytes()
+    if len(data) != 0x100000:
+        pytest.skip(f"Expected 1MB pc-e500.bin at {rom_path}")
+    return data
+
+
+def test_boot_screen_text_decodes() -> None:
+    """Ensure the decoder reproduces the familiar boot menu."""
+
+    rom_image = _load_rom()
+    emu = PCE500Emulator(
+        save_lcd_on_exit=False, perfetto_trace=False, trace_enabled=False
+    )
+    emu.load_rom(rom_image[0xC0000:0x100000], start_address=0xC0000)
+    emu.reset()
+    emu.run(20_000)
+
+    lines = decode_display_text(emu.lcd, emu.memory)
+
+    # Boot banner should match the ROM string resources.
+    assert lines[0] == "S2(CARD):NEW CARD"
+    assert lines[1] == ""
+    assert lines[2].startswith("   PF1 --- INITIALIZE")
+    assert lines[3].startswith("   PF2 --- DO NOT INITIALIZE")

--- a/pce500/display/text_decoder.py
+++ b/pce500/display/text_decoder.py
@@ -1,0 +1,72 @@
+"""Utilities to decode LCD controller VRAM into ASCII text."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+FONT_BASE = 0x00F2215
+GLYPH_WIDTH = 5
+GLYPH_STRIDE = 6
+GLYPH_COUNT = 96  # ASCII 0x20-0x7F
+CHAR_COLUMNS = 40
+CHAR_ROWS = 4
+PIXELS_PER_CHAR_COL = 6  # 5 glyph columns + 1 spacer
+CHAR_HEIGHT = 7
+
+
+def _read_glyph_columns(memory) -> Dict[Tuple[int, ...], str]:
+    lookup: Dict[Tuple[int, ...], str] = {}
+    for index in range(GLYPH_COUNT):
+        code = 0x20 + index
+        offset = FONT_BASE + index * GLYPH_STRIDE
+        columns = [memory.read_byte(offset + i) & 0x7F for i in range(GLYPH_WIDTH)]
+        lookup[tuple(columns)] = chr(code)
+    return lookup
+
+
+def _font_lookup(memory) -> Dict[Tuple[int, ...], str]:
+    # Avoid caching complexities; reading 96 glyphs is cheap
+    return _read_glyph_columns(memory)
+
+
+def decode_display_text(controller, memory) -> List[str]:
+    """Decode the current LCD VRAM into textual rows."""
+
+    lookup = _font_lookup(memory)
+    buffer = controller.get_display_buffer()
+    if buffer is None:
+        return []
+
+    height, width = buffer.shape
+    lines: List[str] = []
+
+    for page in range(CHAR_ROWS):
+        row_chars: List[str] = []
+        row_base = page * 8
+        if row_base + CHAR_HEIGHT > height:
+            break
+
+        for char_index in range(CHAR_COLUMNS):
+            col_base = char_index * PIXELS_PER_CHAR_COL
+            if col_base + GLYPH_WIDTH > width:
+                row_chars.append(" ")
+                continue
+
+            columns: List[int] = []
+            for glyph_col in range(GLYPH_WIDTH):
+                bits = 0
+                col = col_base + glyph_col
+                for row in range(CHAR_HEIGHT):
+                    if not buffer[row_base + row, col]:
+                        bits |= 1 << row
+                columns.append(bits & 0x7F)
+
+            glyph = tuple(columns)
+            row_chars.append(lookup.get(glyph, "?"))
+
+        lines.append("".join(row_chars).rstrip())
+
+    return lines
+
+
+__all__ = ["decode_display_text"]


### PR DESCRIPTION
## Summary
- add an LCD text decoder that reads the ROM font and combined controller buffer
- align the controller wrapper display buffer with the real panel wiring and export decoded text from run_pce500
- add regression coverage for the decoder and refresh existing display buffer tests

## Testing
- uv run python -m pytest pce500/display