### PR TITLE
Guard sys.path injection in trace tool

### DIFF
--- a/pce500/tools/trace_memory.py
+++ b/pce500/tools/trace_memory.py
@@ -6,7 +6,10 @@ from pathlib import Path
 from collections import Counter
 
 # Add parent directory to path
-sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+repo_root = Path(__file__).parent.parent.parent
+repo_root_str = str(repo_root)
+if repo_root_str not in sys.path:
+    sys.path.insert(0, repo_root_str)
 
 from pce500 import PCE500Emulator
 from sc62015.pysc62015.emulator import RegisterName


### PR DESCRIPTION
## Summary
- ensure the trace_memory helper only prepends the repository root to sys.path once to avoid duplicate entries

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914fcc7863c83319a1a016f14b67674)