### PR TITLE
pce500: remove LCD chip-select magic values

### DIFF
--- a/pce500/display/controller_wrapper.py
+++ b/pce500/display/controller_wrapper.py
@@ -94,12 +94,13 @@ class HD61202Controller:
         except ValueError:
             return
 
-        if command.cs.value == 0b00:
-            self.cs_both_count += 1
-        elif command.cs.value == 0b01:
-            self.cs_right_count += 1
-        elif command.cs.value == 0b10:
-            self.cs_left_count += 1
+        cs_counter_attr = {
+            ChipSelect.BOTH: "cs_both_count",
+            ChipSelect.RIGHT: "cs_right_count",
+            ChipSelect.LEFT: "cs_left_count",
+        }.get(command.cs)
+        if cs_counter_attr is not None:
+            setattr(self, cs_counter_attr, getattr(self, cs_counter_attr) + 1)
 
         operation_pc = cpu_pc if cpu_pc is not None else self._get_current_pc()
         self.pipeline.apply(LCDOperation(command=command, pc=operation_pc))

--- a/pce500/tests/test_controller_wrapper.py
+++ b/pce500/tests/test_controller_wrapper.py
@@ -1,0 +1,13 @@
+from pce500.display.controller_wrapper import HD61202Controller
+
+
+def test_write_tracks_chip_select_counters_without_magic_values() -> None:
+    lcd = HD61202Controller()
+
+    lcd.write(0xA000, 0x00)  # BOTH
+    lcd.write(0xA004, 0x00)  # RIGHT
+    lcd.write(0xA008, 0x00)  # LEFT
+
+    assert lcd.cs_both_count == 1
+    assert lcd.cs_right_count == 1
+    assert lcd.cs_left_count == 1


### PR DESCRIPTION
### Motivation
- Remove hard-coded chip-select bit-pattern checks in `HD61202Controller.write` to make intent explicit and tie logic to the `ChipSelect` enum for better maintainability.

### Description
- Replace `if command.cs.value == 0b00/0b01/0b10` branches with a `ChipSelect`→attribute mapping and update the corresponding counter via `getattr`/`setattr`, and add a focused regression test `pce500/tests/test_controller_wrapper.py` that verifies BOTH/RIGHT/LEFT counters increment.

### Testing
- Ran `uv run pytest pce500/tests/test_controller_wrapper.py -q` which passed (`1 passed`), and `uv run ruff check pce500/display/controller_wrapper.py pce500/tests/test_controller_wrapper.py` which returned `All checks passed!`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddf1a535848331b1f6d675a198747d)