### PR TITLE
Docs: SCIL architecture and rust emulator guides

### DIFF
--- a/docs/rust_emulator_file_map.md
+++ b/docs/rust_emulator_file_map.md
@@ -1,0 +1,66 @@
+# Full-Rust Emulator File Map
+
+Quick map of Rust-side files and how they relate to the SCIL architecture notes in `docs/scil_arch_report.md` (manifest/binder/family, execution, tracing, build).
+
+## SCIL interpreter (emulators/rust_scil)
+
+- `emulators/rust_scil/src/state.rs`: register/flag model and aliasing (ties to register/alias notes and flag shadows FC/FZ).
+- `emulators/rust_scil/src/eval.rs`: SCIL evaluator using binder, tmps, PRE, IMEM caches (matches eval and gotchas sections: PRE modes, IMEM caches, tmp invalidation).
+- `emulators/rust_scil/src/bus.rs`: `Bus` trait and `Space` enum (Int/Ext/Code) used by eval; aligns with memory/addressing.
+- `emulators/rust_scil/src/ast.rs`: SCIL AST node definitions referenced by manifest payload and evaluator.
+
+## Core runtime on top of SCIL (sc62015/core)
+
+- `sc62015/core/src/exec.rs`: HybridBus, opcode lookup, execute_step wrapper around `rust_scil::eval::step`; consumes manifest payload (handlers.rs/opcode_index.rs) and binder.
+- `sc62015/core/src/perfetto.rs`: Perfetto tracer for instruction/memory instants (ties to tracing notes).
+- `sc62015/core/src/snapshot.rs`: snapshot load/save, range deserialization (constraints section: export variants, readonly ranges).
+- `sc62015/core/src/lcd.rs`: LCD device + display buffer export (hardware device layer used by bus; aliasing/constraints around display buffer).
+- `sc62015/core/src/lib.rs`: re-exports core types (MemoryImage, PerfettoTracer, execute_step, etc.) and metadata (fast_mode, interrupts); glues core for rustcore.
+
+## Rust bridge / CLI (sc62015/rustcore)
+
+- `sc62015/rustcore/src/lib.rs`: pyo3 bindings exposing the core runtime to Python (`_sc62015_rustcore`), loads generated manifest payload/index, handles binder serialization, exposes execute_step/state access (aligns with manifest/binder/family usage and constraints on FC/FZ).
+- `sc62015/rustcore/src/bin/pce500-cli.rs`: pure-Rust CLI harness that loads manifest payload, builds HybridBus, steps instructions, and can emit traces/snapshots (uses build/tracing notes).
+- `sc62015/rustcore/generated/{manifest.json,handlers.rs,opcode_index.rs}`: generated payload/index from `tools/scil_codegen_rust.py` (see generation pipeline and size constraints).
+
+## Supporting files and generation
+
+- `tools/scil_codegen_manifest.py`: enumerates decoded variants with templates + PRE, builds manifest entries (manifest/binder/family sections).
+- `tools/scil_codegen_rust.py`: writes manifest payload/index consumed by rustcore/core.
+
+## Build/trace touchpoints
+
+- Build rustcore and CLI: `uv run maturin develop --manifest-path sc62015/rustcore/Cargo.toml` (pulls in core + generated payload).
+- Build SCIL interpreter: `cargo build` in `emulators/rust_scil`.
+- Tracing: `sc62015/core/src/perfetto.rs` and dispatcher bridging in `pce500` glue (see tracing section). Environment flags (e.g., `RUST_MEM_TRACE`, `RUST_EXT_TRACE`, `IMEM_TRACE`) map directly to evaluator/device tracing described in the main SCIL report.
+
+## ASCII module chart
+
+```
+               +----------------------+
+               | tools/scil_codegen_* |
+               | (manifest/payload)   |
+               +----------+-----------+
+                          |
+          generated payload (manifest.json /
+             handlers.rs / opcode_index.rs)
+                          |
+          +---------------+-----------------+
+          |                                 |
++---------v---------+              +--------v--------+
+| emulators/rust_scil|             | sc62015/core    |
+| (state, eval, bus) |             | (exec, perfetto,|
+|                     |             |  snapshot, lcd) |
++---------+---------+              +--------+--------+
+          | eval::step                       | HybridBus/execute_step
+          +---------------+------------------+
+                          |
+                +---------v---------+
+                | sc62015/rustcore  |
+                | (pyo3 bridge, CLI)|
+                +---------+---------+
+                          |
+             +------------+-------------+
+             |                          |
+      Python via pyo3             `pce500-cli`
+```

--- a/docs/rust_emulator_reuse.md
+++ b/docs/rust_emulator_reuse.md
@@ -1,0 +1,39 @@
+# Rust Emulator Reuse Plan (No SCIL)
+
+What can be reused for a full-Rust emulator that bypasses SCIL, and what cannot.
+
+## Reusable as-is or with light adaptation
+
+- Memory & addressing
+  - `sc62015/core/src/memory.rs`: `MemoryImage`, address helpers, readonly/fallback ranges.
+  - Address masks/constants in `sc62015/core/src/lib.rs` (e.g., `INTERNAL_MEMORY_START`, `ADDRESS_MASK`).
+- Devices
+  - `sc62015/core/src/lcd.rs`: LCD controller, VRAM, `display_buffer` export.
+  - `sc62015/core/src/keyboard.rs`: keyboard matrix handling.
+  - `sc62015/core/src/timer.rs`: timer scaffolding (if kept).
+- Tracing/telemetry
+  - `sc62015/core/src/perfetto.rs`: Perfetto tracer for instruction/memory instants/counters.
+  - Event schema patterns from `pce500` tracing glue (if matching dispatcher/Perfetto).
+- Snapshots
+  - `sc62015/core/src/snapshot.rs`: archive format, range deserialization, register packing/unpacking (adjust registers if model changes).
+- Glue/runtime scaffolding
+  - HybridBus/host-device wiring patterns in `sc62015/core/src/exec.rs` (minus SCIL eval hook).
+  - Perfetto emission patterns in `pce500/emulator.py` as reference for payload shapes.
+- Build/interop
+  - pyo3 glue structure in `sc62015/rustcore/src/lib.rs` (for a Python extension), minus SCIL payload loading.
+  - CLI scaffolding in `sc62015/rustcore/src/bin/pce500-cli.rs` (arg parsing, snapshot load/save, tracing hooks), swapping in your core execute step.
+
+## Reusable concepts but needs refactor
+
+- Opcode lookup scaffolding (`OpcodeLookup`, `OpcodeIndexView`) in `sc62015/core/src/exec.rs`: map/retrieval pattern is useful; source data must come from your new decoder/dispatch table.
+- Perfetto event schemas: tracer is reusable; adjust annotations to your core.
+- Snapshot register packing: current layout matches SCIL regs (A/B/BA, I/IL/IH, etc.); update if your register model differs.
+
+## Not reusable (SCIL-bound)
+
+- SCIL interpreter/AST: `emulators/rust_scil` (state/eval/ast) and generated payload (`handlers.rs`, `manifest.json`, `opcode_index.rs`).
+- SCIL decode/codegen: `tools/scil_codegen_*`, `sc62015/decoding/*`, `sc62015/scil/*` bound_repr/serde.
+
+## Summary
+
+Keep the device layer (memory, LCD, keyboard), snapshot container/format (tweak registers as needed), tracing infrastructure, bus/device wiring patterns, and pyo3/CLI scaffolding. Replace SCIL decode/eval and generated payloads with your new core’s decode/execute, reusing the surrounding runtime and tooling.

--- a/docs/scil_arch_report.md
+++ b/docs/scil_arch_report.md
@@ -1,0 +1,261 @@
+# SCIL Architecture & Emulator Notes
+
+## Overview
+
+SCIL is a semantics DSL for the SC62015 CPU. Each instruction has:
+
+- A decoded form (`DecodedInstr`): opcode, mnemonic/family, length, binds (operands), optional PRE latch.
+- A bound SCIL AST (`Instr`): sequence of `Stmt`/`Expr` nodes executed by the interpreters.
+- Binder defaults (operand expressions) and layout metadata for disassembly/tracing.
+
+## Data Flow (build & runtime)
+
+```
+[opcode stream] --> decode_map.decode_with_pre_variants()
+                     | (register/pointer selectors, PRE variants)
+                     v
+              DecodedInstr (mnemonic, binds, length, pre)
+                     |
+                     | from_decoded.build()
+                     v
+              Bound Instr + binder defaults (Expr)
+                     |
+           tools/scil_codegen_rust.py
+                     |-- manifest.json        (JSON array of entries)
+                     |-- handlers.rs (PAYLOAD: &str of manifest JSON)
+                     '-- opcode_index.rs (opcode+PRE -> manifest index)
+                     |
+ Rust runtime loads PAYLOAD + opcode_index --> lookup ManifestEntry --> eval Instr
+```
+
+## Memory & Addressing
+
+- External/code space: 24-bit addresses (0x000000–0xFFFFFF).
+- Internal memory (IMEM): 0x100000–0x1000FF, accessed via 8-bit offsets. PRE prefixes remap IMEM addressing modes.
+- IMEM modes: `(n)`, `(BP+n)`, `(PX+n)`, `(PY+n)`, `(BP+PX)`, `(BP+PY)` selected via operands; PRE can override with the 4×4 matrix in `pre_modes.py`.
+- `resolve_imem_addr` caches per-tmp lookups; must invalidate when tmps change.
+
+## Register Model & Aliases
+
+- 8/16/24-bit registers: A, B, BA (A|B), IL, IH, I (IL|IH), X, Y, U, S, F.
+- Flags: C/Z; mirrored into F and also into FC/FZ shadow regs in the Rust state.
+- PC is masked to 20 bits (`0x0F_FFFF`).
+- Writing BA updates A/B; writing A/B updates BA. Writing IL/IH updates I accordingly.
+
+## Key Components (Rust)
+
+- `emulators/rust_scil/src/state.rs`: register/flag storage with alias handling.
+- `emulators/rust_scil/src/eval.rs`: executes SCIL AST over an `Env`:
+  - `Env` holds `State`, `Bus`, binder map, tmps, PRE latch, IMEM index, caches.
+  - `eval_expr` evaluates `Expr` (const, tmp, reg, mem, ops).
+  - `exec_stmt` executes statements (fetch, setreg, store, setflag, if/goto/call, mem swaps, ext/int moves).
+  - IMEM last-write cache for read-after-write without reloading bus.
+- `bus::Bus` trait: `load/store(space, addr, bits)`. Spaces: Int (IMEM), Ext, Code.
+- `pre_modes.rs`: PRE matrix, `needs_pre_variants`, and iterator for all PRE latches.
+- `eval::step`: entry point: build `Env` from binder, run semantics list.
+
+## Generation Pipeline
+
+- `tools/scil_codegen_manifest.py`:
+  - Builds 121 operand selector templates + 40 cross-width templates for reg-arith opcodes.
+  - For each opcode: decode with templates + PRE variants; dedup by (mnemonic, length, family, PRE, binder shape).
+  - Emits ~177k entries (every legal reg/pointer/PRE combination).
+- `tools/scil_codegen_rust.py`: writes `manifest.json`, `handlers.rs` (PAYLOAD string), `opcode_index.rs`.
+
+### Manifest entry contents
+
+Each entry in `manifest.json` encodes:
+
+- `opcode`: primary opcode byte.
+- `mnemonic`: human-readable mnemonic.
+- `family`: decoder family tag (drives PRE applicability/semantics grouping).
+- `length`: total byte length for this variant.
+- `pre`: optional PRE latch (`first`/`second` IMEM addressing modes).
+- `instr`: full SCIL AST (`name`, `length`, `semantics` list of statements with nested expressions).
+- `binder`: default operand bindings (serialized `Expr` objects) to populate tmps/regs before execution.
+- `layout`: operand/disassembly metadata (`key`, `kind`, `meta` with offsets/lengths).
+- `bound_repr`: compact pre-bound representation for quick lookup.
+- `id`: manifest index (referenced by `opcode_index.rs`).
+
+### Binder (operand binding) model
+
+- Binder is a per-instruction map `name -> Expr` produced at decode time (e.g., `dst`, `src`, `addr`, `ptr`).
+- Values are SCIL expressions representing operand sources: register selectors, immediates, displacements, pointer selectors, tmp refs, etc.; whatever the decoder emitted for that operand gets lifted into an `Expr` and stored under its name.
+- At runtime, the evaluator clones the binder into the `Env`; `Stmt::Fetch` looks up `dst.name` in the binder, evaluates it, and seeds tmps/regs before executing semantics. Binder itself is immutable during execution; tmps/regs evolve.
+- Binder decouples decode from execution: no re-decode is needed—operands come from the serialized binder (in `manifest.json` / `handlers.rs` payload and `bound_repr`), and the same binder is used by Rust and Python interpreters.
+- Cache sensitivity: binder-supplied tmps drive IMEM address resolution; when tmps change, related caches (e.g., IMEM addr cache) must be invalidated to avoid stale addresses.
+- Parity/testing: binder contents are part of `bound_repr` and passed into `scil_step_json`/Python evaluator; state comparisons must tolerate fields like FC/FZ (flag shadows) that the binder-driven execution can populate in Rust state.
+
+### Family classification
+
+- Family is the decoder/emitter classification string on each decoded variant (`family` in manifest).
+- Drives PRE expansion: only families in `pre_modes.IMEM_FAMILIES` get base+16 PRE variants; non-IMEM families do not.
+- Reflects operand/behavior shape (e.g., `imem_move`, `imem_const`, `ext_reg`, `imm8`, `rel8`, `loop_move`, `adc_imem`).
+- Used at generation time to decide PRE coverage; runtime uses the pre-expanded manifest (family itself is metadata, AST carries semantics).
+- Null/missing family means no PRE expansion.
+
+## Gotchas
+
+- PRE explosion: IMEM families get 17 variants (base + 16 PRE modes).
+- Internal-offset vs absolute: IMEM loads/stores use 8-bit offsets; addresses ≥0x100000 bypass PRE and map to 0–0xFF.
+- Tmp reuse: IMEM cache must be invalidated when tmps mutate (fixed via `Env::set_tmp`).
+- Flag shadows: Rust state keeps FC/FZ; Python state ignores them. When comparing states, skip FC/FZ fields.
+- Snapshot/export: Python `export_flat_memory` may return 2 or 3 values; Rust bridge now handles both.
+- Fallback path: On Rust exec error, bridge restores snapshot and runs Python backend; ensure snapshot restore uses the in-memory struct.
+- Large generated artifacts: `sc62015/rustcore/generated/{manifest.json,handlers.rs}` ~425 MB each, `opcode_index.rs` ~20 MB.
+- IMEM last-write cache: `eval_expr` consults `imem_last_write` to return just-written values without a bus read.
+
+## Code structure & dependencies
+
+- `sc62015/decoding`: opcode decoders, PRE modes, stream reader; produces `DecodedInstr` + operand layout.
+- `sc62015/scil`: SCIL AST (`ast`), builder (`from_decoded`), serde helpers, bound_repr cache.
+- `tools/scil_codegen_manifest.py`: runs decoders + SCIL builder to enumerate variants (requires `binja-test-mocks` in PYTHONPATH).
+- `tools/scil_codegen_rust.py`: emits `manifest.json`, `handlers.rs` (PAYLOAD string), `opcode_index.rs`.
+- `emulators/rust_scil`: Rust SCIL interpreter (state, eval, bus).
+- `sc62015/core`: Rust core runtime (HybridBus, Perfetto tracer, snapshots, LCD, keyboard) building on rust_scil.
+- `sc62015/rustcore`: pyo3 bridge + CLI (`pce500-cli`), consumes generated payload and core; built with `maturin`.
+- `sc62015/pysc62015`: Python bridge (`BridgeCPU`) and emulator; can call into rustcore or pure Python backend.
+- Generated artifacts are large and ideally regenerated or moved to LFS rather than pushed.
+
+### Module map (key files)
+
+- `emulators/rust_scil/src/state.rs`: register/flag storage with alias handling.
+- `emulators/rust_scil/src/eval.rs`: SCIL evaluator (expr + stmt execution, IMEM caching).
+- `emulators/rust_scil/src/bus.rs`: `Bus` trait and space enum (Int/Ext/Code).
+- `sc62015/decoding/decode_map.py`: opcode decoders, register/pointer selectors, PRE-aware variants.
+- `sc62015/decoding/pre_modes.py`: PRE matrix and applicability (`IMEM_FAMILIES`).
+- `sc62015/scil/from_decoded.py`: builds SCIL AST + binder from `DecodedInstr`.
+- `sc62015/core/src/exec.rs`: HybridBus, opcode lookup, Rust-side execute_step wrapper.
+- `sc62015/core/src/perfetto.rs`: Rust Perfetto tracer (instruction/memory instants).
+- `sc62015/core/src/snapshot.rs`: snapshot load/save, range deserialization helpers.
+- `sc62015/core/src/lcd.rs`: LCD controller + display buffer export.
+- `sc62015/rustcore/src/lib.rs`: pyo3 bindings, manifest loading, bridge glue.
+- `sc62015/rustcore/src/bin/pce500-cli.rs`: pure-Rust CLI harness.
+- `sc62015/pysc62015/_rust_bridge.py`: Python bridge to rustcore (sync, fallback).
+- `sc62015/pysc62015/cpu.py` / `emulator.py`: Python CPU facade and emulator wrapper.
+- `tools/scil_codegen_manifest.py` / `tools/scil_codegen_rust.py`: manifest + Rust payload generation.
+
+## Operational constraints & flags
+
+- Address masks: PC is 20 bits; IMEM offsets are 8 bits; IMEM base 0x100000.
+- Aliases: BA<->A/B, I<->IL/IH; flags C/Z mirrored into F and FC/FZ (Rust state).
+- PRE applies only to families in `IMEM_FAMILIES`.
+- Env caches: IMEM addr cache keyed by tmp name (invalidate on tmp writes); IMEM last-write cache short-circuits reads after writes.
+- Parity/testing helpers: `FORCE_BINJA_MOCK=1` for Binary Ninja mocks; tracing flags (`RUST_MEM_TRACE`, `RUST_EXT_TRACE`, `IMEM_TRACE`, `LCD_LOOP_TRACE`); parity tests compare Rust/Python states with FC/FZ ignored on Python side.
+
+## Build & regeneration notes
+
+- Python deps: `uv sync --extra dev --extra pce500 --extra web` (needs `binja-test-mocks` for manifest generation).
+- Regenerate manifest/payload: `python tools/scil_codegen_rust.py --out-dir sc62015/rustcore/generated` (PYTHONPATH must include `binja-test-mocks`), yields `manifest.json`, `handlers.rs`, `opcode_index.rs`.
+- Build Rust SCIL interpreter: `cargo build` / `cargo test` in `emulators/rust_scil`.
+- Build rustcore (pyo3 + CLI): `uv run maturin develop --manifest-path sc62015/rustcore/Cargo.toml` (Python 3.11+, pyo3 0.22).
+- Core/CLI relies on generated payload; `sc62015/rustcore/build.rs` will auto-run `tools/scil_codegen_rust.py` if payload is missing (requires `binja-test-mocks` on PYTHONPATH). If trimming size is needed, regenerate with fewer templates/PRE families or move artifacts to LFS.
+
+## Tracing, snapshots, and perf
+
+- Tracing: legacy `trace_dispatcher` (instants/counters) + `PerfettoTracer` (core/perfetto.rs) for instruction/memory events; new tracer bridges dispatcher events into Perfetto.
+- Env flags: `RUST_MEM_TRACE`, `RUST_EXT_TRACE`, `IMEM_TRACE`, `LCD_LOOP_TRACE`, `RUST_PC_TRACE`, `RUST_INTERNAL_WRITE_TRACE` toggle diagnostics.
+- Snapshots: Python `export_flat_memory` returns 2 or 3 values (memory + ranges [+ readonly]); Rust bridge tolerates both. Register snapshots include aliases; FC/FZ present only in Rust state. LCD payload optional.
+- CLI: `pce500-cli` (rustcore) can load/save snapshots, step, and emit trace JSON (convertible to Perfetto via scripts if needed).
+
+## Minimal Usage Snippets
+
+_Execute one instruction with Rust SCIL evaluator (conceptual)_
+
+```rust
+use rust_scil::{ast::Instr, eval, state::State, bus::Bus};
+
+let mut state = State::default();
+let mut bus = MyBusImpl::new(); // implements Bus
+let binder = /* from manifest entry */ std::collections::HashMap::new();
+let instr: Instr = /* from manifest entry */;
+
+eval::step(&mut state, &mut bus, &instr, &binder, None)?;
+```
+
+_Apply a PRE mode override_
+
+```rust
+use rust_scil::ast::PreLatch;
+let pre = Some(PreLatch { first: "(PX+n)".into(), second: "(BP+n)".into() });
+eval::step(&mut state, &mut bus, &instr, &binder, pre)?;
+```
+
+_Python bridge fallback handling (fixed)_
+
+```python
+snapshot = bridge.snapshot_registers()
+try:
+    opcode, length = bridge._runtime.execute_instruction()
+except Exception:
+    bridge.restore_snapshot(snapshot)
+    opcode, length = bridge._execute_via_fallback(addr)
+```
+
+## ASCII Relationship Diagram
+
+```
+               +----------------------+
+               |  opcode stream       |
+               +----------+-----------+
+                          |
+                  decode_map.decode_with_pre_variants
+                          |
+                +---------v---------+
+                |   DecodedInstr    |
+                | (mnemonic, binds, |
+                |  family, pre)     |
+                +---------+---------+
+                          |
+                    from_decoded.build
+                          |
+                +---------v---------+
+                | Bound Instr (AST) |
+                | + binder defaults |
+                +---------+---------+
+                          |
+             tools/scil_codegen_rust.py
+        (manifest.json / handlers.rs / opcode_index.rs)
+                          |
+         +----------------+----------------+
+         |                                 |
+ +-------v-------+                 +-------v-------+
+ | Rust runtime  |                 | Python runtime|
+ | (loads PAYLOAD|                 | (same SCIL AST|
+ |  + index)     |                 |  interpreter) |
+ +---+-----------+                 +---+-----------+
+     |                                   |
+     | eval::step                        | execute_build
+     v                                   v
+ +---+---------------------+    +--------+-----------+
+ | Env(State, Bus, PRE,    |    | CPUState, Memory   |
+ |  binder, tmps, caches)  |    | Adapter            |
+ +------------+------------+    +--------------------+
+              | Bus.load/store            | memory read/write
+              v                           v
+         +----+----+                 +----+----+
+         | Memory  |                 | Memory  |
+         +---------+                 +---------+
+```
+
+## Intermediary Artifacts
+
+- `DecodedInstr` → `BoundInstrRepr` (cached JSON form used in manifest).
+- `LayoutEntry` (operand display metadata) captured during decode templates.
+- PRE latch (`PreLatch(first, second)`) attached when IMEM family needs it.
+- Binder map: name → `Expr` (e.g., register selectors, immediates).
+
+## Rust Emulator Integration
+
+- `sc62015/rustcore/src/lib.rs`:
+  - Loads manifest payload and opcode index.
+  - `OpcodeLookup` maps `(opcode, pre)` to manifest entry.
+  - `execute_step` builds binder, sets up `HybridBus`, and calls `eval::step`.
+  - Exposes Python bindings via pyo3 (`_sc62015_rustcore`), used by `BridgeCPU`.
+- `HybridBus` bridges Rust memory image with host (Python) memory and devices (LCD, keyboard), and optional Perfetto tracer.
+- `PerfettoTracer` (core/perfetto.rs) emits instruction/memory instant events for trace comparison.
+
+## Testing & Parity
+
+- Parity tests compare Rust vs Python execution (`test_rust_execution_matches_pyemu`), with state dicts normalized (skip FC/FZ).
+- IMEM cache invalidation and fallback snapshot restore fixes keep parity green.

--- a/scripts/capture_snapshot.py
+++ b/scripts/capture_snapshot.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Capture a PC-E500 emulator snapshot for fast replay/debug loops."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+# Allow running without PYTHONPATH set
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from pce500.run_pce500 import run_emulator
+
+
+def _apply_preset(args: argparse.Namespace) -> None:
+    """Apply optional presets (currently, a Rust-fast profile)."""
+
+    if args.preset == "rust-fast":
+        os.environ.setdefault("SC62015_CPU_BACKEND", "rust")
+        os.environ.setdefault("RUST_TIMER_IN_RUST", "1")
+        if args.fast_mode is None:
+            args.fast_mode = True
+        if args.timeout_secs is None:
+            args.timeout_secs = 0.0
+        if args.no_perfetto is None:
+            args.no_perfetto = True
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Capture a .pcsnap bundle")
+    parser.add_argument(
+        "--output",
+        type=str,
+        required=True,
+        help="Path to write the snapshot (.pcsnap)",
+    )
+    parser.add_argument(
+        "--steps",
+        type=int,
+        default=15000,
+        help="Instructions to execute before capturing the snapshot (default: 15000)",
+    )
+    parser.add_argument(
+        "--fast-mode",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Enable the emulator fast path (default: on for Rust preset/backend)",
+    )
+    parser.add_argument(
+        "--timeout-secs",
+        type=float,
+        default=None,
+        help="Abort after this many seconds (default: 0 for Rust preset/backend, 10 otherwise)",
+    )
+    parser.add_argument(
+        "--perfetto",
+        action="store_true",
+        help="Enable new Perfetto tracing during capture",
+    )
+    parser.add_argument(
+        "--no-perfetto",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Disable legacy perfetto tracing (default: off; rust-fast preset also forces off unless overridden)",
+    )
+    parser.add_argument(
+        "--trace-file",
+        type=str,
+        default="pc-e500.perfetto-trace",
+        help="Perfetto trace path (only used when --perfetto is set)",
+    )
+    parser.add_argument(
+        "--preset",
+        choices=["rust-fast"],
+        help="Convenience preset (rust-fast sets backend=rust, timers in Rust, fast_mode on, timeout 0)",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Silence run statistics",
+    )
+    args = parser.parse_args()
+
+    _apply_preset(args)
+    perfetto_trace_enabled = False
+    if args.no_perfetto is not None:
+        perfetto_trace_enabled = not bool(args.no_perfetto)
+    if args.perfetto:
+        perfetto_trace_enabled = True
+
+    run_emulator(
+        num_steps=args.steps,
+        perfetto_trace=perfetto_trace_enabled,
+        new_perfetto=args.perfetto,
+        trace_file=args.trace_file,
+        timeout_secs=args.timeout_secs,
+        fast_mode=args.fast_mode,
+        print_stats=not args.quiet,
+        save_snapshot=args.output,
+        # snapshots are for speed; avoid extra overhead unless requested
+        save_lcd=not args.quiet,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/list_sources.sh
+++ b/scripts/list_sources.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# List Python, Rust, and Markdown sources, excluding tests and generated outputs.
+# Relies on `fd` for fast searching.
+
+if ! command -v fd >/dev/null 2>&1; then
+  echo "fd is required but not installed" >&2
+  exit 1
+fi
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+fd --color=never --type f \
+  --extension py --extension rs --extension md \
+  "$ROOT" \
+  --exclude '*/tests/*' \
+  --exclude 'tests' \
+  --exclude '*/generated/*' \
+  --exclude 'generated' \
+  --exclude '*/target/*' \
+  --exclude 'target' \
+  --exclude '__pycache__' \
+  --exclude '.venv' \
+  --exclude 'venv' \
+  | LC_ALL=C sort

--- a/scripts/run_from_snapshot.py
+++ b/scripts/run_from_snapshot.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Replay a PC-E500 snapshot and optionally emit a Perfetto trace."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+# Allow running without PYTHONPATH set
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from pce500.run_pce500 import run_emulator
+
+
+def _apply_preset(args: argparse.Namespace) -> None:
+    """Apply optional presets (currently, a Rust-fast profile)."""
+
+    if args.preset == "rust-fast":
+        os.environ.setdefault("SC62015_CPU_BACKEND", "rust")
+        os.environ.setdefault("RUST_TIMER_IN_RUST", "1")
+        if args.fast_mode is None:
+            args.fast_mode = True
+        if args.timeout_secs is None:
+            args.timeout_secs = 0.0
+        if args.no_perfetto is None:
+            args.no_perfetto = True
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Replay a .pcsnap bundle")
+    parser.add_argument(
+        "--snapshot",
+        type=str,
+        required=True,
+        help="Path to a .pcsnap file captured via run_pce500.py or capture_snapshot.py",
+    )
+    parser.add_argument(
+        "--steps",
+        type=int,
+        default=100,
+        help="Number of instructions to execute from the snapshot (default: 100)",
+    )
+    parser.add_argument(
+        "--fast-mode",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Enable the emulator fast path (default: on for Rust preset/backend)",
+    )
+    parser.add_argument(
+        "--timeout-secs",
+        type=float,
+        default=None,
+        help="Abort after this many seconds (default: 0 for Rust preset/backend, 10 otherwise)",
+    )
+    parser.add_argument(
+        "--perfetto",
+        action="store_true",
+        help="Enable new Perfetto tracing during replay",
+    )
+    parser.add_argument(
+        "--no-perfetto",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Disable legacy perfetto tracing (default: off; rust-fast preset also forces off unless overridden)",
+    )
+    parser.add_argument(
+        "--trace-file",
+        type=str,
+        default="snapshot-run.perfetto-trace",
+        help="Perfetto trace path (only used when --perfetto is set)",
+    )
+    parser.add_argument(
+        "--save-snapshot",
+        type=str,
+        help="Optionally save the post-run snapshot to this path",
+    )
+    parser.add_argument(
+        "--preset",
+        choices=["rust-fast"],
+        help="Convenience preset (rust-fast sets backend=rust, timers in Rust, fast_mode on, timeout 0)",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Silence run statistics",
+    )
+    args = parser.parse_args()
+
+    _apply_preset(args)
+    perfetto_trace_enabled = False
+    if args.no_perfetto is not None:
+        perfetto_trace_enabled = not bool(args.no_perfetto)
+    if args.perfetto:
+        # New tracer implies legacy Perfetto stays off to avoid double overhead.
+        perfetto_trace_enabled = False
+
+    run_emulator(
+        num_steps=args.steps,
+        perfetto_trace=perfetto_trace_enabled,
+        new_perfetto=args.perfetto,
+        trace_file=args.trace_file,
+        timeout_secs=args.timeout_secs,
+        fast_mode=args.fast_mode,
+        print_stats=not args.quiet,
+        load_snapshot=args.snapshot,
+        save_snapshot=args.save_snapshot,
+        # Snapshot replays should not waste time saving LCD PNGs unless asked
+        save_lcd=not args.quiet,
+    ).close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_with_snapshot.sh
+++ b/scripts/run_with_snapshot.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Lightweight wrapper around run_pce500.py to exercise snapshot capture/replay.
+# Environment variables:
+#   SC62015_CPU_BACKEND   Backend selection (rust/python) – defaults to python.
+#   FAST_MODE             If set, passes --fast-mode (defaults to 1 for rust).
+#   RUST_TIMER_IN_RUST    Forced to 1 for rust backend unless provided.
+#   SNAPSHOT_IN           Optional .pcsnap path to load before stepping.
+#   SNAPSHOT_OUT          Optional .pcsnap path to capture if SNAPSHOT_IN is absent.
+#   SNAPSHOT_SAVE_AFTER   Optional .pcsnap path to save after the replay step.
+#   SNAPSHOT_CAPTURE_STEPS  Steps for the capture stage (default: 15000).
+#   RUN_STEPS             Steps for the replay stage (default: 500).
+#   TIMEOUT_SECS          Override timeout; defaults to 0 for rust, 10 otherwise.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+BACKEND="${SC62015_CPU_BACKEND:-python}"
+
+# Defaults for Rust: timers in Rust, fast_mode on, no timeout
+if [[ "$BACKEND" == "rust" ]]; then
+    export RUST_TIMER_IN_RUST="${RUST_TIMER_IN_RUST:-1}"
+    FAST_MODE="${FAST_MODE:-1}"
+    TIMEOUT_SECS="${TIMEOUT_SECS:-0}"
+else
+    FAST_MODE="${FAST_MODE:-}"
+    TIMEOUT_SECS="${TIMEOUT_SECS:-10}"
+fi
+
+base_cmd=(uv run python pce500/run_pce500.py --timeout-secs "$TIMEOUT_SECS" --no-perfetto)
+if [[ -n "$FAST_MODE" ]]; then
+    base_cmd+=(--fast-mode)
+fi
+
+# If we only have SNAPSHOT_OUT, capture first then reuse it for replay.
+if [[ -z "${SNAPSHOT_IN:-}" && -n "${SNAPSHOT_OUT:-}" ]]; then
+    cap_steps="${SNAPSHOT_CAPTURE_STEPS:-15000}"
+    echo "Capturing snapshot to ${SNAPSHOT_OUT} (steps=${cap_steps})..."
+    "${base_cmd[@]}" --steps "$cap_steps" --save-snapshot "$SNAPSHOT_OUT"
+    SNAPSHOT_IN="$SNAPSHOT_OUT"
+fi
+
+run_steps="${RUN_STEPS:-500}"
+run_cmd=("${base_cmd[@]}" --steps "$run_steps")
+if [[ -n "${SNAPSHOT_IN:-}" ]]; then
+    run_cmd+=(--load-snapshot "$SNAPSHOT_IN")
+fi
+if [[ -n "${SNAPSHOT_SAVE_AFTER:-}" ]]; then
+    run_cmd+=(--save-snapshot "$SNAPSHOT_SAVE_AFTER")
+fi
+
+echo "Replaying snapshot (steps=${run_steps})..."
+FORCE_BINJA_MOCK=1 "${run_cmd[@]}"


### PR DESCRIPTION
## Summary
- add SCIL architecture report, rust emulator file map, and reuse plan docs
- add helper scripts for snapshots and source listing

## Testing
- not run (docs/scripts only)