### PR TITLE
Introduce canonical state model snapshots

### DIFF
--- a/pce500/README.md
+++ b/pce500/README.md
@@ -94,7 +94,12 @@ display state. It exposes:
 
 - `SnapshotOrchestrator.step()` for single-step scenarios with optional inputs.
 - `SnapshotOrchestrator.run_scenario()` for multi-step snapshot fixtures.
-- Structured dataclasses (`OrchestratorSnapshot`, `CPUSnapshot`, etc.) that tests can diff.
+- Structured dataclasses (`OrchestratorSnapshot`, `EmulatorState`, `StateDiff`) that tests can diff.
 
 See `pce500/tests/test_orchestrator.py` for example usage covering keyboard input,
 metadata propagation, and trace observer integration.
+
+The canonical snapshot schema lives in `pce500.state_model`. The helper functions
+`capture_state()` and `diff_states()` convert emulator instances into immutable
+`EmulatorState` objects and compute structured deltas (`StateDiff`). These utilities
+power the orchestrator and can be used directly in lower-level subsystem tests.

--- a/pce500/__init__.py
+++ b/pce500/__init__.py
@@ -3,24 +3,38 @@
 # Import from the main implementation
 from .emulator import PCE500Emulator
 from .orchestrator import (
-    CPUSnapshot,
-    KeyboardSnapshot,
-    MemorySnapshot,
     OrchestratorInputs,
     OrchestratorSnapshot,
-    PeripheralSnapshots,
     SnapshotOrchestrator,
-    TimerSnapshot,
+)
+from .state_model import (
+    CPUState,
+    EmulatorState,
+    FieldDiff,
+    KeyboardState,
+    MemoryState,
+    PeripheralState,
+    StateDiff,
+    TimerState,
+    capture_state,
+    diff_states,
+    empty_state_diff,
 )
 
 __all__ = [
     "PCE500Emulator",
-    "SnapshotOrchestrator",
     "OrchestratorInputs",
     "OrchestratorSnapshot",
-    "CPUSnapshot",
-    "MemorySnapshot",
-    "KeyboardSnapshot",
-    "TimerSnapshot",
-    "PeripheralSnapshots",
+    "SnapshotOrchestrator",
+    "CPUState",
+    "MemoryState",
+    "KeyboardState",
+    "TimerState",
+    "PeripheralState",
+    "EmulatorState",
+    "FieldDiff",
+    "StateDiff",
+    "capture_state",
+    "diff_states",
+    "empty_state_diff",
 ]

--- a/pce500/orchestrator.py
+++ b/pce500/orchestrator.py
@@ -3,85 +3,30 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Sequence
+from typing import Dict, Optional, Sequence
 
-from sc62015.pysc62015.instr.opcodes import IMEMRegisters
-
-from .display.pipeline import LCDSnapshot
 from .emulator import PCE500Emulator
-from .memory import INTERNAL_MEMORY_START
-from .peripherals import (
-    CassetteSnapshot,
-    PeripheralManager,
-    SerialSnapshot,
-    StdIOSnapshot,
+from .state_model import (
+    EmulatorState,
+    StateDiff,
+    capture_state,
+    diff_states,
+    empty_state_diff,
 )
 from .tracing import TraceObserver, trace_dispatcher
 
 
 @dataclass
-class CPUSnapshot:
-    """Registers and flag state captured from the SC62015 core."""
-
-    registers: Dict[str, int]
-    flags: Dict[str, int]
-    cycles: int
-    instruction_count: int
-
-
-@dataclass
-class MemorySnapshot:
-    """Subset of memory relevant to snapshot comparisons."""
-
-    internal_ram: bytes
-    imr: int
-    isr: int
-
-
-@dataclass
-class KeyboardSnapshot:
-    """Keyboard latch, FIFO, and pressed key information."""
-
-    pressed_keys: List[str]
-    fifo: List[int]
-    kol: int
-    koh: int
-    kil: int
-
-
-@dataclass
-class TimerSnapshot:
-    """State of the programmable timers."""
-
-    enabled: bool
-    next_mti: int
-    next_sti: int
-    mti_period: int
-    sti_period: int
-
-
-@dataclass
-class PeripheralSnapshots:
-    """Snapshots of peripheral adapters."""
-
-    serial: SerialSnapshot
-    cassette: CassetteSnapshot
-    stdio: StdIOSnapshot
-
-
-@dataclass
 class OrchestratorSnapshot:
-    """Composite snapshot captured after each orchestrator step."""
+    """Composite snapshot and diff captured after each orchestrator step."""
 
-    cpu: CPUSnapshot
-    memory: MemorySnapshot
-    keyboard: KeyboardSnapshot
-    display: LCDSnapshot
-    peripherals: PeripheralSnapshots
-    timers: TimerSnapshot
-    memory_access_log: Dict[str, Dict[str, List[tuple[int, int]]]]
-    executed_instructions: int = 0
-    cycle_count: int = 0
+    state: EmulatorState
+    diff: StateDiff
+    executed_instructions: int
+    cycle_count: int
+    memory_access_log: Dict[str, Dict[str, list[tuple[int, int]]]] = field(
+        default_factory=dict
+    )
     metadata: Dict[str, object] = field(default_factory=dict)
 
 
@@ -116,6 +61,7 @@ class SnapshotOrchestrator:
             enable_new_tracing=enable_new_tracing,
         )
         self._registered_observers: set[TraceObserver] = set()
+        self._last_state: Optional[EmulatorState] = None
 
     # ------------------------------------------------------------------ #
     # Lifecycle helpers
@@ -128,12 +74,13 @@ class SnapshotOrchestrator:
         """Reset all subsystems to their power-on state."""
 
         self._emulator.reset()
+        self._last_state = None
 
     def load_rom(self, rom_data: bytes, *, start_address: Optional[int] = None) -> None:
         """Load a ROM blob into memory and reset to the entry vector."""
 
         self._emulator.load_rom(rom_data, start_address=start_address)
-        self._emulator.reset()
+        self.reset()
 
     def bootstrap_from_rom_image(
         self,
@@ -155,6 +102,7 @@ class SnapshotOrchestrator:
             imr_value=imr_value,
             isr_value=isr_value,
         )
+        self._last_state = None
 
     def close(self) -> None:
         """Release registered observers and stop tracing."""
@@ -162,6 +110,7 @@ class SnapshotOrchestrator:
         for observer in tuple(self._registered_observers):
             trace_dispatcher.unregister(observer)
         self._registered_observers.clear()
+        self._last_state = None
         self._emulator.stop_tracing()
 
     def __enter__(self) -> "SnapshotOrchestrator":
@@ -198,26 +147,9 @@ class SnapshotOrchestrator:
     ) -> OrchestratorSnapshot:
         """Capture a composite snapshot of emulator subsystems."""
 
-        cpu_state = self._capture_cpu_state(executed_instructions)
-        memory_state = self._capture_memory_state()
-        keyboard_state = self._capture_keyboard_state()
-        display_state = self._emulator.lcd.get_snapshot()
-        peripheral_state = self._capture_peripheral_state()
-        timer_state = self._capture_timer_state()
-        memory_access = self._emulator.memory.get_imem_access_tracking()
-
-        return OrchestratorSnapshot(
-            cpu=cpu_state,
-            memory=memory_state,
-            keyboard=keyboard_state,
-            display=display_state,
-            peripherals=peripheral_state,
-            timers=timer_state,
-            memory_access_log=memory_access,
-            executed_instructions=executed_instructions,
-            cycle_count=self._emulator.cycle_count,
-            metadata=dict(metadata or {}),
-        )
+        if metadata is None:
+            metadata = {}
+        return self._build_snapshot(executed_instructions, metadata)
 
     def apply_inputs(self, inputs: OrchestratorInputs) -> int:
         """Apply inputs and return number of instructions executed."""
@@ -241,19 +173,17 @@ class SnapshotOrchestrator:
 
         step_inputs = inputs or OrchestratorInputs()
         executed = self.apply_inputs(step_inputs)
-        return self.capture_snapshot(
-            executed_instructions=executed, metadata=step_inputs.metadata
-        )
+        return self._build_snapshot(executed, dict(step_inputs.metadata))
 
     def run_scenario(
         self,
         steps: Sequence[OrchestratorInputs],
         *,
         include_initial_snapshot: bool = False,
-    ) -> List[OrchestratorSnapshot]:
+    ) -> list[OrchestratorSnapshot]:
         """Run a multi-step scenario returning snapshots after each step."""
 
-        snapshots: List[OrchestratorSnapshot] = []
+        snapshots: list[OrchestratorSnapshot] = []
         if include_initial_snapshot:
             snapshots.append(self.capture_snapshot())
 
@@ -264,68 +194,28 @@ class SnapshotOrchestrator:
     # ------------------------------------------------------------------ #
     # Internal snapshot helpers
     # ------------------------------------------------------------------ #
-    def _capture_cpu_state(self, executed: int) -> CPUSnapshot:
-        state = self._emulator.get_cpu_state()
-        registers = {
-            key: int(state[key])
-            for key in ("pc", "a", "b", "ba", "i", "x", "y", "u", "s")
-        }
-        flags = {name: int(value) for name, value in state["flags"].items()}
-        return CPUSnapshot(
-            registers=registers,
-            flags=flags,
-            cycles=int(state.get("cycles", 0)),
-            instruction_count=self._emulator.instruction_count,
+    def _build_snapshot(
+        self, executed: int, metadata: Dict[str, object]
+    ) -> OrchestratorSnapshot:
+        state = capture_state(self._emulator)
+        if self._last_state is not None:
+            diff = diff_states(self._last_state, state)
+        else:
+            diff = empty_state_diff()
+        snapshot = OrchestratorSnapshot(
+            state=state,
+            diff=diff,
+            executed_instructions=executed,
+            cycle_count=self._emulator.cycle_count,
+            memory_access_log=self._emulator.memory.get_imem_access_tracking(),
+            metadata=dict(metadata),
         )
-
-    def _capture_memory_state(self) -> MemorySnapshot:
-        emu = self._emulator
-        ram_start = emu.INTERNAL_RAM_START
-        ram_end = ram_start + emu.INTERNAL_RAM_SIZE
-        internal_ram = bytes(emu.memory.external_memory[ram_start:ram_end])
-        imr_addr = INTERNAL_MEMORY_START + IMEMRegisters.IMR
-        isr_addr = INTERNAL_MEMORY_START + IMEMRegisters.ISR
-        imr = emu.memory.read_byte(imr_addr) & 0xFF
-        isr = emu.memory.read_byte(isr_addr) & 0xFF
-        return MemorySnapshot(internal_ram=internal_ram, imr=imr, isr=isr)
-
-    def _capture_keyboard_state(self) -> KeyboardSnapshot:
-        keyboard = self._emulator.keyboard
-        pressed = sorted(keyboard.get_pressed_keys())
-        fifo = keyboard.fifo_snapshot()
-        kol = keyboard.kol_value
-        koh = keyboard.koh_value
-        kil = keyboard.peek_keyboard_input()
-        return KeyboardSnapshot(
-            pressed_keys=pressed, fifo=fifo, kol=kol, koh=koh, kil=kil
-        )
-
-    def _capture_peripheral_state(self) -> PeripheralSnapshots:
-        peripherals: PeripheralManager = self._emulator.peripherals
-        return PeripheralSnapshots(
-            serial=peripherals.serial.snapshot(),
-            cassette=peripherals.cassette.snapshot(),
-            stdio=peripherals.stdio.snapshot(),
-        )
-
-    def _capture_timer_state(self) -> TimerSnapshot:
-        scheduler = self._emulator._scheduler  # pylint: disable=protected-access
-        return TimerSnapshot(
-            enabled=bool(scheduler.enabled),
-            next_mti=int(scheduler.next_mti),
-            next_sti=int(scheduler.next_sti),
-            mti_period=int(scheduler.mti_period),
-            sti_period=int(scheduler.sti_period),
-        )
+        self._last_state = state
+        return snapshot
 
 
 __all__ = [
-    "CPUSnapshot",
-    "MemorySnapshot",
-    "KeyboardSnapshot",
-    "TimerSnapshot",
-    "PeripheralSnapshots",
-    "OrchestratorSnapshot",
     "OrchestratorInputs",
+    "OrchestratorSnapshot",
     "SnapshotOrchestrator",
 ]

--- a/pce500/state_model.py
+++ b/pce500/state_model.py
@@ -1,0 +1,313 @@
+"""Canonical emulator state snapshots and diff utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, Optional, Tuple
+from sc62015.pysc62015.instr.opcodes import IMEMRegisters
+
+from .display.pipeline import LCDSnapshot
+from .emulator import PCE500Emulator
+from .memory import INTERNAL_MEMORY_START
+from .peripherals import (
+    CassetteSnapshot,
+    PeripheralManager,
+    SerialSnapshot,
+    StdIOSnapshot,
+)
+
+
+@dataclass(frozen=True)
+class CPUState:
+    """Registers, flags, and execution counters captured from the SC62015 core."""
+
+    registers: Dict[str, int]
+    flags: Dict[str, int]
+    cycles: int
+    instruction_count: int
+
+
+@dataclass(frozen=True)
+class MemoryState:
+    """Internal RAM and interrupt mask/status bytes."""
+
+    internal_ram: bytes
+    imr: int
+    isr: int
+
+
+@dataclass(frozen=True)
+class KeyboardState:
+    """Keyboard latch, FIFO, and debounced key data."""
+
+    pressed_keys: Tuple[str, ...]
+    fifo: Tuple[int, ...]
+    kol: int
+    koh: int
+    kil: int
+
+
+@dataclass(frozen=True)
+class TimerState:
+    """Programmable timer scheduler state."""
+
+    enabled: bool
+    next_mti: int
+    next_sti: int
+    mti_period: int
+    sti_period: int
+
+
+@dataclass(frozen=True)
+class PeripheralState:
+    """Snapshots of serial, cassette, and stdio adapters."""
+
+    serial: SerialSnapshot
+    cassette: CassetteSnapshot
+    stdio: StdIOSnapshot
+
+
+@dataclass(frozen=True)
+class EmulatorState:
+    """Composite immutable snapshot of emulator subsystems."""
+
+    cpu: CPUState
+    memory: MemoryState
+    keyboard: KeyboardState
+    timers: TimerState
+    peripherals: PeripheralState
+    display: LCDSnapshot
+
+
+@dataclass(frozen=True)
+class FieldDiff:
+    """Difference for a single named field."""
+
+    name: str
+    before: object
+    after: object
+
+
+@dataclass(frozen=True)
+class StateDiff:
+    """Aggregated differences between two emulator states."""
+
+    cpu: Tuple[FieldDiff, ...] = field(default_factory=tuple)
+    memory: Tuple[FieldDiff, ...] = field(default_factory=tuple)
+    keyboard: Tuple[FieldDiff, ...] = field(default_factory=tuple)
+    timers: Tuple[FieldDiff, ...] = field(default_factory=tuple)
+    display_changed: bool = False
+    peripherals_changed: Dict[str, bool] = field(default_factory=dict)
+
+    def is_empty(self) -> bool:
+        """Return True when no differences were recorded."""
+
+        return (
+            not self.cpu
+            and not self.memory
+            and not self.keyboard
+            and not self.timers
+            and not self.display_changed
+            and not any(self.peripherals_changed.values())
+        )
+
+
+def empty_state_diff() -> StateDiff:
+    """Return a reusable empty diff instance."""
+
+    return StateDiff()
+
+
+def capture_state(emulator: PCE500Emulator) -> EmulatorState:
+    """Capture the current emulator state as canonical snapshot."""
+
+    cpu_state = _capture_cpu_state(emulator)
+    memory_state = _capture_memory_state(emulator)
+    keyboard_state = _capture_keyboard_state(emulator)
+    timer_state = _capture_timer_state(emulator)
+    peripheral_state = _capture_peripheral_state(emulator.peripherals)
+    display_state = emulator.lcd.get_snapshot()
+    return EmulatorState(
+        cpu=cpu_state,
+        memory=memory_state,
+        keyboard=keyboard_state,
+        timers=timer_state,
+        peripherals=peripheral_state,
+        display=display_state,
+    )
+
+
+def diff_states(before: Optional[EmulatorState], after: EmulatorState) -> StateDiff:
+    """Compute structured differences between two emulator states."""
+
+    if before is None:
+        return empty_state_diff()
+
+    cpu_diffs = _diff_cpu(before.cpu, after.cpu)
+    memory_diffs = _diff_memory(before.memory, after.memory)
+    keyboard_diffs = _diff_keyboard(before.keyboard, after.keyboard)
+    timer_diffs = _diff_timers(before.timers, after.timers)
+    display_changed = before.display != after.display
+    peripherals_changed = {
+        "serial": before.peripherals.serial != after.peripherals.serial,
+        "cassette": before.peripherals.cassette != after.peripherals.cassette,
+        "stdio": before.peripherals.stdio != after.peripherals.stdio,
+    }
+    return StateDiff(
+        cpu=cpu_diffs,
+        memory=memory_diffs,
+        keyboard=keyboard_diffs,
+        timers=timer_diffs,
+        display_changed=display_changed,
+        peripherals_changed=peripherals_changed,
+    )
+
+
+def _capture_cpu_state(emulator: PCE500Emulator) -> CPUState:
+    snapshot = emulator.get_cpu_state()
+    registers = {
+        "pc": int(snapshot["pc"]),
+        "a": int(snapshot["a"]),
+        "b": int(snapshot["b"]),
+        "ba": int(snapshot["ba"]),
+        "i": int(snapshot["i"]),
+        "x": int(snapshot["x"]),
+        "y": int(snapshot["y"]),
+        "u": int(snapshot["u"]),
+        "s": int(snapshot["s"]),
+    }
+    flags = {name: int(value) for name, value in snapshot["flags"].items()}
+    return CPUState(
+        registers=registers,
+        flags=flags,
+        cycles=int(snapshot["cycles"]),
+        instruction_count=int(emulator.instruction_count),
+    )
+
+
+def _capture_memory_state(emulator: PCE500Emulator) -> MemoryState:
+    ram_start = emulator.INTERNAL_RAM_START
+    ram_end = ram_start + emulator.INTERNAL_RAM_SIZE
+    internal_ram = bytes(emulator.memory.external_memory[ram_start:ram_end])
+    imr_addr = INTERNAL_MEMORY_START + IMEMRegisters.IMR
+    isr_addr = INTERNAL_MEMORY_START + IMEMRegisters.ISR
+    imr = emulator.memory.read_byte(imr_addr) & 0xFF
+    isr = emulator.memory.read_byte(isr_addr) & 0xFF
+    return MemoryState(internal_ram=internal_ram, imr=imr, isr=isr)
+
+
+def _capture_keyboard_state(emulator: PCE500Emulator) -> KeyboardState:
+    keyboard = emulator.keyboard
+    pressed = tuple(sorted(keyboard.get_pressed_keys()))
+    fifo = tuple(keyboard.fifo_snapshot())
+    return KeyboardState(
+        pressed_keys=pressed,
+        fifo=fifo,
+        kol=keyboard.kol_value,
+        koh=keyboard.koh_value,
+        kil=keyboard.peek_keyboard_input(),
+    )
+
+
+def _capture_timer_state(emulator: PCE500Emulator) -> TimerState:
+    scheduler = emulator._scheduler  # pylint: disable=protected-access
+    return TimerState(
+        enabled=bool(scheduler.enabled),
+        next_mti=int(scheduler.next_mti),
+        next_sti=int(scheduler.next_sti),
+        mti_period=int(scheduler.mti_period),
+        sti_period=int(scheduler.sti_period),
+    )
+
+
+def _capture_peripheral_state(peripherals: PeripheralManager) -> PeripheralState:
+    return PeripheralState(
+        serial=peripherals.serial.snapshot(),
+        cassette=peripherals.cassette.snapshot(),
+        stdio=peripherals.stdio.snapshot(),
+    )
+
+
+def _diff_cpu(before: CPUState, after: CPUState) -> Tuple[FieldDiff, ...]:
+    diffs: list[FieldDiff] = []
+    diffs.extend(_diff_mapping("registers", before.registers, after.registers))
+    diffs.extend(_diff_mapping("flags", before.flags, after.flags))
+    if before.cycles != after.cycles:
+        diffs.append(FieldDiff("cycles", before.cycles, after.cycles))
+    if before.instruction_count != after.instruction_count:
+        diffs.append(
+            FieldDiff(
+                "instruction_count",
+                before.instruction_count,
+                after.instruction_count,
+            )
+        )
+    return tuple(diffs)
+
+
+def _diff_memory(before: MemoryState, after: MemoryState) -> Tuple[FieldDiff, ...]:
+    diffs: list[FieldDiff] = []
+    if before.imr != after.imr:
+        diffs.append(FieldDiff("imr", before.imr, after.imr))
+    if before.isr != after.isr:
+        diffs.append(FieldDiff("isr", before.isr, after.isr))
+    if before.internal_ram != after.internal_ram:
+        diffs.append(FieldDiff("internal_ram", "<bytes>", "<bytes>"))
+    return tuple(diffs)
+
+
+def _diff_keyboard(
+    before: KeyboardState, after: KeyboardState
+) -> Tuple[FieldDiff, ...]:
+    diffs: list[FieldDiff] = []
+    if before.pressed_keys != after.pressed_keys:
+        diffs.append(FieldDiff("pressed_keys", before.pressed_keys, after.pressed_keys))
+    if before.fifo != after.fifo:
+        diffs.append(FieldDiff("fifo", before.fifo, after.fifo))
+    if before.kol != after.kol:
+        diffs.append(FieldDiff("kol", before.kol, after.kol))
+    if before.koh != after.koh:
+        diffs.append(FieldDiff("koh", before.koh, after.koh))
+    if before.kil != after.kil:
+        diffs.append(FieldDiff("kil", before.kil, after.kil))
+    return tuple(diffs)
+
+
+def _diff_timers(before: TimerState, after: TimerState) -> Tuple[FieldDiff, ...]:
+    diffs: list[FieldDiff] = []
+    if before.enabled != after.enabled:
+        diffs.append(FieldDiff("enabled", before.enabled, after.enabled))
+    if before.next_mti != after.next_mti:
+        diffs.append(FieldDiff("next_mti", before.next_mti, after.next_mti))
+    if before.next_sti != after.next_sti:
+        diffs.append(FieldDiff("next_sti", before.next_sti, after.next_sti))
+    if before.mti_period != after.mti_period:
+        diffs.append(FieldDiff("mti_period", before.mti_period, after.mti_period))
+    if before.sti_period != after.sti_period:
+        diffs.append(FieldDiff("sti_period", before.sti_period, after.sti_period))
+    return tuple(diffs)
+
+
+def _diff_mapping(
+    prefix: str, before: Dict[str, int], after: Dict[str, int]
+) -> Iterable[FieldDiff]:
+    for key in sorted(set(before.keys()) | set(after.keys())):
+        previous = before.get(key)
+        current = after.get(key)
+        if previous != current:
+            yield FieldDiff(f"{prefix}.{key}", previous, current)
+
+
+__all__ = [
+    "CPUState",
+    "MemoryState",
+    "KeyboardState",
+    "TimerState",
+    "PeripheralState",
+    "EmulatorState",
+    "FieldDiff",
+    "StateDiff",
+    "capture_state",
+    "diff_states",
+    "empty_state_diff",
+]

--- a/pce500/tests/test_orchestrator.py
+++ b/pce500/tests/test_orchestrator.py
@@ -67,18 +67,19 @@ def test_step_advances_cpu_registers() -> None:
         _disable_interrupt_sources(orchestrator)
         orchestrator.emulator.cpu.regs.set(RegisterName.PC, 0xC0000)
 
-        initial = orchestrator.capture_snapshot()
-        assert initial.cpu.registers["pc"] == 0xC0000
+    initial = orchestrator.capture_snapshot()
+    assert initial.state.cpu.registers["pc"] == 0xC0000
 
-        first = orchestrator.step(
-            OrchestratorInputs(max_instructions=0, metadata={"tag": "noop"})
-        )
-        assert first.executed_instructions == 0
-        assert first.cycle_count == initial.cycle_count
-        assert first.metadata["tag"] == "noop"
+    first = orchestrator.step(
+        OrchestratorInputs(max_instructions=0, metadata={"tag": "noop"})
+    )
+    assert first.executed_instructions == 0
+    assert first.cycle_count == initial.cycle_count
+    assert first.metadata["tag"] == "noop"
+    assert first.diff.is_empty()
 
-        second = orchestrator.step(OrchestratorInputs(max_instructions=0))
-        assert second.cycle_count == first.cycle_count
+    second = orchestrator.step(OrchestratorInputs(max_instructions=0))
+    assert second.cycle_count == first.cycle_count
 
 
 def test_run_scenario_returns_snapshots_with_metadata() -> None:
@@ -98,12 +99,12 @@ def test_run_scenario_returns_snapshots_with_metadata() -> None:
         _disable_interrupt_sources(orchestrator)
         orchestrator.emulator.cpu.regs.set(RegisterName.PC, 0xC0000)
 
-        snapshots = orchestrator.run_scenario(steps, include_initial_snapshot=True)
-        assert len(snapshots) == 3
-        assert snapshots[0].executed_instructions == 0
-        assert "KEY_F1" in snapshots[1].keyboard.pressed_keys
-        assert snapshots[1].metadata["label"] == "press_pf1"
-        assert snapshots[2].executed_instructions == 1
+    snapshots = orchestrator.run_scenario(steps, include_initial_snapshot=True)
+    assert len(snapshots) == 3
+    assert snapshots[0].executed_instructions == 0
+    assert "KEY_F1" in snapshots[1].state.keyboard.pressed_keys
+    assert snapshots[1].metadata["label"] == "press_pf1"
+    assert snapshots[2].executed_instructions == 1
 
 
 def test_register_observer_receives_execution_events() -> None:

--- a/pce500/tests/test_state_model.py
+++ b/pce500/tests/test_state_model.py
@@ -1,0 +1,42 @@
+"""Tests for the canonical state snapshot and diff utilities."""
+
+from __future__ import annotations
+
+from sc62015.pysc62015.emulator import RegisterName
+
+from pce500.emulator import PCE500Emulator
+from pce500.state_model import (
+    FieldDiff,
+    capture_state,
+    diff_states,
+    empty_state_diff,
+)
+
+
+def test_capture_state_contains_core_components() -> None:
+    emu = PCE500Emulator(perfetto_trace=False)
+    state = capture_state(emu)
+
+    assert "pc" in state.cpu.registers
+    assert isinstance(state.memory.imr, int)
+    assert isinstance(state.keyboard.pressed_keys, tuple)
+    assert state.timers.mti_period > 0
+    # Serial snapshot should be captured even when idle.
+    assert hasattr(state.peripherals.serial, "ucr")
+
+
+def test_diff_states_detects_cpu_register_change() -> None:
+    emu = PCE500Emulator(perfetto_trace=False)
+    before = capture_state(emu)
+
+    emu.cpu.regs.set(RegisterName.A, 0x12)
+    after = capture_state(emu)
+
+    diff = diff_states(before, after)
+    assert not diff.is_empty()
+    assert FieldDiff("registers.a", before.cpu.registers["a"], 0x12) in diff.cpu
+
+
+def test_empty_state_diff_reports_no_changes() -> None:
+    diff = empty_state_diff()
+    assert diff.is_empty()


### PR DESCRIPTION
## Summary
- add `pce500.state_model` with immutable snapshots and structured diffs
- refactor `SnapshotOrchestrator` to emit `EmulatorState` and `StateDiff`
- cover new helpers with unit tests and document snapshot usage

## Testing
- uv run ruff format --check .
- uv run ruff check .
- uv run pytest

Fixes mblsha/binja-esr-tests#82
