### PR TITLE
Drop remaining compat naming

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,7 +244,7 @@ The web emulator (`web/`) provides a browser-based interface to the PC-E500 emul
 ### Architecture
 - **Backend**: Flask server (`app.py`) managing emulator state and providing REST API
 - **Frontend**: JavaScript SPA with virtual keyboard and real-time display updates
-- **Keyboard**: Single compat keyboard implementation (matrix via KOL/KOH/KIL)
+- **Keyboard**: Single keyboard handler implementation (matrix via KOL/KOH/KIL)
 
 ### Key Implementation Details
 
@@ -291,7 +291,7 @@ FORCE_BINJA_MOCK=1 python run_tests.py
 
 ## Keyboard Implementation Details
 
-The project uses a single compat keyboard implementation (`pce500/keyboard_compat.py`):
+The project uses a single keyboard handler implementation (`pce500/keyboard_handler.py`):
 - **Column Selection**: KOL (bits 0–7) and KOH (bits 0–2) control columns KO0–KO10 (active-high)
 - **Row Reading**: KIL returns row bits KI0–KI7 according to currently strobed columns
 - **Debouncing**: Queue-based press/release debouncing with configurable read thresholds

--- a/pce500/keyboard_handler.py
+++ b/pce500/keyboard_handler.py
@@ -1,4 +1,4 @@
-"""Compatibility wrapper around the deterministic keyboard matrix."""
+"""Keyboard handler wrapping the deterministic matrix implementation."""
 
 from __future__ import annotations
 

--- a/pce500/run_pce500.py
+++ b/pce500/run_pce500.py
@@ -254,7 +254,7 @@ def run_emulator(
                     # Consider latched so countdown can proceed without requiring a KIL read
                     latched_kil_seen = True
             elif press_when_col is not None:
-                # Column-based trigger using last observed KOL/KOH (compat mapping)
+                # Column-based trigger using last observed KOL/KOH (handler mapping)
                 kol = getattr(emu, "_last_kol", 0)
                 koh = getattr(emu, "_last_koh", 0)
                 active_cols = []
@@ -299,7 +299,7 @@ def run_emulator(
         if sweep_rows:
             koh = getattr(emu, "_last_koh", 0)
             kol = getattr(emu, "_last_kol", 0)
-            # Derive active columns for active-high mapping (compat):
+            # Derive active columns for active-high mapping (handler semantics):
             # KO0..KO7 from KOL bits 0..7, KO8..KO10 from KOH bits 0..2
             active_cols = []
             for col in range(8):
@@ -739,7 +739,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--press-when-col",
         type=int,
-        help="Press the auto key when this KO column becomes active (compat mapping)",
+        help="Press the auto key when this KO column becomes active (handler mapping)",
     )
     parser.add_argument(
         "--display-trace",

--- a/pce500/tests/test_keyboard_handler.py
+++ b/pce500/tests/test_keyboard_handler.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 
 from typing import List
-from pce500.keyboard_compat import PCE500KeyboardHandler
+from pce500.keyboard_handler import PCE500KeyboardHandler
 from pce500.keyboard_matrix import (
     FIFO_BASE,
     FIFO_HEAD_ADDR,

--- a/pce500/tools/analyze_keyboard_divergence.py
+++ b/pce500/tools/analyze_keyboard_divergence.py
@@ -23,8 +23,8 @@ class Divergence:
     """Represents a divergence between two traces."""
 
     op_num: int
-    compat_event: OpEvent
-    hardware_event: Optional[OpEvent]
+    baseline_event: OpEvent
+    comparison_event: Optional[OpEvent]
     time_delta_ms: float
     pc_diverged: bool
 
@@ -89,21 +89,21 @@ def analyze_with_simplified_approach():
     print("-" * 80)
 
     # From the execution output we know:
-    compat_stats = {
+    baseline_stats = {
         "instructions": 20000,  # Expected
         "time": "< 10s",
-        "implementation": "compat",
+        "implementation": "baseline",
     }
 
     # Historical hardware keyboard stats removed; project now uses a single keyboard
 
-    print("Keyboard (compat):")
-    print(f"  - Instructions executed: ~{compat_stats['instructions']}")
-    print(f"  - Time taken: {compat_stats['time']}")
+    print("Keyboard baseline:")
+    print(f"  - Instructions executed: ~{baseline_stats['instructions']}")
+    print(f"  - Time taken: {baseline_stats['time']}")
     print("  - Performance: ~2000+ instructions/second")
 
-    print("\nNote: Project now uses a single keyboard implementation (compat).")
-    print("Previous hardware-vs-compat divergence references are historical.")
+    print("\nNote: the project now uses a single keyboard handler implementation.")
+    print("Previous hardware-versus-baseline divergence references are historical.")
 
     print("\n" + "=" * 80)
     print("ANALYSIS:")
@@ -111,8 +111,8 @@ def analyze_with_simplified_approach():
 
     print("""
 Historic notes referenced a hardware keyboard variant being slower primarily
-due to CPU emulator instruction pipeline inefficiencies. The single compat
-keyboard remains, and optimization focus should be on the SC62015 pipeline.
+due to CPU emulator instruction pipeline inefficiencies. The single keyboard
+handler remains, and optimization focus should be on the SC62015 pipeline.
 """)
 
     print("\nTo see detailed trace analysis, open the traces in Perfetto UI:")
@@ -130,9 +130,9 @@ def main():
         description="Analyze keyboard performance divergence"
     )
     parser.add_argument(
-        "--compat",
-        default="emulator-profile-fast.perfetto-trace",
-        help="Path to compat keyboard trace (baseline)",
+        "--baseline",
+        default="emulator-profile-baseline.perfetto-trace",
+        help="Path to the baseline keyboard trace",
     )
     parser.add_argument(
         "--hardware",
@@ -149,12 +149,12 @@ def main():
     args = parser.parse_args()
 
     # Check files exist
-    compat_path = Path(args.compat)
+    baseline_path = Path(args.baseline)
     hardware_path = Path(args.hardware)
 
-    if not compat_path.exists():
-        print(f"Error: Compat trace not found: {compat_path}")
-        print("Please ensure you have the baseline trace from compat keyboard")
+    if not baseline_path.exists():
+        print(f"Error: Baseline trace not found: {baseline_path}")
+        print("Please ensure you have captured a reference keyboard trace")
         sys.exit(1)
 
     if not hardware_path.exists():
@@ -170,8 +170,8 @@ def main():
         print("\n" + "=" * 80)
         print("TRACE FILE INFO:")
         print("-" * 80)
-        print(f"Compat trace: {compat_path}")
-        parse_perfetto_trace(str(compat_path))
+        print(f"Baseline trace: {baseline_path}")
+        parse_perfetto_trace(str(baseline_path))
 
         print(f"Hardware trace: {hardware_path}")
         parse_perfetto_trace(str(hardware_path))

--- a/pce500/tools/debug_keyboard.py
+++ b/pce500/tools/debug_keyboard.py
@@ -10,7 +10,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 from pce500 import PCE500Emulator
 from sc62015.pysc62015.emulator import RegisterName
 
-# Create emulator (single compat keyboard implementation)
+# Create emulator (keyboard handler built into the emulator)
 print("Creating emulator...")
 emu = PCE500Emulator(
     trace_enabled=False,

--- a/pce500/tools/performance_findings.md
+++ b/pce500/tools/performance_findings.md
@@ -3,7 +3,7 @@
 ## Executive Summary
 Current performance limitations are primarily in the SC62015 CPU emulator’s
 instruction decoding/execution pipeline (excessive memory reads and re‑decoding).
-The project now uses a single keyboard implementation (compat); previous hardware
+The project now uses a single keyboard handler implementation; previous hardware
 keyboard comparisons are historical and not relevant to current code paths.
 
 ## Key Findings
@@ -56,7 +56,7 @@ The issue is in the SC62015 emulator's `execute_instruction` pipeline:
 - Pass decoded instruction data through the pipeline instead of re-fetching
 
 ## Keyboard
-The emulator uses a single compat keyboard implementation with debounced press/release.
+The emulator uses a single keyboard handler implementation with debounced press/release.
 Keyboard code is not the performance bottleneck; focus should remain on CPU pipeline
 optimizations listed above.
 

--- a/pce500/tools/trace_memory.py
+++ b/pce500/tools/trace_memory.py
@@ -22,7 +22,7 @@ class MemoryTracer:
         return self.original_read(address, cpu_pc)
 
 
-# Create emulator (single compat keyboard implementation)
+# Create emulator (default keyboard handler)
 print("Creating emulator...")
 emu = PCE500Emulator(
     trace_enabled=False,

--- a/web/README.md
+++ b/web/README.md
@@ -17,7 +17,7 @@ The web UI talks to a single emulator implementation:
 
 - **Flask Backend** (`app.py`): Manages the SC62015 + PC‑E500 emulator and provides REST API.
 - **JavaScript Frontend** (`static/app.js`): Interactive UI with state polling.
-- **Keyboard**: Handled by the emulator’s compat keyboard implementation (`pce500/keyboard_compat.py`). The web UI only calls API endpoints to press/release keys and to fetch debug/queue information.
+- **Keyboard**: Handled by the emulator’s keyboard handler implementation (`pce500/keyboard_handler.py`). The web UI only calls API endpoints to press/release keys and to fetch debug/queue information.
 
 ## Quick Start
 
@@ -82,17 +82,17 @@ This ensures responsive updates during both active computation and idle states.
 ### Keyboard Matrix
 
 The PC‑E500 uses a matrix scanning system with three registers:
-- `KOL` (0xF0): Key Output Low – selects columns KO0..KO7 (compat: active-high bits)
-- `KOH` (0xF1): Key Output High – selects columns KO8..KO10 via bits 0..2 (compat: active‑high bits)
+- `KOL` (0xF0): Key Output Low – selects columns KO0..KO7 (handler uses active-high bits)
+- `KOH` (0xF1): Key Output High – selects columns KO8..KO10 via bits 0..2 (handler uses active‑high bits)
 - `KIL` (0xF2): Key Input – reads rows KI0..KI7
 
-This project now uses a single “compat” keyboard implementation that simulates debounced
+This project now uses a single keyboard handler implementation that simulates debounced
 press/release behavior consistent with firmware scanning patterns. To adjust layout or
-debouncing, edit `pce500/keyboard_compat.py` (`KEYBOARD_LAYOUT`, `DEFAULT_*_READS`).
+debouncing, edit `pce500/keyboard_handler.py` (`KEYBOARD_LAYOUT`, `DEFAULT_*_READS`).
 
 ## Development
 
-- To modify the keyboard layout, edit `KEYBOARD_LAYOUT` in `pce500/keyboard_compat.py`.
+- To modify the keyboard layout, edit `KEYBOARD_LAYOUT` in `pce500/keyboard_handler.py`.
 - To adjust update rates, modify `UPDATE_TIME_THRESHOLD` and `UPDATE_INSTRUCTION_THRESHOLD` in `web/app.py`.
 
 ## Known Limitations

--- a/web/app.py
+++ b/web/app.py
@@ -112,7 +112,7 @@ def initialize_emulator():
 
     # Create emulator instance
     with emulator_lock:
-        # Use compat keyboard implementation
+        # Use the emulator's keyboard handler implementation
         # Enable lightweight opcode/disassembly tracing so Instruction History populates
         # (emulator maintains a bounded deque, so overhead remains reasonable)
         emulator = PCE500Emulator(

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -992,7 +992,7 @@ const REGISTER_DESCRIPTIONS = {
     'PY': 'RAM PY Pointer - Y pointer for indexed addressing',
     'AMC': 'Address Modify Control - Virtually joins CE0/CE1 RAM regions',
     
-    // Keyboard I/O (compat keyboard semantics)
+    // Keyboard I/O (emulator keyboard handler semantics)
     'KOL': 'Key Output Low (KO0–KO7) - Selects columns (active-high)',
     'KOH': 'Key Output High (KO8–KO10 via bits 0–2) - Selects columns (active-high)',
     'KIL': 'Key Input (KI0–KI7) - Reads keyboard matrix rows',


### PR DESCRIPTION
## Summary
- rename `keyboard_compat.py` to `keyboard_handler.py` and update importing call sites
- scrub docs, tools, and web UI comments that referenced the old compat layer
- keep behavioural logic unchanged while clarifying the single handler terminology

## Testing
- uv run pytest
