### PR TITLE
Add snapshot pipeline for LCD tracing

### DIFF
--- a/pce500/display/__init__.py
+++ b/pce500/display/__init__.py
@@ -15,6 +15,14 @@ from .hd61202 import (
 
 # Import the controller wrapper for emulator compatibility
 from .controller_wrapper import HD61202Controller
+from .font import glyph_bitmap, glyph_columns, text_columns
+from .pipeline import (
+    LCDChipSnapshot,
+    LCDOperation,
+    LCDPipeline,
+    LCDSnapshot,
+    replay_operations,
+)
 
 # Import visualization functionality
 from .lcd_visualization import generate_lcd_image_from_trace
@@ -37,6 +45,14 @@ __all__ = [
     # Helper functions
     "parse_command",
     "render_combined_image",
+    "glyph_columns",
+    "glyph_bitmap",
+    "text_columns",
+    "LCDPipeline",
+    "LCDSnapshot",
+    "LCDChipSnapshot",
+    "LCDOperation",
+    "replay_operations",
     # Visualization
     "generate_lcd_image_from_trace",
     # Text decoding

--- a/pce500/display/font.py
+++ b/pce500/display/font.py
@@ -1,0 +1,67 @@
+"""Shared helpers for working with the PC-E500 ROM font."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Dict, List, Tuple
+
+FONT_BASE = 0x00F2215
+GLYPH_WIDTH = 5
+GLYPH_STRIDE = 6  # five data columns + spacer
+GLYPH_COUNT = 96  # ASCII 0x20-0x7F
+GLYPH_HEIGHT = 7
+
+
+def _read_glyph_columns(memory, index: int) -> Tuple[int, ...]:
+    """Return the raw column bytes for a glyph index."""
+    if not (0 <= index < GLYPH_COUNT):
+        raise ValueError(f"Glyph index out of range: {index}")
+
+    offset = FONT_BASE + index * GLYPH_STRIDE
+    return tuple(memory.read_byte(offset + i) & 0x7F for i in range(GLYPH_WIDTH))
+
+
+def _font_lookup(memory) -> Dict[str, Tuple[int, ...]]:
+    """Build (and cache) the mapping from ASCII characters to column tuples."""
+    key = id(memory)
+
+    @lru_cache(maxsize=8)
+    def _build(_: int) -> Dict[str, Tuple[int, ...]]:
+        mapping: Dict[str, Tuple[int, ...]] = {}
+        for index in range(GLYPH_COUNT):
+            char_code = 0x20 + index
+            mapping[chr(char_code)] = _read_glyph_columns(memory, index)
+        return mapping
+
+    return _build(key)
+
+
+def glyph_columns(memory, char: str) -> Tuple[int, ...]:
+    """Return the ROM column data for a single ASCII character."""
+    if not char:
+        raise ValueError("Character must be non-empty")
+    lookup = _font_lookup(memory)
+    if char not in lookup:
+        raise KeyError(f"Character {char!r} is not available in the ROM font")
+    return lookup[char]
+
+
+def text_columns(memory, text: str) -> List[int]:
+    """Return the concatenated column bytes (including spacers) for text."""
+    columns: List[int] = []
+    for char in text:
+        glyph = glyph_columns(memory, char)
+        columns.extend(glyph)
+        columns.append(0)  # Implicit spacer column between glyphs
+    return columns
+
+
+def glyph_bitmap(memory, char: str) -> List[List[int]]:
+    """Decode the ROM glyph into a 2D bitmap (0 = pixel on, 1 = pixel off)."""
+    columns = glyph_columns(memory, char)
+    bitmap: List[List[int]] = [[1] * GLYPH_WIDTH for _ in range(GLYPH_HEIGHT)]
+    for col_idx, column in enumerate(columns):
+        for row in range(GLYPH_HEIGHT):
+            if (column >> row) & 1:
+                bitmap[row][col_idx] = 0
+    return bitmap

--- a/pce500/display/pipeline.py
+++ b/pce500/display/pipeline.py
@@ -1,0 +1,171 @@
+"""Event-driven LCD pipeline with snapshot support."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from .hd61202 import ChipSelect, Command, HD61202, parse_command
+
+Observer = Callable[[Dict[str, object], "LCDSnapshot"], None]
+
+
+@dataclass(frozen=True)
+class LCDChipSnapshot:
+    """Immutable representation of a single HD61202 chip."""
+
+    on: bool
+    start_line: int
+    page: int
+    y_address: int
+    vram: Tuple[Tuple[int, ...], ...]
+    instruction_count: int
+    data_write_count: int
+
+
+@dataclass(frozen=True)
+class LCDSnapshot:
+    """Snapshot of the full PC-E500 display (two chips)."""
+
+    chips: Tuple[LCDChipSnapshot, ...]
+
+
+@dataclass(frozen=True)
+class LCDOperation:
+    """One parsed LCD command coupled with optional metadata."""
+
+    command: Command
+    pc: Optional[int] = None
+
+
+def _chip_indices(cs: ChipSelect) -> Sequence[int]:
+    if cs == ChipSelect.BOTH:
+        return (0, 1)
+    if cs == ChipSelect.RIGHT:
+        return (1,)
+    if cs == ChipSelect.LEFT:
+        return (0,)
+    return ()
+
+
+def _snapshot_from_chips(chips: Sequence[HD61202]) -> LCDSnapshot:
+    capture = []
+    for chip in chips:
+        capture.append(
+            LCDChipSnapshot(
+                on=chip.state.on,
+                start_line=chip.state.start_line,
+                page=chip.state.page,
+                y_address=chip.state.y_address,
+                vram=tuple(tuple(row) for row in chip.vram),
+                instruction_count=chip.instruction_count,
+                data_write_count=chip.data_write_count,
+            )
+        )
+    return LCDSnapshot(tuple(capture))
+
+
+class LCDPipeline:
+    """Replay LCD commands, emit events, and expose VRAM snapshots."""
+
+    def __init__(self, chips: Optional[Sequence[HD61202]] = None):
+        self._chips: List[HD61202] = (
+            list(chips)
+            if chips is not None
+            else [
+                HD61202(),
+                HD61202(),
+            ]
+        )
+        self._observers: List[Observer] = []
+
+    @property
+    def chips(self) -> List[HD61202]:
+        return self._chips
+
+    @property
+    def snapshot(self) -> LCDSnapshot:
+        return _snapshot_from_chips(self._chips)
+
+    def subscribe(self, observer: Observer) -> None:
+        self._observers.append(observer)
+
+    def apply(self, operation: LCDOperation) -> List[Dict[str, object]]:
+        return self._apply_command(operation.command, operation.pc)
+
+    def apply_raw(
+        self, address: int, value: int, pc: Optional[int] = None
+    ) -> List[Dict[str, object]]:
+        command = parse_command(address, value)
+        return self._apply_command(command, pc)
+
+    def replay(self, operations: Iterable[LCDOperation]) -> LCDSnapshot:
+        for operation in operations:
+            self.apply(operation)
+        return self.snapshot
+
+    def _dispatch(self, events: List[Dict[str, object]]) -> None:
+        if not events or not self._observers:
+            return
+        snap = self.snapshot
+        for event in events:
+            for observer in self._observers:
+                observer(dict(event), snap)
+
+    def _apply_command(
+        self, command: Command, pc: Optional[int]
+    ) -> List[Dict[str, object]]:
+        events: List[Dict[str, object]] = []
+        for chip_idx in _chip_indices(command.cs):
+            chip = self._chips[chip_idx]
+            if command.instr is not None:
+                column_snapshot = chip.state.y_address
+                chip.write_instruction(command.instr, command.data)
+                events.append(
+                    {
+                        "type": "instruction",
+                        "chip": chip_idx,
+                        "instruction": command.instr.name,
+                        "instruction_name": command.instr.name.lower(),
+                        "instruction_code": command.instr.value,
+                        "data": command.data,
+                        "page": chip.state.page,
+                        "column": column_snapshot,
+                        "pc": pc,
+                    }
+                )
+            else:
+                column_raw = chip.state.y_address & 0xFF
+                page_before = chip.state.page
+                chip.write_data(command.data, pc_source=pc)
+                column_written = column_raw % chip.LCD_WIDTH_PIXELS
+                next_column = chip.state.y_address & 0xFF
+                events.append(
+                    {
+                        "type": "data",
+                        "chip": chip_idx,
+                        "page": page_before,
+                        "column": column_written,
+                        "column_raw": column_raw,
+                        "column_next": next_column,
+                        "data": command.data,
+                        "pc": pc,
+                    }
+                )
+        self._dispatch(events)
+        return events
+
+
+def replay_operations(
+    operations: Iterable[LCDOperation],
+) -> Tuple[LCDSnapshot, List[Dict[str, object]]]:
+    """Convenience wrapper for test code."""
+    pipeline = LCDPipeline()
+    emitted: List[Dict[str, object]] = []
+
+    def _collect(event: Dict[str, object], _snapshot: LCDSnapshot) -> None:
+        emitted.append(event)
+
+    pipeline.subscribe(_collect)
+    pipeline.replay(operations)
+    return pipeline.snapshot, emitted

--- a/pce500/display/test_font_helpers.py
+++ b/pce500/display/test_font_helpers.py
@@ -1,0 +1,73 @@
+"""Tests for the ROM font helper utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import pytest
+
+from pce500.display.font import (
+    FONT_BASE,
+    GLYPH_HEIGHT,
+    GLYPH_STRIDE,
+    GLYPH_WIDTH,
+    glyph_bitmap,
+    glyph_columns,
+    text_columns,
+)
+
+
+class _RomMemory:
+    def __init__(self, data: bytes):
+        self._data = data
+
+    def read_byte(self, address: int) -> int:
+        return self._data[address]
+
+
+def _load_rom() -> bytes:
+    rom_path = Path(__file__).resolve().parent.parent.parent / "data" / "pc-e500.bin"
+    if not rom_path.exists():
+        pytest.skip(f"ROM image missing at {rom_path}")
+    data = rom_path.read_bytes()
+    if len(data) != 0x100000:
+        pytest.skip("Expected 1MB pc-e500.bin ROM image")
+    return data
+
+
+def test_glyph_columns_match_rom_bytes():
+    rom = _load_rom()
+    memory = _RomMemory(rom)
+
+    for char in "A9? ":
+        columns = glyph_columns(memory, char)
+        index = ord(char) - 0x20
+        expected = tuple(
+            rom[FONT_BASE + index * GLYPH_STRIDE + i] & 0x7F for i in range(GLYPH_WIDTH)
+        )
+        assert columns == expected
+
+
+def test_glyph_bitmap_dimensions_and_bits():
+    rom = _load_rom()
+    memory = _RomMemory(rom)
+    bitmap = glyph_bitmap(memory, "S")
+
+    assert len(bitmap) == GLYPH_HEIGHT
+    assert all(len(row) == GLYPH_WIDTH for row in bitmap)
+    # At least one dark pixel should be present.
+    assert sum(pixel == 0 for row in bitmap for pixel in row) > 0
+
+
+def test_text_columns_appends_spacers():
+    rom = _load_rom()
+    memory = _RomMemory(rom)
+    columns = text_columns(memory, "AB")
+
+    assert len(columns) == GLYPH_STRIDE * 2
+    first = columns[:GLYPH_WIDTH]
+    second = columns[GLYPH_STRIDE : GLYPH_STRIDE + GLYPH_WIDTH]
+
+    assert first == list(glyph_columns(memory, "A"))
+    assert second == list(glyph_columns(memory, "B"))
+    # Spacer columns should be present (zeroed) between glyphs.
+    assert columns[GLYPH_WIDTH] == 0

--- a/pce500/display/test_pipeline.py
+++ b/pce500/display/test_pipeline.py
@@ -1,0 +1,66 @@
+"""Tests for the LCD pipeline snapshot helpers."""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+from pce500.display.pipeline import (
+    LCDOperation,
+    LCDPipeline,
+    replay_operations,
+)
+from pce500.display.hd61202 import parse_command
+
+
+def _op(address: int, value: int, pc: int | None = None) -> LCDOperation:
+    return LCDOperation(command=parse_command(address, value), pc=pc)
+
+
+def test_pipeline_replay_updates_both_chips():
+    pipeline = LCDPipeline()
+    pipeline.apply(_op(0x2000, 0x3F))  # ON
+    pipeline.apply(_op(0x2000, 0xB8))  # SET PAGE 0
+    pipeline.apply(_op(0x2000, 0x40))  # SET Y = 0
+    pipeline.apply(_op(0x2002, 0x55, pc=0xF20000))
+
+    snapshot = pipeline.snapshot
+    assert snapshot.chips[0].vram[0][0] == 0x55
+    assert snapshot.chips[1].vram[0][0] == 0x55
+    # Instruction/data counters should reflect the writes.
+    assert snapshot.chips[0].instruction_count == 3
+    assert snapshot.chips[0].data_write_count == 1
+
+
+def test_pipeline_observer_receives_events_and_snapshot():
+    pipeline = LCDPipeline()
+    events: List[Tuple[dict, int]] = []
+
+    def _observer(event: dict, snapshot) -> None:
+        events.append((event, snapshot.chips[event["chip"]].y_address))
+
+    pipeline.subscribe(_observer)
+    pipeline.apply(_op(0x2008, 0x3F))  # LEFT chip only
+    pipeline.apply(_op(0x2008, 0xB8))
+    pipeline.apply(_op(0x2008, 0x40))
+    pipeline.apply(_op(0x200A, 0xAA))
+
+    assert any(evt["type"] == "data" for evt, _ in events)
+    last_event, y_address = events[-1]
+    assert last_event["type"] == "data"
+    assert last_event["chip"] == 0  # left chip
+    assert y_address == 1  # column advanced after the write
+
+
+def test_replay_operations_helper_collects_events():
+    operations = [
+        _op(0x2000, 0x3F),
+        _op(0x2004, 0xB8),  # RIGHT chip page set
+        _op(0x2004, 0x40),
+        _op(0x2006, 0x7E),
+    ]
+    snapshot, events = replay_operations(operations)
+
+    assert snapshot.chips[1].vram[0][0] == 0x7E
+    assert len(events) == 5
+    assert events[-1]["type"] == "data"
+    assert events[-1]["chip"] == 1

--- a/pce500/display/text_decoder.py
+++ b/pce500/display/text_decoder.py
@@ -4,35 +4,22 @@ from __future__ import annotations
 
 from typing import Dict, List, Tuple
 
-FONT_BASE = 0x00F2215
-GLYPH_WIDTH = 5
-GLYPH_STRIDE = 6
-GLYPH_COUNT = 96  # ASCII 0x20-0x7F
+from .font import GLYPH_HEIGHT, GLYPH_WIDTH, glyph_columns
+
 CHAR_COLUMNS = 40
 CHAR_ROWS = 4
 PIXELS_PER_CHAR_COL = 6  # 5 glyph columns + 1 spacer
-CHAR_HEIGHT = 7
-
-
-def _read_glyph_columns(memory) -> Dict[Tuple[int, ...], str]:
-    lookup: Dict[Tuple[int, ...], str] = {}
-    for index in range(GLYPH_COUNT):
-        code = 0x20 + index
-        offset = FONT_BASE + index * GLYPH_STRIDE
-        columns = [memory.read_byte(offset + i) & 0x7F for i in range(GLYPH_WIDTH)]
-        lookup[tuple(columns)] = chr(code)
-    return lookup
-
-
-def _font_lookup(memory) -> Dict[Tuple[int, ...], str]:
-    # Avoid caching complexities; reading 96 glyphs is cheap
-    return _read_glyph_columns(memory)
+CHAR_HEIGHT = GLYPH_HEIGHT
 
 
 def decode_display_text(controller, memory) -> List[str]:
     """Decode the current LCD VRAM into textual rows."""
 
-    lookup = _font_lookup(memory)
+    reverse_lookup: Dict[Tuple[int, ...], str] = {}
+    for code in range(0x20, 0x20 + 96):
+        char = chr(code)
+        reverse_lookup[glyph_columns(memory, char)] = char
+
     buffer = controller.get_display_buffer()
     if buffer is None:
         return []
@@ -56,13 +43,13 @@ def decode_display_text(controller, memory) -> List[str]:
             for glyph_col in range(GLYPH_WIDTH):
                 bits = 0
                 col = col_base + glyph_col
-                for row in range(CHAR_HEIGHT):
+                for row in range(GLYPH_HEIGHT):
                     if not buffer[row_base + row, col]:
                         bits |= 1 << row
                 columns.append(bits & 0x7F)
 
             glyph = tuple(columns)
-            row_chars.append(lookup.get(glyph, "?"))
+            row_chars.append(reverse_lookup.get(glyph, "?"))
 
         lines.append("".join(row_chars).rstrip())
 


### PR DESCRIPTION
## Summary
- add reusable LCDPipeline with immutable snapshots and replay helpers
- move ROM font logic into shared helpers used by the text decoder
- extend display test suite with pipeline and font validation for snapshot staging

## Testing
- UV_CACHE_DIR=/Users/mblsha/src/github/binja-esr-tests/public-src/.uv-cache uv run python -m pytest pce500/display