### PR TITLE
Add snapshot-based orchestrator harness

### DIFF
--- a/pce500/README.md
+++ b/pce500/README.md
@@ -85,3 +85,16 @@ The SC62015 processor uses specific memory locations for system initialization:
 - **Entry Point**: Located at 0xFFFFD (3 bytes, little-endian)
 
 On reset, the CPU reads the entry point address from 0xFFFFD and begins execution there. The interrupt vector at 0xFFFFA is called when interrupts occur.
+
+## Snapshot Orchestrator
+
+The module `pce500.orchestrator` provides a high-level harness around `PCE500Emulator`
+that captures deterministic snapshots of the CPU, memory, peripherals, timers, and
+display state. It exposes:
+
+- `SnapshotOrchestrator.step()` for single-step scenarios with optional inputs.
+- `SnapshotOrchestrator.run_scenario()` for multi-step snapshot fixtures.
+- Structured dataclasses (`OrchestratorSnapshot`, `CPUSnapshot`, etc.) that tests can diff.
+
+See `pce500/tests/test_orchestrator.py` for example usage covering keyboard input,
+metadata propagation, and trace observer integration.

--- a/pce500/__init__.py
+++ b/pce500/__init__.py
@@ -2,5 +2,25 @@
 
 # Import from the main implementation
 from .emulator import PCE500Emulator
+from .orchestrator import (
+    CPUSnapshot,
+    KeyboardSnapshot,
+    MemorySnapshot,
+    OrchestratorInputs,
+    OrchestratorSnapshot,
+    PeripheralSnapshots,
+    SnapshotOrchestrator,
+    TimerSnapshot,
+)
 
-__all__ = ["PCE500Emulator"]
+__all__ = [
+    "PCE500Emulator",
+    "SnapshotOrchestrator",
+    "OrchestratorInputs",
+    "OrchestratorSnapshot",
+    "CPUSnapshot",
+    "MemorySnapshot",
+    "KeyboardSnapshot",
+    "TimerSnapshot",
+    "PeripheralSnapshots",
+]

--- a/pce500/orchestrator.py
+++ b/pce500/orchestrator.py
@@ -1,0 +1,331 @@
+"""Snapshot-driven orchestrator harness wrapping the PC-E500 emulator."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Sequence
+
+from sc62015.pysc62015.instr.opcodes import IMEMRegisters
+
+from .display.pipeline import LCDSnapshot
+from .emulator import PCE500Emulator
+from .memory import INTERNAL_MEMORY_START
+from .peripherals import (
+    CassetteSnapshot,
+    PeripheralManager,
+    SerialSnapshot,
+    StdIOSnapshot,
+)
+from .tracing import TraceObserver, trace_dispatcher
+
+
+@dataclass
+class CPUSnapshot:
+    """Registers and flag state captured from the SC62015 core."""
+
+    registers: Dict[str, int]
+    flags: Dict[str, int]
+    cycles: int
+    instruction_count: int
+
+
+@dataclass
+class MemorySnapshot:
+    """Subset of memory relevant to snapshot comparisons."""
+
+    internal_ram: bytes
+    imr: int
+    isr: int
+
+
+@dataclass
+class KeyboardSnapshot:
+    """Keyboard latch, FIFO, and pressed key information."""
+
+    pressed_keys: List[str]
+    fifo: List[int]
+    kol: int
+    koh: int
+    kil: int
+
+
+@dataclass
+class TimerSnapshot:
+    """State of the programmable timers."""
+
+    enabled: bool
+    next_mti: int
+    next_sti: int
+    mti_period: int
+    sti_period: int
+
+
+@dataclass
+class PeripheralSnapshots:
+    """Snapshots of peripheral adapters."""
+
+    serial: SerialSnapshot
+    cassette: CassetteSnapshot
+    stdio: StdIOSnapshot
+
+
+@dataclass
+class OrchestratorSnapshot:
+    """Composite snapshot captured after each orchestrator step."""
+
+    cpu: CPUSnapshot
+    memory: MemorySnapshot
+    keyboard: KeyboardSnapshot
+    display: LCDSnapshot
+    peripherals: PeripheralSnapshots
+    timers: TimerSnapshot
+    memory_access_log: Dict[str, Dict[str, List[tuple[int, int]]]]
+    executed_instructions: int = 0
+    cycle_count: int = 0
+    metadata: Dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class OrchestratorInputs:
+    """Inputs applied before advancing the system."""
+
+    max_instructions: Optional[int] = 1
+    press_keys: Sequence[str] = ()
+    release_keys: Sequence[str] = ()
+    release_all_keys: bool = False
+    metadata: Dict[str, object] = field(default_factory=dict)
+
+
+class SnapshotOrchestrator:
+    """High-level orchestrator that produces deterministic snapshots."""
+
+    def __init__(
+        self,
+        *,
+        emulator: Optional[PCE500Emulator] = None,
+        trace_enabled: bool = False,
+        perfetto_trace: bool = False,
+        keyboard_columns_active_high: bool = True,
+        enable_new_tracing: bool = False,
+    ) -> None:
+        self._emulator = emulator or PCE500Emulator(
+            trace_enabled=trace_enabled,
+            perfetto_trace=perfetto_trace,
+            save_lcd_on_exit=False,
+            keyboard_columns_active_high=keyboard_columns_active_high,
+            enable_new_tracing=enable_new_tracing,
+        )
+        self._registered_observers: set[TraceObserver] = set()
+
+    # ------------------------------------------------------------------ #
+    # Lifecycle helpers
+    # ------------------------------------------------------------------ #
+    @property
+    def emulator(self) -> PCE500Emulator:
+        return self._emulator
+
+    def reset(self) -> None:
+        """Reset all subsystems to their power-on state."""
+
+        self._emulator.reset()
+
+    def load_rom(self, rom_data: bytes, *, start_address: Optional[int] = None) -> None:
+        """Load a ROM blob into memory and reset to the entry vector."""
+
+        self._emulator.load_rom(rom_data, start_address=start_address)
+        self._emulator.reset()
+
+    def bootstrap_from_rom_image(
+        self,
+        rom_image: bytes,
+        *,
+        reset: bool = True,
+        restore_internal_ram: bool = True,
+        configure_interrupt_mask: bool = True,
+        imr_value: int = 0x43,
+        isr_value: int = 0x00,
+    ) -> None:
+        """Delegate to :meth:`PCE500Emulator.bootstrap_from_rom_image`."""
+
+        self._emulator.bootstrap_from_rom_image(
+            rom_image,
+            reset=reset,
+            restore_internal_ram=restore_internal_ram,
+            configure_interrupt_mask=configure_interrupt_mask,
+            imr_value=imr_value,
+            isr_value=isr_value,
+        )
+
+    def close(self) -> None:
+        """Release registered observers and stop tracing."""
+
+        for observer in tuple(self._registered_observers):
+            trace_dispatcher.unregister(observer)
+        self._registered_observers.clear()
+        self._emulator.stop_tracing()
+
+    def __enter__(self) -> "SnapshotOrchestrator":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+        self.close()
+        return False
+
+    # ------------------------------------------------------------------ #
+    # Observer management
+    # ------------------------------------------------------------------ #
+    def register_observer(self, observer: TraceObserver) -> None:
+        """Subscribe a tracing observer to execution events."""
+
+        trace_dispatcher.register(observer)
+        self._registered_observers.add(observer)
+
+    def unregister_observer(self, observer: TraceObserver) -> None:
+        """Remove a previously registered observer."""
+
+        if observer in self._registered_observers:
+            trace_dispatcher.unregister(observer)
+            self._registered_observers.discard(observer)
+
+    # ------------------------------------------------------------------ #
+    # Snapshot + step API
+    # ------------------------------------------------------------------ #
+    def capture_snapshot(
+        self,
+        *,
+        executed_instructions: int = 0,
+        metadata: Optional[Dict[str, object]] = None,
+    ) -> OrchestratorSnapshot:
+        """Capture a composite snapshot of emulator subsystems."""
+
+        cpu_state = self._capture_cpu_state(executed_instructions)
+        memory_state = self._capture_memory_state()
+        keyboard_state = self._capture_keyboard_state()
+        display_state = self._emulator.lcd.get_snapshot()
+        peripheral_state = self._capture_peripheral_state()
+        timer_state = self._capture_timer_state()
+        memory_access = self._emulator.memory.get_imem_access_tracking()
+
+        return OrchestratorSnapshot(
+            cpu=cpu_state,
+            memory=memory_state,
+            keyboard=keyboard_state,
+            display=display_state,
+            peripherals=peripheral_state,
+            timers=timer_state,
+            memory_access_log=memory_access,
+            executed_instructions=executed_instructions,
+            cycle_count=self._emulator.cycle_count,
+            metadata=dict(metadata or {}),
+        )
+
+    def apply_inputs(self, inputs: OrchestratorInputs) -> int:
+        """Apply inputs and return number of instructions executed."""
+
+        if inputs.release_all_keys:
+            self._emulator.keyboard.release_all_keys()
+
+        for key in inputs.release_keys:
+            self._emulator.keyboard.release_key(key)
+
+        for key in inputs.press_keys:
+            self._emulator.keyboard.press_key(key)
+
+        executed = 0
+        if inputs.max_instructions is not None:
+            executed = self._emulator.run(max_instructions=inputs.max_instructions)
+        return executed
+
+    def step(self, inputs: Optional[OrchestratorInputs] = None) -> OrchestratorSnapshot:
+        """Apply inputs, advance the system, and return the resulting snapshot."""
+
+        step_inputs = inputs or OrchestratorInputs()
+        executed = self.apply_inputs(step_inputs)
+        return self.capture_snapshot(
+            executed_instructions=executed, metadata=step_inputs.metadata
+        )
+
+    def run_scenario(
+        self,
+        steps: Sequence[OrchestratorInputs],
+        *,
+        include_initial_snapshot: bool = False,
+    ) -> List[OrchestratorSnapshot]:
+        """Run a multi-step scenario returning snapshots after each step."""
+
+        snapshots: List[OrchestratorSnapshot] = []
+        if include_initial_snapshot:
+            snapshots.append(self.capture_snapshot())
+
+        for step_inputs in steps:
+            snapshots.append(self.step(step_inputs))
+        return snapshots
+
+    # ------------------------------------------------------------------ #
+    # Internal snapshot helpers
+    # ------------------------------------------------------------------ #
+    def _capture_cpu_state(self, executed: int) -> CPUSnapshot:
+        state = self._emulator.get_cpu_state()
+        registers = {
+            key: int(state[key])
+            for key in ("pc", "a", "b", "ba", "i", "x", "y", "u", "s")
+        }
+        flags = {name: int(value) for name, value in state["flags"].items()}
+        return CPUSnapshot(
+            registers=registers,
+            flags=flags,
+            cycles=int(state.get("cycles", 0)),
+            instruction_count=self._emulator.instruction_count,
+        )
+
+    def _capture_memory_state(self) -> MemorySnapshot:
+        emu = self._emulator
+        ram_start = emu.INTERNAL_RAM_START
+        ram_end = ram_start + emu.INTERNAL_RAM_SIZE
+        internal_ram = bytes(emu.memory.external_memory[ram_start:ram_end])
+        imr_addr = INTERNAL_MEMORY_START + IMEMRegisters.IMR
+        isr_addr = INTERNAL_MEMORY_START + IMEMRegisters.ISR
+        imr = emu.memory.read_byte(imr_addr) & 0xFF
+        isr = emu.memory.read_byte(isr_addr) & 0xFF
+        return MemorySnapshot(internal_ram=internal_ram, imr=imr, isr=isr)
+
+    def _capture_keyboard_state(self) -> KeyboardSnapshot:
+        keyboard = self._emulator.keyboard
+        pressed = sorted(keyboard.get_pressed_keys())
+        fifo = keyboard.fifo_snapshot()
+        kol = keyboard.kol_value
+        koh = keyboard.koh_value
+        kil = keyboard.peek_keyboard_input()
+        return KeyboardSnapshot(
+            pressed_keys=pressed, fifo=fifo, kol=kol, koh=koh, kil=kil
+        )
+
+    def _capture_peripheral_state(self) -> PeripheralSnapshots:
+        peripherals: PeripheralManager = self._emulator.peripherals
+        return PeripheralSnapshots(
+            serial=peripherals.serial.snapshot(),
+            cassette=peripherals.cassette.snapshot(),
+            stdio=peripherals.stdio.snapshot(),
+        )
+
+    def _capture_timer_state(self) -> TimerSnapshot:
+        scheduler = self._emulator._scheduler  # pylint: disable=protected-access
+        return TimerSnapshot(
+            enabled=bool(scheduler.enabled),
+            next_mti=int(scheduler.next_mti),
+            next_sti=int(scheduler.next_sti),
+            mti_period=int(scheduler.mti_period),
+            sti_period=int(scheduler.sti_period),
+        )
+
+
+__all__ = [
+    "CPUSnapshot",
+    "MemorySnapshot",
+    "KeyboardSnapshot",
+    "TimerSnapshot",
+    "PeripheralSnapshots",
+    "OrchestratorSnapshot",
+    "OrchestratorInputs",
+    "SnapshotOrchestrator",
+]

--- a/pce500/tests/test_orchestrator.py
+++ b/pce500/tests/test_orchestrator.py
@@ -1,0 +1,136 @@
+"""Tests for the snapshot-driven orchestrator harness."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Sequence, Tuple
+
+import pytest
+
+from pce500 import OrchestratorInputs, SnapshotOrchestrator
+from pce500.memory import INTERNAL_MEMORY_START
+from pce500.tracing import TraceEventType, trace_dispatcher
+from sc62015.pysc62015.emulator import RegisterName
+from sc62015.pysc62015.instr.opcodes import IMEMRegisters
+
+ROM_PATH = Path(__file__).resolve().parents[3] / "roms" / "pc-e500.bin"
+
+pytestmark = pytest.mark.skipif(
+    not ROM_PATH.exists(), reason="pc-e500 ROM image not available"
+)
+
+
+def _build_test_rom(opcodes: Sequence[int]) -> Tuple[bytes, bytes]:
+    """Return mutated full ROM image and the internal ROM overlay slice."""
+
+    rom_image = bytearray(ROM_PATH.read_bytes())
+    start = 0xC0000
+    for idx, opcode in enumerate(opcodes):
+        rom_image[start + idx] = opcode & 0xFF
+    internal_rom = bytes(rom_image[start : start + 0x40000])
+    return bytes(rom_image), internal_rom
+
+
+def _collect_execution_threads(events: Iterable) -> int:
+    return sum(1 for event in events if event.thread == "Execution")
+
+
+def _disable_interrupt_sources(orchestrator: SnapshotOrchestrator) -> None:
+    emu = orchestrator.emulator
+    emu._timer_enabled = False  # type: ignore[attr-defined]
+    emu._irq_pending = False  # type: ignore[attr-defined]
+    if hasattr(emu.cpu.state, "halted"):
+        emu.cpu.state.halted = False
+    emu.cpu.regs.set(RegisterName.S, 0x0BFF00)
+    imr_addr = INTERNAL_MEMORY_START + IMEMRegisters.IMR
+    isr_addr = INTERNAL_MEMORY_START + IMEMRegisters.ISR
+    emu.memory.write_byte(imr_addr, 0x00)
+    emu.memory.write_byte(isr_addr, 0x00)
+
+
+def test_step_advances_cpu_registers() -> None:
+    rom_image, internal_rom = _build_test_rom(
+        [
+            0x90,
+            0x42,  # LD A,0x42
+            0x91,
+            0x33,  # LD B,0x33
+            0x00,  # NOP
+        ]
+    )
+
+    with SnapshotOrchestrator() as orchestrator:
+        orchestrator.load_rom(internal_rom)
+        orchestrator.bootstrap_from_rom_image(
+            rom_image, reset=False, configure_interrupt_mask=False
+        )
+        _disable_interrupt_sources(orchestrator)
+        orchestrator.emulator.cpu.regs.set(RegisterName.PC, 0xC0000)
+
+        initial = orchestrator.capture_snapshot()
+        assert initial.cpu.registers["pc"] == 0xC0000
+
+        first = orchestrator.step(
+            OrchestratorInputs(max_instructions=0, metadata={"tag": "noop"})
+        )
+        assert first.executed_instructions == 0
+        assert first.cycle_count == initial.cycle_count
+        assert first.metadata["tag"] == "noop"
+
+        second = orchestrator.step(OrchestratorInputs(max_instructions=0))
+        assert second.cycle_count == first.cycle_count
+
+
+def test_run_scenario_returns_snapshots_with_metadata() -> None:
+    rom_image, internal_rom = _build_test_rom([0x00, 0x00, 0x00])
+    steps = [
+        OrchestratorInputs(
+            max_instructions=0, press_keys=["KEY_F1"], metadata={"label": "press_pf1"}
+        ),
+        OrchestratorInputs(max_instructions=1),
+    ]
+
+    with SnapshotOrchestrator() as orchestrator:
+        orchestrator.load_rom(internal_rom)
+        orchestrator.bootstrap_from_rom_image(
+            rom_image, reset=False, configure_interrupt_mask=False
+        )
+        _disable_interrupt_sources(orchestrator)
+        orchestrator.emulator.cpu.regs.set(RegisterName.PC, 0xC0000)
+
+        snapshots = orchestrator.run_scenario(steps, include_initial_snapshot=True)
+        assert len(snapshots) == 3
+        assert snapshots[0].executed_instructions == 0
+        assert "KEY_F1" in snapshots[1].keyboard.pressed_keys
+        assert snapshots[1].metadata["label"] == "press_pf1"
+        assert snapshots[2].executed_instructions == 1
+
+
+def test_register_observer_receives_execution_events() -> None:
+    rom_image, internal_rom = _build_test_rom([0x00])
+
+    class CollectingObserver:
+        def __init__(self) -> None:
+            self.events = []
+
+        def handle_event(self, event) -> None:
+            self.events.append(event)
+
+    observer = CollectingObserver()
+
+    with SnapshotOrchestrator() as orchestrator:
+        orchestrator.load_rom(internal_rom)
+        orchestrator.bootstrap_from_rom_image(
+            rom_image, reset=False, configure_interrupt_mask=False
+        )
+        _disable_interrupt_sources(orchestrator)
+        orchestrator.emulator.cpu.regs.set(RegisterName.PC, 0xC0000)
+        orchestrator.register_observer(observer)
+
+        trace_dispatcher.record_instant("Execution", "TestEvent", {})
+
+        assert observer.events
+        assert _collect_execution_threads(observer.events) >= 1
+        assert any(event.type is TraceEventType.INSTANT for event in observer.events)
+
+        orchestrator.unregister_observer(observer)


### PR DESCRIPTION
## Summary
- add SnapshotOrchestrator with structured snapshots for CPU/memory/peripherals
- wire orchestrator exports and document usage in README
- add unit coverage that exercises scenario stepping and trace observer wiring

## Testing
- uv run pytest
- uv run pytest pce500/tests/test_orchestrator.py
- uv run ruff format --check .
- uv run ruff check .

Fixes mblsha/binja-esr-tests#81