### PR TITLE
pce500: replace unused loop variables with discard names in keyboard scan and demo

### DIFF
--- a/pce500/keyboard_matrix.py
+++ b/pce500/keyboard_matrix.py
@@ -338,7 +338,7 @@ class KeyboardMatrix:
 
         events: List[MatrixEvent] = []
         active_cols = set(self._active_columns())
-        for key_code, state in self._key_states.items():
+        for _key_code, state in self._key_states.items():
             generated = self._update_key_state(state, active_cols)
             if generated:
                 events.extend(generated)

--- a/pce500/tests/test_keyboard_strobing_demo.py
+++ b/pce500/tests/test_keyboard_strobing_demo.py
@@ -70,7 +70,7 @@ def demonstrate_keyboard_strobing():
     print("-" * 50)
 
     # Run scan without any keys pressed
-    for i in range(9):
+    for _ in range(9):
         emu.step()
 
     col0_result = emu.memory.read_byte(0x00)
@@ -79,7 +79,7 @@ def demonstrate_keyboard_strobing():
     print(f"Column 1 scan result: 0x{col1_result:02X} (expected 0xFF)")
 
     # Continue scanning column 10
-    for i in range(6):
+    for _ in range(6):
         emu.step()
     col10_result = emu.memory.read_byte(0x02)
     print(f"Column 10 scan result: 0x{col10_result:02X} (expected 0xFF)")
@@ -92,7 +92,7 @@ def demonstrate_keyboard_strobing():
     emu.press_key("KEY_Q")
 
     # Run scan again
-    for i in range(9):
+    for _ in range(9):
         emu.step()
 
     col0_result = emu.memory.read_byte(0x00)
@@ -108,7 +108,7 @@ def demonstrate_keyboard_strobing():
     emu.press_key("KEY_P")
 
     # Continue to scan column 10
-    for i in range(6):
+    for _ in range(6):
         emu.step()
     col10_result = emu.memory.read_byte(0x02)
     print(f"Column 10 scan result: 0x{col10_result:02X} (expected 0xFE - bit 0 low)")
@@ -121,7 +121,7 @@ def demonstrate_keyboard_strobing():
 
     # Reset and scan again
     emu.cpu.regs.set(RegisterName.PC, 0x0000)
-    for i in range(9):
+    for _ in range(9):
         emu.step()
 
     col0_result = emu.memory.read_byte(0x00)


### PR DESCRIPTION
### Motivation
- Silence a small lint/code-smell where loop indices are intentionally unused by making the discard intent explicit and improving readability.

### Description
- Replace `key_code` with `_key_code` in `KeyboardMatrix.scan_tick()` and replace `for i in ...` with `for _ in ...` in `pce500/tests/test_keyboard_strobing_demo.py` so unused iteration variables are named as discards.

### Testing
- Ran the focused lint check `uv run ruff check pce500/keyboard_matrix.py pce500/tests/test_keyboard_strobing_demo.py --select B007`, which passed.
- Ran the targeted test suite `FORCE_BINJA_MOCK=1 uv run pytest pce500/tests/test_keyboard_matrix.py pce500/tests/test_keyboard_strobing_demo.py -q`, which passed (all tests green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddf1a535848331b1f6d675a198747d)