### PR TITLE
Wire LLAMA perfetto tracing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ lcd_right.png
 *.perfetto-trace
 .claude/
 *.bin
+*.log
 
 # Rust build artifacts
 target/

--- a/pce500/run_pce500.py
+++ b/pce500/run_pce500.py
@@ -109,9 +109,6 @@ def run_emulator(
                 return
             if not inject(key_code, release=release):
                 return
-            ensure = getattr(emu, "_ensure_key_irq_mask", None)
-            if callable(ensure):
-                ensure()
             emu._set_isr_bits(int(ISRFlag.KEYI))
             emu._irq_pending = True
             emu._irq_source = IRQSource.KEY
@@ -604,6 +601,9 @@ def main(
     save_snapshot: str | Path | None = None,
 ):
     """Example with Perfetto tracing enabled."""
+    # Local import for KEYI_DEBUG injection.
+    from sc62015.pysc62015.instr.opcodes import IMEMRegisters
+
     # Enable performance profiling if requested
     if profile_emulator:
         from pce500.tracing.perfetto_tracing import enable_profiling, tracer
@@ -655,6 +655,24 @@ def main(
         load_snapshot=load_snapshot,
         save_snapshot=save_snapshot,
     ) as emu:
+        if os.getenv("KEYI_DEBUG") == "1":
+            try:
+                # One-shot KEYI set after reset to prove IRQ path.
+                emu._set_isr_bits(int(ISRFlag.KEYI))
+                emu._irq_pending = True
+                emu._irq_source = (
+                    emu._irq_source if getattr(emu, "_irq_source", None) else "KEY"
+                )
+                from pce500.emulator import INTERNAL_MEMORY_START
+
+                imr_addr = INTERNAL_MEMORY_START + IMEMRegisters.IMR
+                isr_addr = INTERNAL_MEMORY_START + IMEMRegisters.ISR
+                print(
+                    f"[key-debug] forced KEYI set imr=0x{emu.memory.read_byte(imr_addr):02X} "
+                    f"isr=0x{emu.memory.read_byte(isr_addr):02X}"
+                )
+            except Exception as exc:
+                print(f"[key-debug] forced PF2 press failed: {exc}")
         # Pass-through secondary scheduling parameters via emulator attributes
         if auto2_press_key and auto2_press_after_steps is not None:
             setattr(emu, "_auto2_key", auto2_press_key)

--- a/sc62015/core/Cargo.lock
+++ b/sc62015/core/Cargo.lock
@@ -87,9 +87,9 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "borsh"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
+checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
 dependencies = [
  "cfg_aliases",
 ]
@@ -291,6 +291,12 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -668,6 +674,7 @@ name = "sc62015-core"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "lazy_static",
  "retrobus-perfetto",
  "serde",
  "serde_json",
@@ -754,9 +761,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.110"
+version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -925,18 +932,18 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.28"
+version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43fa6694ed34d6e57407afbccdeecfa268c470a7d2a5b0cf49ce9fcc345afb90"
+checksum = "4ea879c944afe8a2b25fef16bb4ba234f47c694565e97383b36f3a878219065c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.28"
+version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c640b22cd9817fae95be82f0d2f90b11f7605f6c319d16705c459b27ac2cbc26"
+checksum = "cf955aa904d6040f70dc8e9384444cb1030aed272ba3cb09bbc4ab9e7c1f34f5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/sc62015/core/Cargo.toml
+++ b/sc62015/core/Cargo.toml
@@ -11,6 +11,8 @@ serde_json = "1.0"
 thiserror = "1.0"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
 retrobus-perfetto = { git = "https://github.com/mblsha/retrobus-perfetto.git" }
+lazy_static = "1.4"
+
 [dependencies.clap]
 version = "4.5"
 features = ["derive"]

--- a/sc62015/core/src/lcd.rs
+++ b/sc62015/core/src/lcd.rs
@@ -3,6 +3,10 @@ use std::env;
 
 const LCD_WIDTH: usize = 64;
 const LCD_PAGES: usize = 8;
+#[allow(dead_code)]
+const LCD_RANGE_LOW: u32 = 0x2000;
+#[allow(dead_code)]
+const LCD_RANGE_HIGH: u32 = 0xA000;
 pub const LCD_DISPLAY_ROWS: usize = 32;
 pub const LCD_DISPLAY_COLS: usize = 240;
 

--- a/sc62015/core/src/lib.rs
+++ b/sc62015/core/src/lib.rs
@@ -1,30 +1,34 @@
-pub mod memory;
 pub mod keyboard;
 pub mod lcd;
+pub mod llama;
+pub mod memory;
+pub mod perfetto;
 pub mod snapshot;
 pub mod timer;
-pub mod perfetto;
-pub mod llama;
 
 use crate::llama::{opcodes::RegName, state::LlamaState};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::sync::Mutex;
 use std::time::SystemTime;
 use thiserror::Error;
 
 pub use keyboard::KeyboardMatrix;
 pub use lcd::{LcdController, LCD_DISPLAY_COLS, LCD_DISPLAY_ROWS};
+pub use llama::state::LlamaState as CpuState;
 pub use memory::{
     MemoryImage, ADDRESS_MASK, EXTERNAL_SPACE, INTERNAL_ADDR_MASK, INTERNAL_MEMORY_START,
     INTERNAL_RAM_SIZE, INTERNAL_RAM_START, INTERNAL_SPACE,
 };
 pub use perfetto::PerfettoTracer;
-pub use timer::TimerContext;
+lazy_static::lazy_static! {
+    pub static ref PERFETTO_TRACER: Mutex<Option<PerfettoTracer>> = Mutex::new(None);
+}
 pub use snapshot::{
     load_snapshot, pack_registers, save_snapshot, unpack_registers, SnapshotLoad, SNAPSHOT_MAGIC,
     SNAPSHOT_REGISTER_LAYOUT, SNAPSHOT_VERSION,
 };
-pub use llama::state::LlamaState as CpuState;
+pub use timer::TimerContext;
 
 pub type Result<T> = std::result::Result<T, CoreError>;
 

--- a/sc62015/core/src/perfetto.rs
+++ b/sc62015/core/src/perfetto.rs
@@ -115,4 +115,14 @@ impl PerfettoTracer {
             .save(&self.path)
             .map_err(|e| crate::CoreError::Other(format!("perfetto save: {e}")))
     }
+
+    /// Lightweight instant for IMEM/ISR diagnostics (used by test hooks).
+    pub fn record_keyi_set(&mut self, addr: u32, value: u8) {
+        let mut ev = self
+            .builder
+            .add_instant_event(self.exec_track, "KEYI_Set".to_string(), 0);
+        ev.add_annotation("offset", addr as u64);
+        ev.add_annotation("value", value as u64);
+        ev.finish();
+    }
 }

--- a/sc62015/core/src/snapshot.rs
+++ b/sc62015/core/src/snapshot.rs
@@ -55,7 +55,9 @@ impl RangeSerde {
     }
 }
 
-pub(crate) fn deserialize_range<'de, D>(deserializer: D) -> std::result::Result<(u32, u32), D::Error>
+pub(crate) fn deserialize_range<'de, D>(
+    deserializer: D,
+) -> std::result::Result<(u32, u32), D::Error>
 where
     D: serde::Deserializer<'de>,
 {
@@ -160,9 +162,9 @@ pub fn load_snapshot(path: &Path, memory: &mut MemoryImage) -> Result<SnapshotLo
     let metadata = {
         let mut meta_buf = Vec::new();
         {
-            let mut meta_file = archive.by_name("snapshot.json").map_err(|e| {
-                CoreError::InvalidSnapshot(format!("snapshot.json missing: {e}"))
-            })?;
+            let mut meta_file = archive
+                .by_name("snapshot.json")
+                .map_err(|e| CoreError::InvalidSnapshot(format!("snapshot.json missing: {e}")))?;
             meta_file.read_to_end(&mut meta_buf)?;
         }
         let metadata: SnapshotMetadata = serde_json::from_slice(&meta_buf)?;
@@ -176,9 +178,9 @@ pub fn load_snapshot(path: &Path, memory: &mut MemoryImage) -> Result<SnapshotLo
 
     let registers = {
         let mut reg_buf = Vec::new();
-        let mut reg_file = archive.by_name("registers.bin").map_err(|e| {
-            CoreError::InvalidSnapshot(format!("registers.bin missing: {e}"))
-        })?;
+        let mut reg_file = archive
+            .by_name("registers.bin")
+            .map_err(|e| CoreError::InvalidSnapshot(format!("registers.bin missing: {e}")))?;
         reg_file.read_to_end(&mut reg_buf)?;
         unpack_registers(&reg_buf)?
     };

--- a/sc62015/rustcore/Cargo.lock
+++ b/sc62015/rustcore/Cargo.lock
@@ -18,6 +18,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,6 +123,52 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "clap"
+version = "4.5.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "crc32fast"
@@ -200,10 +296,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -280,6 +388,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "parking_lot_core"
@@ -658,6 +772,8 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 name = "sc62015-core"
 version = "0.1.0"
 dependencies = [
+ "clap",
+ "lazy_static",
  "retrobus-perfetto",
  "serde",
  "serde_json",
@@ -745,6 +861,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,6 +927,12 @@ name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "wasip2"


### PR DESCRIPTION
## Summary
- hand the Perfetto trace path to the LLAMA backend when the new tracer is active
- attach KEYI tracing to the keyboard matrix so key scans reach perfetto
- keep perfetto tracing enabled across emulator and core updates

## Testing
- not run (CI)
