### PR TITLE
Simplify operand emptiness check in opcode lifting

### DIFF
--- a/sc62015/pysc62015/instr/opcodes.py
+++ b/sc62015/pysc62015/instr/opcodes.py
@@ -869,7 +869,7 @@ class Instruction:
             src_mode = dst_mode
 
         operands = tuple(self.operands())
-        if len(operands) == 0:
+        if not operands:
             il.append(il.unimplemented())
         else:
             # For destination operand, disable side effects on first lift() to avoid double increment


### PR DESCRIPTION
## Summary
- replace the explicit length check on operands with a direct truthiness check to clarify intent

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914fcc7863c83319a1a016f14b67674)