### PR TITLE
Fix web emulator backend lifecycle

### DIFF
--- a/pce500/emulator.py
+++ b/pce500/emulator.py
@@ -680,6 +680,30 @@ class PCE500Emulator:
         if self._new_trace_enabled and new_tracer.enabled:
             print(f"Stopping new tracing, saved to {self._trace_path}")
             new_tracer.stop()
+        self._new_trace_enabled = False
+
+    def start_tracing(self, path: Optional[str] = None) -> None:
+        """Enable instruction tracing to the provided path."""
+        if path:
+            self._trace_path = path
+        self._new_trace_enabled = True
+        if not new_tracer.enabled:
+            new_tracer.start(self._trace_path)
+
+    @property
+    def tracing_enabled(self) -> bool:
+        """Return ``True`` when instruction tracing is active."""
+        return self._new_trace_enabled and new_tracer.enabled
+
+    def get_keyboard_register_state(self) -> Dict[str, int]:
+        """Expose current keyboard matrix register values."""
+        if not hasattr(self, "keyboard"):
+            return {"kol": 0, "koh": 0, "kil": 0}
+        keyboard = self.keyboard
+        kol = keyboard.kol_value if hasattr(keyboard, "kol_value") else 0
+        koh = keyboard.koh_value if hasattr(keyboard, "koh_value") else 0
+        kil = keyboard.peek_keyboard_input()
+        return {"kol": kol & 0xFF, "koh": koh & 0xFF, "kil": kil & 0xFF}
 
     def __enter__(self):
         return self

--- a/web/README.md
+++ b/web/README.md
@@ -15,7 +15,7 @@ A web-based emulator for the Sharp PC-E500 pocket computer, built with Flask and
 
 The web UI talks to a single emulator implementation:
 
-- **Flask Backend** (`app.py`): Manages the SC62015 + PC‑E500 emulator and provides REST API.
+- **Flask Backend** (`app.py` + `emulator_service.py`): Provides the REST API and manages a shared emulator instance, including lifecycle, tracing and paced execution.
 - **JavaScript Frontend** (`static/app.js`): Interactive UI with state polling.
 - **Keyboard**: Handled by the emulator’s keyboard handler implementation (`pce500/keyboard_handler.py`). The web UI only calls API endpoints to press/release keys and to fetch debug/queue information.
 
@@ -33,6 +33,10 @@ The web UI talks to a single emulator implementation:
    ```
 
 3. Open your browser to `http://localhost:8080`
+
+### Configuration
+
+- By default the API is same-origin only. To opt into cross-origin requests set `PCE500_WEB_ALLOWED_ORIGINS` (comma-separated) or configure `WEB_ALLOWED_ORIGINS` in Flask config before importing `app`.
 
 ## API Endpoints
 
@@ -73,11 +77,11 @@ The virtual keyboard mimics the PC-E500's physical layout. You can also use your
 
 ### Update Logic
 
-The emulator state updates when either condition is met:
+The emulator service emits state snapshots when either condition is met:
 - 100ms have elapsed (10 FPS target)
 - 100,000 instructions have executed
 
-This ensures responsive updates during both active computation and idle states.
+This ensures responsive updates during both active computation and idle states while avoiding CPU spin.
 
 ### Keyboard Matrix
 
@@ -93,7 +97,7 @@ debouncing, edit `pce500/keyboard_handler.py` (`KEYBOARD_LAYOUT`, `DEFAULT_*_REA
 ## Development
 
 - To modify the keyboard layout, edit `KEYBOARD_LAYOUT` in `pce500/keyboard_handler.py`.
-- To adjust update rates, modify `UPDATE_TIME_THRESHOLD` and `UPDATE_INSTRUCTION_THRESHOLD` in `web/app.py`.
+- To adjust update rates, modify `UPDATE_TIME_THRESHOLD` and `UPDATE_INSTRUCTION_THRESHOLD` in `web/emulator_service.py`.
 
 ## Known Limitations
 

--- a/web/app.py
+++ b/web/app.py
@@ -1,305 +1,59 @@
 """Flask backend for PC-E500 web emulator."""
 
-import base64
-import io
+from __future__ import annotations
+
+import os
 import sys
-import threading
-import time
 from pathlib import Path
-from typing import Optional
 
 from flask import (
     Flask,
     jsonify,
-    request,
     render_template,
-    send_from_directory,
+    request,
     send_file,
+    send_from_directory,
 )
 from flask_cors import CORS
-from sc62015.pysc62015.instr.opcodes import IMEMRegisters
-from sc62015.pysc62015.constants import IMRFlag, INTERNAL_MEMORY_START
-from PIL import Image, ImageOps
+from PIL import Image, ImageOps  # type: ignore
 
-# Add parent directory to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent))
-from pce500 import PCE500Emulator
-from pce500.tracing.perfetto_tracing import tracer as perfetto_tracer
+# Ensure imports work when running as a module or script
+CURRENT_DIR = Path(__file__).parent
+PARENT_DIR = CURRENT_DIR.parent
+if str(CURRENT_DIR) not in sys.path:
+    sys.path.insert(0, str(CURRENT_DIR))
+if str(PARENT_DIR) not in sys.path:
+    sys.path.insert(0, str(PARENT_DIR))
+
+try:  # pragma: no cover - exercised under WSGI
+    from .emulator_service import TRACE_PATH, init_app, service
+except ImportError:  # pragma: no cover - direct script execution
+    from emulator_service import TRACE_PATH, init_app, service  # type: ignore
 
 app = Flask(__name__)
-CORS(app)  # Enable CORS for API endpoints
 
-# Global emulator instance and control state
-emulator: Optional[PCE500Emulator] = None
-emulator_lock = threading.Lock()
-emulator_thread: Optional[threading.Thread] = None
-emulator_state = {
-    "is_running": False,
-    "last_update_time": 0,
-    "last_update_instructions": 0,
-    "screen": None,
-    "registers": {},
-    "flags": {},
-    "instruction_count": 0,
-    "instruction_history": [],
-    "speed_calc_time": None,
-    "speed_calc_instructions": None,
-    "emulation_speed": None,
-    "speed_ratio": None,
-}
-
-# Update thresholds
-UPDATE_TIME_THRESHOLD = 0.1  # 100ms (10fps)
-UPDATE_INSTRUCTION_THRESHOLD = 100000  # 100k instructions
-
-# Trace file path
-TRACE_PATH = "pc-e500.perfetto-trace"
-
-
-def _calculate_emulation_speed(
-    previous_time: Optional[float],
-    previous_instructions: Optional[int],
-    current_time: float,
-    current_instructions: int,
-) -> tuple[float, float]:
-    """Compute emulator speed metrics.
-
-    This isolates the instruction-per-second calculation that was previously
-    embedded directly inside :func:`update_emulator_state`.  Having the logic in
-    a helper keeps the update function focused on assembling state data instead
-    of juggling nested conditionals and repeated ``speed = 0`` assignments.
-    """
-
-    if previous_time is None or previous_instructions is None:
-        return 0.0, 0.0
-
-    time_delta = current_time - previous_time
-    if time_delta <= 0:
-        return 0.0, 0.0
-
-    speed = (current_instructions - previous_instructions) / time_delta
-    return speed, speed / 2_000_000
-
-
-def initialize_emulator():
-    """Initialize the PC-E500 emulator with ROM."""
-    global emulator
-
-    # Load ROM file
-    rom_path = Path(__file__).parent.parent / "data" / "pc-e500.bin"
-
-    # For testing, create a minimal ROM if the file doesn't exist
-    if not rom_path.exists():
-        # Create a minimal test ROM with a simple program
-        # This is enough to allow the emulator to initialize
-        rom_data = bytearray(0x100000)  # 1MB
-        # Set entry point at 0xFFFFD to 0xC0000 (start of ROM)
-        rom_data[0xFFFFD] = 0x00
-        rom_data[0xFFFFE] = 0x00
-        rom_data[0xFFFFF] = 0x0C
-        # Add a HALT instruction at 0xC0000
-        rom_data[0xC0000] = 0x00  # HALT opcode
+# Restrict CORS by default; allow opt-in via config/env
+allowed_origins = app.config.get("WEB_ALLOWED_ORIGINS") or os.environ.get(
+    "PCE500_WEB_ALLOWED_ORIGINS"
+)
+if allowed_origins:
+    if isinstance(allowed_origins, str):
+        origins = [
+            origin.strip() for origin in allowed_origins.split(",") if origin.strip()
+        ]
     else:
-        with open(rom_path, "rb") as f:
-            rom_data = f.read()
-
-    # Extract the ROM portion from 0xC0000-0x100000 (256KB)
-    # The pc-e500.bin file is a full 1MB dump, but the ROM is only the last 256KB
-    if len(rom_data) >= 0x100000:
-        rom_portion = rom_data[0xC0000:0x100000]
-    else:
-        rom_portion = rom_data  # If file is smaller, use as-is
-
-    # Create emulator instance
-    with emulator_lock:
-        # Use the emulator's keyboard handler implementation
-        # Enable lightweight opcode/disassembly tracing so Instruction History populates
-        # (emulator maintains a bounded deque, so overhead remains reasonable)
-        emulator = PCE500Emulator(
-            trace_enabled=True,
-            perfetto_trace=False,
-            save_lcd_on_exit=False,
-        )
-        emulator.load_rom(rom_portion)
-
-        # Reset to properly set PC from the now-loaded ROM entry point
-        emulator.reset()
-
-        # Update initial state
-        update_emulator_state()
+        origins = allowed_origins
+    if origins:
+        CORS(app, resources={r"/api/*": {"origins": origins}})
 
 
-def update_emulator_state():
-    """Capture current emulator state for API responses."""
-    global emulator_state
-
-    if emulator is None:
-        return
-
-    # Get CPU state
-    cpu_state = emulator.get_cpu_state()
-
-    # Get screen as PNG
-    lcd_image = emulator.lcd.get_combined_display(zoom=1)  # 240x32 pixels
-
-    # Convert PIL image to base64 PNG
-    img_buffer = io.BytesIO()
-    lcd_image.save(img_buffer, format="PNG")
-    img_buffer.seek(0)
-    screen_base64 = base64.b64encode(img_buffer.getvalue()).decode("utf-8")
-
-    # Calculate emulation speed
-    current_time = time.time()
-    current_instructions = emulator.instruction_count
-
-    prev_time = emulator_state.get("speed_calc_time")
-    prev_instructions = emulator_state.get("speed_calc_instructions")
-
-    if emulator_state["is_running"]:
-        speed, speed_ratio = _calculate_emulation_speed(
-            prev_time,
-            prev_instructions,
-            current_time,
-            current_instructions,
-        )
-        emulator_state["emulation_speed"] = speed
-        emulator_state["speed_ratio"] = speed_ratio
-    else:
-        # Not running, clear speed
-        emulator_state["emulation_speed"] = None
-        emulator_state["speed_ratio"] = None
-
-    # Update tracking values
-    emulator_state["speed_calc_time"] = current_time
-    emulator_state["speed_calc_instructions"] = current_instructions
-
-    # Update state dictionary
-    emulator_state.update(
-        {
-            "screen": f"data:image/png;base64,{screen_base64}",
-            "registers": {
-                "pc": cpu_state["pc"],
-                "a": cpu_state["a"],
-                "b": cpu_state["b"],
-                "ba": cpu_state["ba"],
-                "i": cpu_state["i"],
-                "x": cpu_state["x"],
-                "y": cpu_state["y"],
-                "u": cpu_state["u"],
-                "s": cpu_state["s"],
-            },
-            "flags": {"z": cpu_state["flags"]["z"], "c": cpu_state["flags"]["c"]},
-            "instruction_count": emulator.instruction_count,
-            "instruction_history": list(emulator.instruction_history),
-            "last_update_time": current_time,
-            "last_update_instructions": current_instructions,
-            # Interrupt stats (if available) + current IMR/ISR bits
-            "interrupts": (
-                emulator.get_interrupt_stats()
-                if hasattr(emulator, "get_interrupt_stats")
-                else None
-            ),
-        }
-    )
-    # Enrich interrupts with IMR/ISR flag info
-    try:
-        ints = emulator_state.get("interrupts") or {}
-        imr_val = (
-            emulator.memory.read_byte(INTERNAL_MEMORY_START + IMEMRegisters.IMR) & 0xFF
-        )
-        isr_val = (
-            emulator.memory.read_byte(INTERNAL_MEMORY_START + IMEMRegisters.ISR) & 0xFF
-        )
-        irm = 1 if (imr_val & int(IMRFlag.IRM)) else 0
-        keym = 1 if (imr_val & int(IMRFlag.KEYM)) else 0
-        isr_key = 1 if (isr_val & int(IMRFlag.KEYM)) else 0
-        pending = bool(getattr(emulator, "_irq_pending", False))
-        ints.update(
-            {
-                "imr": f"0x{imr_val:02X}",
-                "isr": f"0x{isr_val:02X}",
-                "irm": irm,
-                "keym": keym,
-                "isr_key": isr_key,
-                "pending": pending,
-            }
-        )
-        emulator_state["interrupts"] = ints
-    except Exception:
-        pass
+def initialize_emulator() -> None:
+    """Legacy helper used by tests/CLI."""
+    service.ensure_emulator()
 
 
-@app.route("/api/v1/ocr", methods=["GET"])
-def get_ocr_text():
-    """Return OCR text extracted from the current LCD image.
-
-    Polling target is ~2 Hz from the UI when the emulator is running.
-    """
-    global emulator
-    with emulator_lock:
-        if emulator is None:
-            return jsonify({"ok": False, "error": "Emulator not initialized"}), 500
-        try:
-            img = emulator.lcd.get_combined_display(zoom=1)
-        except Exception as e:
-            return jsonify({"ok": False, "error": f"Failed to capture LCD: {e}"}), 500
-
-    # Preprocess image for OCR
-    try:
-        import pytesseract  # type: ignore
-    except Exception as e:
-        return jsonify(
-            {"ok": False, "error": f"pytesseract not available: {e}", "text": ""}
-        ), 200
-
-    try:
-        im = img.convert("L")
-        # Add a small white border and upscale to help OCR
-        im = ImageOps.expand(im, border=4, fill=255)
-        im = im.resize((im.width * 3, im.height * 3), Image.LANCZOS)
-        # Binarize quickly
-        im = im.point(lambda v: 255 if v > 128 else 0, mode="1")
-        text = pytesseract.image_to_string(im, config="--psm 3")
-        return jsonify({"ok": True, "text": text})
-    except Exception as e:
-        return jsonify({"ok": False, "error": f"OCR failed: {e}", "text": ""}), 200
-
-
-def emulator_run_loop():
-    """Background thread for running the emulator."""
-    global emulator_state
-
-    while emulator_state["is_running"]:
-        if emulator is None:
-            break
-
-        with emulator_lock:
-            try:
-                # Execute one instruction
-                emulator.step()
-
-                # Check if we should update state
-                current_time = time.time()
-                current_instructions = emulator.instruction_count
-
-                time_delta = current_time - emulator_state["last_update_time"]
-                instruction_delta = (
-                    current_instructions - emulator_state["last_update_instructions"]
-                )
-
-                if (
-                    time_delta >= UPDATE_TIME_THRESHOLD
-                    or instruction_delta >= UPDATE_INSTRUCTION_THRESHOLD
-                ):
-                    update_emulator_state()
-
-            except Exception as e:
-                print(f"Emulator error: {e}")
-                emulator_state["is_running"] = False
-                break
-
-        # Small delay to prevent CPU spinning too fast
-        time.sleep(0.0001)
+# Ensure emulator is ready under WSGI servers
+init_app(app)
 
 
 @app.route("/")
@@ -310,75 +64,77 @@ def index():
 
 @app.route("/api/v1/state", methods=["GET"])
 def get_state():
-    """Get current emulator state."""
-    with emulator_lock:
-        # Always update state when explicitly requested
-        if emulator is not None:
-            update_emulator_state()
-
-        return jsonify(emulator_state)
+    """Return current emulator state snapshot."""
+    state = service.snapshot_state()
+    return jsonify(state)
 
 
 @app.route("/api/v1/key", methods=["POST"])
 def handle_key():
     """Handle keyboard input."""
-    data = request.get_json()
-    if not data or "key_code" not in data:
+    data = request.get_json() or {}
+    key_code = data.get("key_code")
+    if not key_code:
         return jsonify({"error": "Missing key_code"}), 400
 
-    key_code = data["key_code"]
-    action = data.get("action", "press")  # 'press' or 'release'
-
-    with emulator_lock:
-        if emulator is None:
-            return jsonify({"error": "Emulator not initialized"}), 500
-
-        try:
-            key_queued = False
-            if action == "press":
-                key_queued = emulator.press_key(key_code)
-                if key_queued:
-                    print(f"Key pressed and queued: {key_code}")
-                else:
-                    print(
-                        f"Key press ignored (not mapped or already queued): {key_code}"
-                    )
-            elif action == "release":
-                # Ignore release if key isn't currently pressed to avoid noise from hover events
-                try:
-                    currently_pressed = set()
-                    if hasattr(emulator, "keyboard"):
-                        kb = emulator.keyboard
-                        if hasattr(kb, "pressed_keys"):
-                            currently_pressed = set(kb.pressed_keys)  # type: ignore[attr-defined]
-                        elif hasattr(kb, "get_pressed_keys"):
-                            currently_pressed = set(kb.get_pressed_keys())  # type: ignore[attr-defined]
-                    if key_code in currently_pressed:
-                        emulator.release_key(key_code)
-                        print(f"Key released: {key_code}")
-                    else:
-                        # Silently ignore spurious release
-                        pass
-                except Exception:
-                    emulator.release_key(key_code)
-            else:
-                return jsonify({"error": f"Invalid action: {action}"}), 400
-
-            # Return debug info for development
-            debug_info = emulator.keyboard.get_debug_info()
-            return jsonify(
-                {
-                    "status": "ok",
-                    "key_queued": key_queued if action == "press" else None,
-                    "message": f"Key {key_code} {'queued' if key_queued else 'not queued (unmapped or already pressed)'}"
-                    if action == "press"
-                    else f"Key {key_code} released",
-                    "debug": debug_info,
-                }
+    action = data.get("action", "press")
+    try:
+        if action == "press":
+            queued = service.press_key(key_code)
+            message = (
+                f"Key {key_code} queued"
+                if queued
+                else f"Key {key_code} not queued (unmapped or already pressed)"
             )
+        elif action == "release":
+            debug_snapshot = service.keyboard_debug_info()
+            pressed = set(debug_snapshot.get("pressed_keys", []))
+            if key_code in pressed:
+                service.release_key(key_code)
+                message = f"Key {key_code} released"
+            else:
+                message = f"Key {key_code} release ignored"
+            queued = None
+        else:
+            return jsonify({"error": f"Invalid action: {action}"}), 400
+    except Exception as exc:  # pragma: no cover - defensive
+        return jsonify({"error": str(exc)}), 500
 
-        except Exception as e:
-            return jsonify({"error": str(e)}), 500
+    debug_info = service.keyboard_debug_info()
+    return jsonify(
+        {
+            "status": "ok",
+            "key_queued": queued,
+            "message": message,
+            "debug": debug_info,
+        }
+    )
+
+
+@app.route("/api/v1/ocr", methods=["GET"])
+def get_ocr_text():
+    """Return OCR text extracted from the current LCD image."""
+    try:
+        img = service.capture_lcd_image()
+    except Exception as exc:
+        return jsonify({"ok": False, "error": f"Failed to capture LCD: {exc}"}), 500
+
+    try:
+        import pytesseract  # type: ignore
+    except Exception as exc:  # pragma: no cover - optional dependency
+        return jsonify(
+            {"ok": False, "error": f"pytesseract not available: {exc}", "text": ""}
+        ), 200
+
+    try:
+        im = img.convert("L")
+        im = ImageOps.expand(im, border=4, fill=255)
+        im = im.resize((im.width * 3, im.height * 3), Image.LANCZOS)
+        im = im.point(lambda v: 255 if v > 128 else 0, mode="1")
+        text = pytesseract.image_to_string(im, config="--psm 3")
+        return jsonify({"ok": True, "text": text})
+    except Exception as exc:  # pragma: no cover - OCR best effort
+        return jsonify({"ok": False, "error": f"OCR failed: {exc}", "text": ""}), 200
 
 
 @app.route("/api/v1/lcd_debug", methods=["GET"])
@@ -386,200 +142,74 @@ def get_lcd_debug():
     """Get PC source for a specific LCD pixel."""
     x = request.args.get("x", type=int)
     y = request.args.get("y", type=int)
-
     if x is None or y is None:
         return jsonify({"error": "Missing x or y parameter"}), 400
-
     if not (0 <= x < 240 and 0 <= y < 32):
         return jsonify({"error": "Coordinates out of range"}), 400
 
-    with emulator_lock:
-        if emulator is None:
-            return jsonify({"error": "Emulator not initialized"}), 500
-
-        pc_source = emulator.lcd.get_pixel_pc_source(x, y)
-        return jsonify({"pc": f"0x{pc_source:06X}" if pc_source is not None else None})
+    pc_source = service.lcd_debug(x, y)
+    return jsonify({"pc": f"0x{pc_source:06X}" if pc_source is not None else None})
 
 
 @app.route("/api/v1/imem_watch", methods=["GET"])
 def get_imem_watch():
     """Get IMEM register access tracking data."""
-    with emulator_lock:
-        if emulator is None:
-            return jsonify({"error": "Emulator not initialized"}), 500
-
-        tracking_data = emulator.memory.get_imem_access_tracking()
-
-        # Format the data for the API response
-        result = {}
-        for reg_name, accesses in tracking_data.items():
-            result[reg_name] = {
-                "reads": [
-                    {"pc": f"0x{pc:06X}", "count": count}
-                    for pc, count in accesses["reads"]
-                ],
-                "writes": [
-                    {"pc": f"0x{pc:06X}", "count": count}
-                    for pc, count in accesses["writes"]
-                ],
-            }
-
-        return jsonify(result)
+    return jsonify(service.imem_watch())
 
 
 @app.route("/api/v1/lcd_stats", methods=["GET"])
 def get_lcd_stats():
     """Get LCD controller statistics."""
-    with emulator_lock:
-        if emulator is None:
-            return jsonify({"error": "Emulator not initialized"}), 500
-
-        # Get chip select counts
-        chip_select_stats = {
-            "both": emulator.lcd.cs_both_count,
-            "left": emulator.lcd.cs_left_count,
-            "right": emulator.lcd.cs_right_count,
-        }
-
-        # Get per-chip statistics
-        chip_stats = emulator.lcd.get_chip_statistics()
-
-        return jsonify({"chip_select": chip_select_stats, "chips": chip_stats})
+    return jsonify(service.lcd_stats())
 
 
 @app.route("/api/v1/key_queue", methods=["GET"])
 def get_key_queue():
     """Get keyboard queue state."""
-    with emulator_lock:
-        if emulator is None:
-            return jsonify({"error": "Emulator not initialized"}), 500
-
-        # Get key queue info
-        queue_info = emulator.keyboard.get_queue_info()
-
-        # Get current KOL/KOH/KIL values
-        keyboard_state = {
-            "kol": f"0x{emulator.keyboard._last_kol:02X}",
-            "koh": f"0x{emulator.keyboard._last_koh:02X}",
-            "kil": f"0x{emulator.keyboard.peek_keyboard_input():02X}",
-        }
-
-        return jsonify({"queue": queue_info, "registers": keyboard_state})
+    queue_info = service.keyboard_queue()
+    keyboard_state = service.keyboard_register_state()
+    return jsonify({"queue": queue_info, "registers": keyboard_state})
 
 
 @app.route("/api/v1/control", methods=["POST"])
 def control_emulator():
     """Control emulator execution (run/pause/step/reset)."""
-    global emulator_thread, emulator_state
-
-    data = request.get_json()
-    if not data or "command" not in data:
+    data = request.get_json() or {}
+    command = data.get("command")
+    if not command:
         return jsonify({"error": "Missing command"}), 400
 
-    command = data["command"]
+    if command == "run":
+        service.run()
+        return jsonify({"status": "running"})
+    if command == "pause":
+        service.pause()
+        return jsonify({"status": "paused"})
+    if command == "step":
+        state = service.snapshot_state()
+        if not state.get("is_running"):
+            service.step()
+        return jsonify({"status": "stepped"})
+    if command == "reset":
+        service.reset()
+        return jsonify({"status": "reset", "is_running": True})
 
-    # We'll do minimal critical sections to avoid deadlocks with the run loop
-    join_needed = False
-    thread_to_join = None
-    response = None
-    with emulator_lock:
-        if emulator is None and command != "reset":
-            response = (jsonify({"error": "Emulator not initialized"}), 500)
-        elif command == "run":
-            if not emulator_state["is_running"]:
-                emulator_state["is_running"] = True
-                emulator_thread = threading.Thread(target=emulator_run_loop)
-                emulator_thread.start()
-            response = jsonify({"status": "running"})
-        elif command == "pause":
-            emulator_state["is_running"] = False
-            # Clear speed tracking
-            emulator_state["speed_calc_time"] = None
-            emulator_state["speed_calc_instructions"] = None
-            if emulator_thread:
-                # Defer join until after releasing the lock to avoid deadlock
-                thread_to_join = emulator_thread
-                join_needed = True
-                emulator_thread = None
-            response = jsonify({"status": "paused"})
-        elif command == "step":
-            if not emulator_state["is_running"]:
-                emulator.step()
-                update_emulator_state()
-            response = jsonify({"status": "stepped"})
-        elif command == "reset":
-            # Stop running if active
-            emulator_state["is_running"] = False
-            # Clear speed tracking
-            emulator_state["speed_calc_time"] = None
-            emulator_state["speed_calc_instructions"] = None
-            if emulator_thread:
-                # Defer join to outside lock
-                thread_to_join = emulator_thread
-                join_needed = True
-                emulator_thread = None
-
-            # Reset or reinitialize emulator
-            if emulator:
-                emulator.reset()
-            else:
-                initialize_emulator()
-
-            # Immediately start running after reset
-            emulator_state["is_running"] = True
-            update_emulator_state()
-
-            # Start background run loop
-            def _start_thread():
-                global emulator_thread
-                emulator_thread = threading.Thread(target=emulator_run_loop)
-                emulator_thread.start()
-
-            _start_thread()
-            response = jsonify({"status": "reset", "is_running": True})
-        else:
-            response = (jsonify({"error": f"Unknown command: {command}"}), 400)
-    # Perform join outside the emulator_lock critical section
-    if join_needed and thread_to_join:
-        thread_to_join.join()
-    return response
+    return jsonify({"error": f"Unknown command: {command}"}), 400
 
 
 @app.route("/trace/start", methods=["POST"])
 def trace_start():
     """Start Perfetto tracing."""
-    global emulator
-
-    with emulator_lock:
-        if emulator and not perfetto_tracer.enabled:
-            # Enable tracing in the emulator
-            emulator._new_trace_enabled = True
-            emulator._trace_path = TRACE_PATH
-            perfetto_tracer.start(TRACE_PATH)
-            return jsonify({"ok": True, "enabled": True, "path": TRACE_PATH})
-        elif perfetto_tracer.enabled:
-            return jsonify(
-                {
-                    "ok": True,
-                    "enabled": True,
-                    "path": TRACE_PATH,
-                    "message": "Already tracing",
-                }
-            )
-        else:
-            return jsonify({"ok": False, "error": "Emulator not initialized"}), 500
+    result = service.start_trace()
+    status = 200 if result.get("ok") else 500
+    return jsonify(result), status
 
 
 @app.route("/trace/stop", methods=["POST"])
 def trace_stop():
     """Stop Perfetto tracing."""
-    if perfetto_tracer.enabled:
-        perfetto_tracer.stop()
-        return jsonify({"ok": True, "enabled": False, "path": TRACE_PATH})
-    else:
-        return jsonify(
-            {"ok": True, "enabled": False, "message": "Not currently tracing"}
-        )
+    result = service.stop_trace()
+    return jsonify(result)
 
 
 @app.route("/trace/download", methods=["GET"])
@@ -590,20 +220,13 @@ def trace_download():
         return send_file(
             str(trace_file), as_attachment=True, download_name="pc-e500.perfetto-trace"
         )
-    else:
-        return jsonify({"error": "Trace file not found"}), 404
+    return jsonify({"error": "Trace file not found"}), 404
 
 
 @app.route("/trace/status", methods=["GET"])
 def trace_status():
     """Get current trace status."""
-    return jsonify(
-        {
-            "enabled": perfetto_tracer.enabled,
-            "path": TRACE_PATH,
-            "file_exists": Path(TRACE_PATH).exists(),
-        }
-    )
+    return jsonify(service.trace_status())
 
 
 @app.route("/static/<path:filename>")
@@ -613,12 +236,7 @@ def static_files(filename):
 
 
 if __name__ == "__main__":
-    # Initialize emulator on startup
-    try:
-        initialize_emulator()
-        print("PC-E500 emulator initialized successfully")
-    except Exception as e:
-        print(f"Failed to initialize emulator: {e}")
-
-    # Run Flask app
+    initialize_emulator()
+    print("PC-E500 emulator initialized successfully")
+    print("Starting web server at http://localhost:8080")
     app.run(debug=True, host="0.0.0.0", port=8080)

--- a/web/emulator_service.py
+++ b/web/emulator_service.py
@@ -1,0 +1,424 @@
+"""Shared emulator lifecycle management for the web API."""
+
+from __future__ import annotations
+
+import base64
+import io
+import threading
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Dict, Optional
+
+from pce500 import PCE500Emulator
+from pce500.tracing.perfetto_tracing import tracer as perfetto_tracer
+from sc62015.pysc62015.constants import IMRFlag, INTERNAL_MEMORY_START
+from sc62015.pysc62015.instr.opcodes import IMEMRegisters
+
+RUN_BATCH_INSTRUCTIONS = 5_000
+RUN_SLEEP_SECONDS = 0.002
+TRACE_PATH = "pc-e500.perfetto-trace"
+
+
+class EmulatorService:
+    """Manage a shared emulator instance and background execution."""
+
+    UPDATE_TIME_THRESHOLD = 0.1
+    UPDATE_INSTRUCTION_THRESHOLD = 100_000
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._emulator: Optional[PCE500Emulator] = None
+        self._state: Dict[str, object] = self._initial_state()
+        self._run_event = threading.Event()
+        self._shutdown = threading.Event()
+        self._runner_thread: Optional[threading.Thread] = None
+
+    @staticmethod
+    def _initial_state() -> Dict[str, object]:
+        return {
+            "is_running": False,
+            "last_update_time": 0.0,
+            "last_update_instructions": 0,
+            "screen": None,
+            "registers": {},
+            "flags": {},
+            "instruction_count": 0,
+            "instruction_history": [],
+            "speed_calc_time": None,
+            "speed_calc_instructions": None,
+            "emulation_speed": None,
+            "speed_ratio": None,
+            "interrupts": None,
+        }
+
+    # ------------------------------------------------------------------ #
+    # Lifecycle
+    # ------------------------------------------------------------------ #
+
+    def ensure_emulator(self) -> PCE500Emulator:
+        """Return an initialised emulator, creating it if necessary."""
+        with self._lock:
+            if self._emulator is None:
+                self._emulator = self._create_emulator()
+            return self._emulator
+
+    def _create_emulator(self) -> PCE500Emulator:
+        rom_path = Path(__file__).parent.parent / "data" / "pc-e500.bin"
+
+        if not rom_path.exists():
+            rom_data = bytearray(0x100000)
+            rom_data[0xFFFFD] = 0x00
+            rom_data[0xFFFFE] = 0x00
+            rom_data[0xFFFFF] = 0x0C
+            rom_data[0xC0000] = 0x00
+        else:
+            with open(rom_path, "rb") as fh:
+                rom_data = fh.read()
+
+        if len(rom_data) >= 0x100000:
+            rom_portion = rom_data[0xC0000:0x100000]
+        else:
+            rom_portion = rom_data
+
+        emulator = PCE500Emulator(
+            trace_enabled=True,
+            perfetto_trace=False,
+            save_lcd_on_exit=False,
+        )
+        emulator.load_rom(rom_portion)
+        emulator.reset()
+        self._update_state_locked(emulator, force=True)
+        return emulator
+
+    def shutdown(self) -> None:
+        """Stop the run thread and release resources."""
+        self._shutdown.set()
+        self._run_event.clear()
+        if self._runner_thread and self._runner_thread.is_alive():
+            self._runner_thread.join(timeout=1.0)
+        with self._lock:
+            if self._emulator:
+                self._emulator.stop_tracing()
+            self._emulator = None
+            self._state = self._initial_state()
+
+    # ------------------------------------------------------------------ #
+    # Runner management
+    # ------------------------------------------------------------------ #
+
+    def run(self) -> None:
+        """Start continuous execution."""
+        self.ensure_emulator()
+        with self._lock:
+            self._state["is_running"] = True
+            self._state["speed_calc_time"] = None
+            self._state["speed_calc_instructions"] = None
+            self._state["emulation_speed"] = None
+            self._state["speed_ratio"] = None
+        self._run_event.set()
+        if not self._runner_thread or not self._runner_thread.is_alive():
+            self._runner_thread = threading.Thread(
+                target=self._runner_loop, name="PCE500Runner", daemon=True
+            )
+            self._runner_thread.start()
+
+    def pause(self) -> None:
+        """Pause continuous execution."""
+        self._run_event.clear()
+        with self._lock:
+            self._state["is_running"] = False
+            self._state["speed_calc_time"] = None
+            self._state["speed_calc_instructions"] = None
+
+    def step(self) -> None:
+        """Execute a single instruction."""
+        with self._lock:
+            emulator = self.ensure_emulator()
+            emulator.step()
+            self._update_state_locked(emulator, force=True)
+
+    def reset(self) -> None:
+        """Reset emulator and resume running."""
+        with self._lock:
+            emulator = self.ensure_emulator()
+            emulator.reset()
+            self._update_state_locked(emulator, force=True)
+            self._state["is_running"] = True
+            self._state["speed_calc_time"] = None
+            self._state["speed_calc_instructions"] = None
+        self._run_event.set()
+        if not self._runner_thread or not self._runner_thread.is_alive():
+            self._runner_thread = threading.Thread(
+                target=self._runner_loop, name="PCE500Runner", daemon=True
+            )
+            self._runner_thread.start()
+
+    def _runner_loop(self) -> None:
+        """Background loop for paced execution."""
+        while not self._shutdown.is_set():
+            if not self._run_event.wait(timeout=0.1):
+                continue
+            while self._run_event.is_set() and not self._shutdown.is_set():
+                with self._lock:
+                    emulator = self._emulator
+                    if emulator is None:
+                        break
+                    emulator.run(RUN_BATCH_INSTRUCTIONS)
+                    self._maybe_update_state_locked(emulator)
+                time.sleep(RUN_SLEEP_SECONDS)
+
+    # ------------------------------------------------------------------ #
+    # State helpers
+    # ------------------------------------------------------------------ #
+
+    def snapshot_state(self) -> Dict[str, object]:
+        """Return the latest emulator state, forcing a refresh when paused."""
+        with self._lock:
+            emulator = self._emulator
+            if emulator:
+                self._update_state_locked(emulator, force=not self._state["is_running"])
+            return dict(self._state)
+
+    def _maybe_update_state_locked(self, emulator: PCE500Emulator) -> None:
+        if not self._state["is_running"]:
+            return
+
+        now = time.time()
+        last_time = self._state["last_update_time"]
+        last_instr = self._state["last_update_instructions"]
+        time_delta = now - last_time
+        instr_delta = emulator.instruction_count - int(last_instr)
+
+        if (
+            time_delta >= self.UPDATE_TIME_THRESHOLD
+            or instr_delta >= self.UPDATE_INSTRUCTION_THRESHOLD
+        ):
+            self._update_state_locked(emulator, force=True)
+
+    def _update_state_locked(
+        self, emulator: PCE500Emulator, *, force: bool = False
+    ) -> None:
+        if not force and self._state["is_running"]:
+            now = time.time()
+            last_time = self._state["last_update_time"]
+            last_instr = self._state["last_update_instructions"]
+            if (
+                now - last_time < self.UPDATE_TIME_THRESHOLD
+                and emulator.instruction_count - int(last_instr)
+                < self.UPDATE_INSTRUCTION_THRESHOLD
+            ):
+                return
+
+        lcd_image = emulator.lcd.get_combined_display(zoom=1)
+        img_buffer = io.BytesIO()
+        lcd_image.save(img_buffer, format="PNG")
+        img_buffer.seek(0)
+        screen_base64 = base64.b64encode(img_buffer.getvalue()).decode("utf-8")
+
+        current_time = time.time()
+        current_instructions = emulator.instruction_count
+        prev_time = self._state.get("speed_calc_time")
+        prev_instr = self._state.get("speed_calc_instructions")
+
+        if self._state["is_running"]:
+            speed, ratio = self._calculate_emulation_speed(
+                prev_time,
+                prev_instr,
+                current_time,
+                current_instructions,
+            )
+            self._state["emulation_speed"] = speed
+            self._state["speed_ratio"] = ratio
+        else:
+            self._state["emulation_speed"] = None
+            self._state["speed_ratio"] = None
+
+        self._state["speed_calc_time"] = current_time
+        self._state["speed_calc_instructions"] = current_instructions
+
+        cpu_state = emulator.get_cpu_state()
+        self._state.update(
+            {
+                "screen": f"data:image/png;base64,{screen_base64}",
+                "registers": {
+                    "pc": cpu_state["pc"],
+                    "a": cpu_state["a"],
+                    "b": cpu_state["b"],
+                    "ba": cpu_state["ba"],
+                    "i": cpu_state["i"],
+                    "x": cpu_state["x"],
+                    "y": cpu_state["y"],
+                    "u": cpu_state["u"],
+                    "s": cpu_state["s"],
+                },
+                "flags": {
+                    "z": cpu_state["flags"]["z"],
+                    "c": cpu_state["flags"]["c"],
+                },
+                "instruction_count": emulator.instruction_count,
+                "instruction_history": list(emulator.instruction_history),
+                "last_update_time": current_time,
+                "last_update_instructions": current_instructions,
+            }
+        )
+        self._state["interrupts"] = self._build_interrupt_snapshot(emulator)
+
+    @staticmethod
+    def _calculate_emulation_speed(
+        previous_time: Optional[float],
+        previous_instructions: Optional[int],
+        current_time: float,
+        current_instructions: int,
+    ) -> tuple[float, float]:
+        if previous_time is None or previous_instructions is None:
+            return 0.0, 0.0
+        delta = current_time - previous_time
+        if delta <= 0:
+            return 0.0, 0.0
+        speed = (current_instructions - previous_instructions) / delta
+        return speed, speed / 2_000_000
+
+    def _build_interrupt_snapshot(
+        self, emulator: PCE500Emulator
+    ) -> Optional[Dict[str, object]]:
+        try:
+            ints = (
+                emulator.get_interrupt_stats()
+                if hasattr(emulator, "get_interrupt_stats")
+                else None
+            )
+            snapshot = ints or {}
+            imr_val = (
+                emulator.memory.read_byte(INTERNAL_MEMORY_START + IMEMRegisters.IMR)
+                & 0xFF
+            )
+            isr_val = (
+                emulator.memory.read_byte(INTERNAL_MEMORY_START + IMEMRegisters.ISR)
+                & 0xFF
+            )
+            snapshot.update(
+                {
+                    "imr": f"0x{imr_val:02X}",
+                    "isr": f"0x{isr_val:02X}",
+                    "irm": 1 if (imr_val & int(IMRFlag.IRM)) else 0,
+                    "keym": 1 if (imr_val & int(IMRFlag.KEYM)) else 0,
+                    "isr_key": 1 if (isr_val & int(IMRFlag.KEYM)) else 0,
+                    "pending": bool(getattr(emulator, "_irq_pending", False)),
+                }
+            )
+            return snapshot
+        except Exception:
+            return ints if ints is not None else None
+
+    # ------------------------------------------------------------------ #
+    # API Helpers
+    # ------------------------------------------------------------------ #
+
+    def keyboard_register_state(self) -> Dict[str, str]:
+        emulator = self.ensure_emulator()
+        registers = emulator.get_keyboard_register_state()
+        return {key: f"0x{value:02X}" for key, value in registers.items()}
+
+    def keyboard_queue(self):
+        emulator = self.ensure_emulator()
+        return emulator.keyboard.get_queue_info()
+
+    def keyboard_debug_info(self) -> Dict[str, object]:
+        with self._lock:
+            emulator = self.ensure_emulator()
+            return emulator.keyboard.get_debug_info()
+
+    def capture_lcd_image(self):
+        with self._lock:
+            emulator = self.ensure_emulator()
+            return emulator.lcd.get_combined_display(zoom=1)
+
+    def press_key(self, key_code: str) -> bool:
+        with self._lock:
+            emulator = self.ensure_emulator()
+            queued = emulator.press_key(key_code)
+            self._update_state_locked(emulator, force=True)
+            return queued
+
+    def release_key(self, key_code: str) -> None:
+        with self._lock:
+            emulator = self.ensure_emulator()
+            emulator.release_key(key_code)
+            self._update_state_locked(emulator, force=True)
+
+    def lcd_debug(self, x: int, y: int) -> Optional[int]:
+        emulator = self.ensure_emulator()
+        return emulator.lcd.get_pixel_pc_source(x, y)
+
+    def imem_watch(self):
+        emulator = self.ensure_emulator()
+        tracking = emulator.memory.get_imem_access_tracking()
+        result = {}
+        for reg_name, accesses in tracking.items():
+            result[reg_name] = {
+                "reads": [
+                    {"pc": f"0x{pc:06X}", "count": count}
+                    for pc, count in accesses["reads"]
+                ],
+                "writes": [
+                    {"pc": f"0x{pc:06X}", "count": count}
+                    for pc, count in accesses["writes"]
+                ],
+            }
+        return result
+
+    def lcd_stats(self):
+        emulator = self.ensure_emulator()
+        chip_select_stats = {
+            "both": emulator.lcd.cs_both_count,
+            "left": emulator.lcd.cs_left_count,
+            "right": emulator.lcd.cs_right_count,
+        }
+        chip_stats = emulator.lcd.get_chip_statistics()
+        return {"chip_select": chip_select_stats, "chips": chip_stats}
+
+    # ------------------------------------------------------------------ #
+    # Trace controls
+    # ------------------------------------------------------------------ #
+
+    def start_trace(self) -> Dict[str, object]:
+        emulator = self.ensure_emulator()
+        if emulator.tracing_enabled:
+            return {
+                "ok": True,
+                "enabled": True,
+                "path": TRACE_PATH,
+                "message": "Already tracing",
+            }
+        emulator.start_tracing(TRACE_PATH)
+        perfetto_tracer.start(TRACE_PATH)
+        return {"ok": True, "enabled": True, "path": TRACE_PATH}
+
+    def stop_trace(self) -> Dict[str, object]:
+        emulator = self.ensure_emulator()
+        emulator.stop_tracing()
+        return {"ok": True, "enabled": False, "path": TRACE_PATH}
+
+    def trace_status(self) -> Dict[str, object]:
+        emulator = self.ensure_emulator()
+        return {
+            "enabled": emulator.tracing_enabled,
+            "path": TRACE_PATH,
+            "file_exists": Path(TRACE_PATH).exists(),
+        }
+
+    @contextmanager
+    def emulator_context(self):
+        """Provide exclusive access to the underlying emulator."""
+        with self._lock:
+            yield self.ensure_emulator()
+
+
+service = EmulatorService()
+
+
+def init_app(app) -> None:
+    """Ensure the emulator is ready when the Flask app starts."""
+    with app.app_context():
+        service.ensure_emulator()

--- a/web/tests/test_emulator_state_updates.py
+++ b/web/tests/test_emulator_state_updates.py
@@ -1,320 +1,115 @@
-"""Tests for emulator state update logic."""
+"""Tests for emulator service state management."""
 
-import unittest
-import time
-import threading
-import sys
+from __future__ import annotations
+
 import os
+import sys
+import time
+import unittest
 from pathlib import Path
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
-# Add parent directories to path
+# Make sure app module is importable
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-# Set FORCE_BINJA_MOCK before importing app
 os.environ["FORCE_BINJA_MOCK"] = "1"
 
-import app
-from app import (
-    update_emulator_state,
-    emulator_run_loop,
-    UPDATE_TIME_THRESHOLD,
-    UPDATE_INSTRUCTION_THRESHOLD,
-)
+from emulator_service import EmulatorService  # type: ignore  # noqa: E402
 
 
-class TestEmulatorStateUpdates(unittest.TestCase):
-    """Test emulator state update mechanisms."""
+class EmulatorServiceStateTests(unittest.TestCase):
+    """Validate the EmulatorService state update behaviour."""
 
-    def setUp(self):
-        """Set up test fixtures."""
-        # Reset global state
-        app.emulator_state = {
-            "is_running": False,
-            "last_update_time": 0,
-            "last_update_instructions": 0,
-            "screen": None,
-            "registers": {},
-            "flags": {},
-            "instruction_count": 0,
-            "instruction_history": [],
-            "speed_calc_time": None,
-            "speed_calc_instructions": None,
-            "emulation_speed": None,
-            "speed_ratio": None,
-        }
+    def setUp(self) -> None:
+        self.service = EmulatorService()
+        self.service._state = self.service._initial_state()
 
-        # Create mock emulator
+        # Mock emulator with minimal surface
         self.mock_emulator = Mock()
         self.mock_emulator.instruction_count = 0
         self.mock_emulator.instruction_history = []
         self.mock_emulator.get_cpu_state.return_value = {
             "pc": 0x100,
-            "a": 0x00,
-            "b": 0x00,
-            "ba": 0x0000,
-            "i": 0x0000,
-            "x": 0x000000,
-            "y": 0x000000,
-            "u": 0x000000,
-            "s": 0x000000,
-            "flags": {"z": 0, "c": 0},
-            "cycles": 0,
+            "a": 0x01,
+            "b": 0x02,
+            "ba": 0x0102,
+            "i": 0x0304,
+            "x": 0x000500,
+            "y": 0x000600,
+            "u": 0x000700,
+            "s": 0x000800,
+            "flags": {"z": 1, "c": 0},
         }
+        self.mock_emulator.memory.read_byte.return_value = 0
+        self.mock_emulator.get_interrupt_stats.return_value = {"total": 0}
 
-        # Mock LCD
         mock_image = Mock()
-        mock_image.save = Mock()
+
+        def fake_save(buffer, format="PNG"):
+            buffer.write(b"PNG")
+
+        mock_image.save.side_effect = fake_save
         self.mock_emulator.lcd.get_combined_display.return_value = mock_image
 
-        # Replace global emulator
-        app.emulator = self.mock_emulator
+        self.service._emulator = self.mock_emulator
 
-    def tearDown(self):
-        """Clean up after tests."""
-        # Ensure emulator is stopped
-        app.emulator_state["is_running"] = False
-        if app.emulator_thread:
-            app.emulator_thread.join(timeout=1)
-            app.emulator_thread = None
+    def test_update_state_basic(self):
+        """_update_state_locked populates expected fields."""
+        self.service._update_state_locked(self.mock_emulator, force=True)
+        state = self.service._state
 
-    def test_update_emulator_state_basic(self):
-        """Test basic state update functionality."""
-        # Call update
-        update_emulator_state()
-
-        # Verify state was updated
-        state = app.emulator_state
         self.assertEqual(state["registers"]["pc"], 0x100)
-        self.assertEqual(state["flags"]["z"], 0)
+        self.assertEqual(state["flags"]["z"], 1)
         self.assertEqual(state["flags"]["c"], 0)
+        self.assertTrue(str(state["screen"]).startswith("data:image/png;base64,"))
         self.assertEqual(state["instruction_count"], 0)
 
-        # Verify screen was captured
-        self.assertTrue(state["screen"].startswith("data:image/png;base64,"))
-        self.mock_emulator.lcd.get_combined_display.assert_called_once_with(zoom=1)
+    def test_maybe_update_state_respects_time_threshold(self):
+        """Updates are skipped when thresholds are unmet."""
+        self.service._state["is_running"] = True
+        self.service._state["last_update_time"] = time.time()
+        self.service._state["last_update_instructions"] = 0
 
-        # Verify timestamp was updated
-        self.assertGreater(state["last_update_time"], 0)
-        self.assertEqual(state["last_update_instructions"], 0)
-
-    def test_update_emulator_state_no_emulator(self):
-        """Test update when emulator is None."""
-        app.emulator = None
-
-        # Should not crash
-        update_emulator_state()
-
-        # State should remain unchanged
-        state = app.emulator_state
-        self.assertEqual(state["registers"], {})
-
-    def test_time_based_update_threshold(self):
-        """Test time-based update threshold."""
-        # Set up initial state
-        app.emulator_state["is_running"] = True
-        app.emulator_state["last_update_time"] = time.time()
-
-        # Mock time to control elapsed time
-        with patch("app.time.time") as mock_time:
-            # Initial time
-            current_time = app.emulator_state["last_update_time"]
-            mock_time.return_value = current_time
-
-            # Run one iteration - should not update (not enough time elapsed)
-            with patch("app.update_emulator_state") as mock_update:
-                # Simulate run loop iteration
-                app.emulator_state["is_running"] = True
-                thread = threading.Thread(target=emulator_run_loop)
-                thread.start()
-
-                # Wait a bit
-                time.sleep(0.05)
-
-                # Stop thread
-                app.emulator_state["is_running"] = False
-                thread.join(timeout=1)
-
-                # Should not have updated
-                mock_update.assert_not_called()
-
-            # Now advance time past threshold
-            mock_time.return_value = current_time + UPDATE_TIME_THRESHOLD + 0.01
-
-            # Run another iteration - should update
-            with patch("app.update_emulator_state") as mock_update:
-                app.emulator_state["is_running"] = True
-                thread = threading.Thread(target=emulator_run_loop)
-                thread.start()
-
-                # Wait a bit
-                time.sleep(0.05)
-
-                # Stop thread
-                app.emulator_state["is_running"] = False
-                thread.join(timeout=1)
-
-                # Should have updated
-                mock_update.assert_called()
-
-    def test_instruction_based_update_threshold(self):
-        """Test instruction-based update threshold."""
-        # Set up initial state
-        app.emulator_state["is_running"] = True
-        app.emulator_state["last_update_instructions"] = 0
-        app.emulator_state["last_update_time"] = time.time()
-
-        # Set instruction count just below threshold
-        self.mock_emulator.instruction_count = UPDATE_INSTRUCTION_THRESHOLD - 1
-
-        with patch("app.update_emulator_state") as mock_update:
-            # Simulate run loop iteration
-            app.emulator_state["is_running"] = True
-            thread = threading.Thread(target=emulator_run_loop)
-            thread.start()
-
-            # Wait a bit
-            time.sleep(0.05)
-
-            # Stop thread
-            app.emulator_state["is_running"] = False
-            thread.join(timeout=1)
-
-            # Should not have updated
+        with patch.object(self.service, "_update_state_locked") as mock_update:
+            self.service._maybe_update_state_locked(self.mock_emulator)
             mock_update.assert_not_called()
 
-        # Now set instruction count past threshold
-        self.mock_emulator.instruction_count = UPDATE_INSTRUCTION_THRESHOLD + 1
+    def test_maybe_update_state_triggers_when_elapsed(self):
+        """Updates occur when thresholds are exceeded."""
+        self.service._state["is_running"] = True
+        self.service._state["last_update_time"] = time.time() - (
+            self.service.UPDATE_TIME_THRESHOLD + 0.01
+        )
+        self.service._state["last_update_instructions"] = 0
 
-        with patch("app.update_emulator_state") as mock_update:
-            app.emulator_state["is_running"] = True
-            thread = threading.Thread(target=emulator_run_loop)
-            thread.start()
+        with patch.object(self.service, "_update_state_locked") as mock_update:
+            self.service._maybe_update_state_locked(self.mock_emulator)
+            mock_update.assert_called_once()
 
-            # Wait a bit
-            time.sleep(0.05)
+    def test_snapshot_state_forces_refresh_when_paused(self):
+        """snapshot_state forces refresh when emulator is paused."""
+        self.service._state["is_running"] = False
+        with patch.object(self.service, "_update_state_locked") as mock_update:
+            self.service.snapshot_state()
+            mock_update.assert_called_once()
 
-            # Stop thread
-            app.emulator_state["is_running"] = False
-            thread.join(timeout=1)
+    def test_keyboard_register_state_format(self):
+        """keyboard_register_state exposes public API values."""
+        self.mock_emulator.get_keyboard_register_state.return_value = {
+            "kol": 0x12,
+            "koh": 0x34,
+            "kil": 0x56,
+        }
+        registers = self.service.keyboard_register_state()
+        self.assertEqual(registers, {"kol": "0x12", "koh": "0x34", "kil": "0x56"})
 
-            # Should have updated
-            mock_update.assert_called()
-
-    def test_emulator_run_loop_exception_handling(self):
-        """Test run loop handles exceptions gracefully."""
-        # Make step() raise an exception
-        self.mock_emulator.step.side_effect = Exception("Test error")
-
-        # Run the loop
-        app.emulator_state["is_running"] = True
-        thread = threading.Thread(target=emulator_run_loop)
-        thread.start()
-
-        # Wait for thread to finish
-        thread.join(timeout=1)
-
-        # Should have stopped running
-        self.assertFalse(app.emulator_state["is_running"])
-
-    def test_emulator_run_loop_stops_when_emulator_none(self):
-        """Test run loop stops when emulator becomes None."""
-        app.emulator = None
-
-        # Run the loop
-        app.emulator_state["is_running"] = True
-        thread = threading.Thread(target=emulator_run_loop)
-        thread.start()
-
-        # Should exit quickly
-        thread.join(timeout=1)
-        self.assertFalse(thread.is_alive())
-
-    def test_state_update_with_different_cpu_values(self):
-        """Test state update with various CPU register values."""
-        test_cases = [
-            {
-                "pc": 0xFFFFFF,
-                "a": 0xFF,
-                "b": 0xFF,
-                "ba": 0xFFFF,
-                "i": 0xFFFF,
-                "x": 0xFFFFFF,
-                "y": 0xFFFFFF,
-                "u": 0xFFFFFF,
-                "s": 0xFFFFFF,
-                "flags": {"z": 1, "c": 1},
-                "cycles": 1000000,
-            },
-            {
-                "pc": 0x000000,
-                "a": 0x00,
-                "b": 0x00,
-                "ba": 0x0000,
-                "i": 0x0000,
-                "x": 0x000000,
-                "y": 0x000000,
-                "u": 0x000000,
-                "s": 0x000000,
-                "flags": {"z": 0, "c": 0},
-                "cycles": 0,
-            },
-            {
-                "pc": 0x123456,
-                "a": 0xAB,
-                "b": 0xCD,
-                "ba": 0xABCD,
-                "i": 0x1234,
-                "x": 0x123456,
-                "y": 0x789ABC,
-                "u": 0xDEF012,
-                "s": 0x345678,
-                "flags": {"z": 1, "c": 0},
-                "cycles": 12345,
-            },
-        ]
-
-        for test_state in test_cases:
-            self.mock_emulator.get_cpu_state.return_value = test_state
-            self.mock_emulator.instruction_count = test_state["cycles"]
-
-            update_emulator_state()
-
-            state = app.emulator_state
-            for reg in ["pc", "a", "b", "ba", "i", "x", "y", "u", "s"]:
-                self.assertEqual(state["registers"][reg], test_state[reg])
-
-            self.assertEqual(state["flags"]["z"], test_state["flags"]["z"])
-            self.assertEqual(state["flags"]["c"], test_state["flags"]["c"])
-            self.assertEqual(state["instruction_count"], test_state["cycles"])
-
-    def test_concurrent_state_updates(self):
-        """Test thread safety of state updates."""
-        # This test verifies that concurrent access doesn't crash
-        update_count = 0
-
-        def update_worker():
-            nonlocal update_count
-            for _ in range(10):
-                with app.emulator_lock:
-                    update_emulator_state()
-                    update_count += 1
-                time.sleep(0.001)
-
-        # Start multiple threads
-        threads = []
-        for _ in range(5):
-            thread = threading.Thread(target=update_worker)
-            thread.start()
-            threads.append(thread)
-
-        # Wait for all threads
-        for thread in threads:
-            thread.join()
-
-        # Should have completed all updates
-        self.assertEqual(update_count, 50)
+    def test_press_key_updates_emulator(self):
+        """press_key delegates to emulator and updates state."""
+        self.mock_emulator.press_key.return_value = True
+        queued = self.service.press_key("KEY_A")
+        self.assertTrue(queued)
+        self.mock_emulator.press_key.assert_called_with("KEY_A")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- move runtime management into a shared emulator service with paced execution and public tracing/keyboard accessors
- rework Flask app endpoints to consume the service, gate CORS on explicit configuration, and document the behaviour
- update tests and docs to cover the new service and avoid private attribute coupling

## Testing
- uv run pytest tests

Closes #88