### PR TITLE
Refactor stepper register mapping to remove duplication

### DIFF
--- a/sc62015/pysc62015/stepper.py
+++ b/sc62015/pysc62015/stepper.py
@@ -29,6 +29,10 @@ _CORE_REGISTER_FIELDS: Tuple[str, ...] = (
     "f",
 )
 
+_REGISTER_BINDINGS: Tuple[Tuple[str, RegisterName], ...] = tuple(
+    (field_name, getattr(RegisterName, field_name.upper())) for field_name in _CORE_REGISTER_FIELDS
+)
+
 
 @dataclass(slots=True)
 class CPURegistersSnapshot:
@@ -54,28 +58,20 @@ class CPURegistersSnapshot:
             if value:
                 temps[index] = value
 
+        register_values = {
+            field_name: regs.get(register_name)
+            for field_name, register_name in _REGISTER_BINDINGS
+        }
+
         return cls(
-            pc=regs.get(RegisterName.PC),
-            ba=regs.get(RegisterName.BA),
-            i=regs.get(RegisterName.I),
-            x=regs.get(RegisterName.X),
-            y=regs.get(RegisterName.Y),
-            u=regs.get(RegisterName.U),
-            s=regs.get(RegisterName.S),
-            f=regs.get(RegisterName.F),
+            **register_values,
             temps=temps,
             call_sub_level=regs.call_sub_level,
         )
 
     def apply_to(self, regs: Registers) -> None:
-        regs.set(RegisterName.PC, self.pc)
-        regs.set(RegisterName.BA, self.ba)
-        regs.set(RegisterName.I, self.i)
-        regs.set(RegisterName.X, self.x)
-        regs.set(RegisterName.Y, self.y)
-        regs.set(RegisterName.U, self.u)
-        regs.set(RegisterName.S, self.s)
-        regs.set(RegisterName.F, self.f)
+        for field_name, register_name in _REGISTER_BINDINGS:
+            regs.set(register_name, getattr(self, field_name))
 
         for index in range(NUM_TEMP_REGISTERS):
             value = self.temps.get(index, 0)
@@ -84,16 +80,7 @@ class CPURegistersSnapshot:
         regs.call_sub_level = self.call_sub_level
 
     def to_dict(self) -> Dict[str, int]:
-        values = {
-            "pc": self.pc,
-            "ba": self.ba,
-            "i": self.i,
-            "x": self.x,
-            "y": self.y,
-            "u": self.u,
-            "s": self.s,
-            "f": self.f,
-        }
+        values = {field_name: getattr(self, field_name) for field_name in _CORE_REGISTER_FIELDS}
         for index, value in self.temps.items():
             values[f"TEMP{index}"] = value
         values["call_sub_level"] = self.call_sub_level


### PR DESCRIPTION
### Motivation
- Reduce a maintainability code smell by centralizing the mapping between snapshot field names and `RegisterName` values to avoid duplicated lists of core register names across methods.

### Description
- Introduce `_REGISTER_BINDINGS` derived from `_CORE_REGISTER_FIELDS` to pair field names with `RegisterName` members. 
- Update `CPURegistersSnapshot.from_registers` to build `register_values` from `_REGISTER_BINDINGS` and pass them via `**` to the constructor. 
- Replace manual per-field `regs.set(...)` calls in `CPURegistersSnapshot.apply_to` with an iteration over `_REGISTER_BINDINGS`. 
- Simplify `CPURegistersSnapshot.to_dict` to construct its mapping from `_CORE_REGISTER_FIELDS` programmatically. 
- Affects `sc62015/pysc62015/stepper.py` only and is intended as a pure refactor with no behavior change.

### Testing
- Ran `uv run ruff check sc62015/pysc62015/stepper.py` and it completed with no lint errors. 
- Ran `FORCE_BINJA_MOCK=1 uv run pytest sc62015/pysc62015/test_stepper.py -q` and all tests passed (3 passed; pytest emitted unrelated config warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d83e475f6083318756def528dd7ad0)