### PR TITLE
Normalize environment flag parsing

### DIFF
--- a/sc62015/pysc62015/config.py
+++ b/sc62015/pysc62015/config.py
@@ -8,7 +8,8 @@ def _env_flag(name: str, default: bool = False) -> bool:
     raw = os.getenv(name)
     if raw is None:
         return default
-    return raw not in {"0", "false", "False", "off", ""}
+    normalized = raw.strip().casefold()
+    return normalized not in {"0", "false", "off", ""}
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary
- normalize environment flag parsing by stripping whitespace and casefolding values before evaluation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914fcc7863c83319a1a016f14b67674)