### PR TITLE
[codex] Fix PC-E500 BASIC TUI input and PRE decoding

### DIFF
--- a/sc62015/core/src/bin/sc62015_lcd.rs
+++ b/sc62015/core/src/bin/sc62015_lcd.rs
@@ -24,12 +24,13 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 const IQ7000_TEXT_ROWS: usize = 8;
 const IQ7000_TEXT_COLS: usize = 16;
 const STATUS_UPDATE_INTERVAL: Duration = Duration::from_millis(100);
-const PF_KEY_HOLD_STEPS: u64 = 2_000;
+const PF_KEY_HOLD_STEPS: u64 = 40_000;
+const CHAR_KEY_HOLD_STEPS: u64 = 10_000;
 const ON_AUTO_HOLD_CYCLES: u64 = 20_000;
 const BASIC_REPL_HUB_PC: u32 = 0x00FFE09;
 const BASIC_WARM_START_PC: u32 = 0x00F9C94;
 const AUTO_TYPE_START_DELAY_STEPS: u64 = 20_000;
-const AUTO_TYPE_GAP_STEPS: u64 = 5_000;
+const AUTO_TYPE_GAP_STEPS: u64 = 20_000;
 const BASIC_KEY_CODE: u8 = 0x04;
 const IMR_MASTER: u8 = 0x80;
 const IMR_KEY: u8 = 0x04;
@@ -123,6 +124,10 @@ struct Args {
     #[arg(long)]
     auto_type: Option<String>,
 
+    /// Auto-press PF1 at the new-card initialization prompt (debug helper).
+    #[arg(long, default_value_t = false)]
+    auto_init: bool,
+
     /// Auto-press the BASIC key after PF1 completes (debug helper).
     #[arg(long, default_value_t = false)]
     auto_basic: bool,
@@ -138,6 +143,18 @@ struct Args {
     /// Write loop report JSON on exit (defaults to loop_report_<epoch>.json).
     #[arg(long, value_name = "PATH")]
     loop_report: Option<PathBuf>,
+
+    /// Load a snapshot before running.
+    #[arg(long, value_name = "PATH")]
+    snapshot_in: Option<PathBuf>,
+
+    /// Save a snapshot when --snapshot-on-text appears (or on exit if no trigger is set).
+    #[arg(long, value_name = "PATH")]
+    snapshot_out: Option<PathBuf>,
+
+    /// LCD text substring that triggers --snapshot-out.
+    #[arg(long, value_name = "TEXT")]
+    snapshot_on_text: Option<String>,
 }
 
 struct TerminalGuard {
@@ -538,6 +555,16 @@ fn decode_row0(
     }
 }
 
+fn decode_display_text(
+    text_decoder: &Option<sc62015_core::device::DeviceTextDecoder>,
+    runtime: &CoreRuntime,
+) -> String {
+    match (text_decoder, runtime.lcd.as_deref()) {
+        (Some(decoder), Some(lcd)) => decoder.decode_display_text(lcd).join("\n"),
+        _ => String::new(),
+    }
+}
+
 fn strip_leading_line_comments(raw: &str) -> String {
     let lines = raw.split('\n');
     let mut output = Vec::new();
@@ -906,7 +933,7 @@ fn inject_key(
     }
     if let Some(kb) = runtime.keyboard.as_mut() {
         let kb_irq_enabled = runtime.timer.kb_irq_enabled || force_key_irq;
-        let _ = kb.inject_matrix_event(code, false, &mut runtime.memory, kb_irq_enabled);
+        kb.press_matrix_code(code, &mut runtime.memory);
         if kb_irq_enabled {
             runtime.timer.key_irq_latched = true;
             if let Some(cur) = runtime.memory.read_internal_byte(IMEM_ISR_OFFSET) {
@@ -920,7 +947,7 @@ fn inject_key(
             }
         }
         if hold_steps == 0 {
-            let _ = kb.inject_matrix_event(code, true, &mut runtime.memory, kb_irq_enabled);
+            kb.release_matrix_code(code, &mut runtime.memory);
         } else {
             pending_releases.retain(|pending| pending.code != code);
             pending_releases.push(PendingRelease {
@@ -954,12 +981,11 @@ fn apply_pending_releases(
         pending_releases.clear();
         return;
     };
-    let kb_irq_enabled = runtime.timer.kb_irq_enabled;
     let mut idx = 0;
     while idx < pending_releases.len() {
         if pending_releases[idx].due_step <= executed {
             let code = pending_releases[idx].code;
-            let _ = kb.inject_matrix_event(code, true, &mut runtime.memory, kb_irq_enabled);
+            kb.release_matrix_code(code, &mut runtime.memory);
             pending_releases.swap_remove(idx);
         } else {
             idx += 1;
@@ -1017,21 +1043,42 @@ fn handle_key_event(
     }
     match key.code {
         KeyCode::Enter => {
-            inject_key(runtime, 0x4F, executed, pending_releases, 0, force_key_irq);
+            inject_key(
+                runtime,
+                0x4F,
+                executed,
+                pending_releases,
+                CHAR_KEY_HOLD_STEPS,
+                force_key_irq,
+            );
             return KeyFeedback {
                 label: Some("=".to_string()),
                 quit: false,
             };
         }
         KeyCode::Backspace => {
-            inject_key(runtime, 0x4D, executed, pending_releases, 0, force_key_irq);
+            inject_key(
+                runtime,
+                0x4D,
+                executed,
+                pending_releases,
+                CHAR_KEY_HOLD_STEPS,
+                force_key_irq,
+            );
             return KeyFeedback {
                 label: Some("BS".to_string()),
                 quit: false,
             };
         }
         KeyCode::Delete => {
-            inject_key(runtime, 0x4C, executed, pending_releases, 0, force_key_irq);
+            inject_key(
+                runtime,
+                0x4C,
+                executed,
+                pending_releases,
+                CHAR_KEY_HOLD_STEPS,
+                force_key_irq,
+            );
             return KeyFeedback {
                 label: Some("DEL".to_string()),
                 quit: false,
@@ -1125,7 +1172,14 @@ fn handle_key_event(
                 }
             }
             if let Some(code) = matrix_code_for_char(ch) {
-                inject_key(runtime, code, executed, pending_releases, 0, force_key_irq);
+                inject_key(
+                    runtime,
+                    code,
+                    executed,
+                    pending_releases,
+                    CHAR_KEY_HOLD_STEPS,
+                    force_key_irq,
+                );
                 return KeyFeedback {
                     label: Some(ch.to_string()),
                     quit: false,
@@ -1151,21 +1205,30 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut runtime = CoreRuntime::new();
     runtime.set_device_model(args.model)?;
     args.model.configure_runtime(&mut runtime, &rom_bytes)?;
-    runtime
-        .memory
-        .set_memory_card_slot_present(matches!(args.card, CardMode::Present));
+    if args.model.is_pce500_family() {
+        if let Some(kb) = runtime.keyboard.as_mut() {
+            kb.set_press_threshold(1);
+        }
+    }
     if args.disable_timers {
         *runtime.timer = TimerContext::new(false, 0, 0);
     } else {
         *runtime.timer =
             TimerContext::new(true, DEFAULT_MTI_PERIOD as i32, DEFAULT_STI_PERIOD as i32);
     }
+    runtime
+        .memory
+        .set_memory_card_slot_present(matches!(args.card, CardMode::Present));
     let loop_config = LoopDetectorConfig {
         detect_stride: args.refresh_steps,
         ..Default::default()
     };
     runtime.enable_loop_detector(loop_config);
-    runtime.power_on_reset();
+    if let Some(snapshot_in) = args.snapshot_in.as_ref() {
+        runtime.load_snapshot(snapshot_in)?;
+    } else {
+        runtime.power_on_reset();
+    }
 
     let text_decoder = args.model.text_decoder(&rom_bytes);
     let (line_count, width) = lcd_geometry(args.model);
@@ -1193,10 +1256,16 @@ fn main() -> Result<(), Box<dyn Error>> {
         args.auto_type.clone().unwrap_or_default().chars().collect();
     let mut auto_type_next_step: Option<u64> = None;
     let mut auto_basic_step: Option<u64> = None;
+    let mut auto_main_pf1_step: Option<u64> = None;
+    let mut auto_menu_pf1_step: Option<u64> = None;
+    let mut auto_init_pending = args.auto_init;
+    let mut auto_main_pf1_pending = args.auto_init;
+    let mut auto_menu_pf1_pending = args.auto_init;
     let mut auto_basic_pending = args.auto_basic;
     let mut jump_basic_pending = args.jump_basic;
     let mut halted_steps: u64 = 0;
     let mut last_lcd_check: u64 = 0;
+    let mut snapshot_saved = false;
     let mut fast_init_cleared = false;
     let fast_init_buf = if args.fast_init && args.model.is_pce500_family() {
         Some(vec![0u8; ROM_WINDOW_START])
@@ -1307,19 +1376,35 @@ fn main() -> Result<(), Box<dyn Error>> {
                     let mut sent = false;
                     while let Some(ch) = auto_type_queue.first().copied() {
                         auto_type_queue.remove(0);
-                        let code = match ch {
-                            '\n' | '\r' => Some(0x4F),
-                            _ => matrix_code_for_char(ch),
+                        let did_inject = match ch {
+                            '\n' | '\r' => {
+                                inject_key(
+                                    &mut runtime,
+                                    0x4F,
+                                    executed,
+                                    &mut pending_releases,
+                                    CHAR_KEY_HOLD_STEPS,
+                                    args.force_key_irq,
+                                );
+                                true
+                            }
+                            _ => {
+                                if let Some(code) = matrix_code_for_char(ch) {
+                                    inject_key(
+                                        &mut runtime,
+                                        code,
+                                        executed,
+                                        &mut pending_releases,
+                                        CHAR_KEY_HOLD_STEPS,
+                                        args.force_key_irq,
+                                    );
+                                    true
+                                } else {
+                                    false
+                                }
+                            }
                         };
-                        if let Some(code) = code {
-                            inject_key(
-                                &mut runtime,
-                                code,
-                                executed,
-                                &mut pending_releases,
-                                0,
-                                args.force_key_irq,
-                            );
+                        if did_inject {
                             last_key = Some(ch.to_string());
                             last_key_step = executed;
                             auto_type_next_step =
@@ -1334,32 +1419,124 @@ fn main() -> Result<(), Box<dyn Error>> {
                     }
                 }
             }
+            if let Some(step) = auto_main_pf1_step {
+                if executed >= step {
+                    inject_key(
+                        &mut runtime,
+                        0x56,
+                        executed,
+                        &mut pending_releases,
+                        PF_KEY_HOLD_STEPS,
+                        args.force_key_irq,
+                    );
+                    last_key = Some("PF1".to_string());
+                    last_key_step = executed;
+                    auto_main_pf1_step = None;
+                    dirty = true;
+                }
+            }
+            if let Some(step) = auto_menu_pf1_step {
+                if executed >= step {
+                    inject_key(
+                        &mut runtime,
+                        0x56,
+                        executed,
+                        &mut pending_releases,
+                        PF_KEY_HOLD_STEPS,
+                        args.force_key_irq,
+                    );
+                    last_key = Some("PF1".to_string());
+                    last_key_step = executed;
+                    auto_menu_pf1_step = None;
+                    dirty = true;
+                }
+            }
             if runtime.state.is_halted() {
                 halted_steps = halted_steps.saturating_add(chunk);
             } else {
                 halted_steps = 0;
             }
-            let should_check_lcd =
-                (auto_basic_pending || jump_basic_pending) && auto_basic_step.is_none();
+            let should_check_lcd = (auto_init_pending
+                || auto_main_pf1_pending
+                || auto_menu_pf1_pending
+                || auto_main_pf1_step.is_some()
+                || auto_menu_pf1_step.is_some()
+                || auto_basic_pending
+                || jump_basic_pending
+                || (auto_type_next_step.is_none() && !auto_type_queue.is_empty()))
+                && auto_basic_step.is_none();
             if should_check_lcd && executed.saturating_sub(last_lcd_check) >= lcd_check_interval {
                 last_lcd_check = executed;
                 let row0 = decode_row0(&text_decoder, &runtime);
-                if (auto_basic_pending || jump_basic_pending)
-                    && auto_basic_step.is_none()
-                    && (row0.contains("S2(CARD):") || row0.contains("S1(MAIN):"))
-                {
-                    if jump_basic_pending {
-                        jump_to_basic_loop(&mut runtime);
-                        jump_basic_pending = false;
-                        if auto_type_next_step.is_none() && !auto_type_queue.is_empty() {
-                            auto_type_next_step =
-                                Some(executed.saturating_add(args.auto_basic_delay));
+                let display_text = decode_display_text(&text_decoder, &runtime);
+                if !snapshot_saved {
+                    if let (Some(path), Some(needle)) =
+                        (args.snapshot_out.as_ref(), args.snapshot_on_text.as_ref())
+                    {
+                        if display_text.contains(needle) {
+                            runtime.save_snapshot(path)?;
+                            eprintln!("[snapshot] saved to {}", path.display());
+                            snapshot_saved = true;
                         }
-                        dirty = true;
-                    } else {
-                        auto_basic_step = Some(executed.saturating_add(args.auto_basic_delay));
-                        auto_basic_pending = false;
                     }
+                }
+                if auto_init_pending && row0.contains("S2(CARD):NEW CARD") {
+                    inject_key(
+                        &mut runtime,
+                        0x56,
+                        executed,
+                        &mut pending_releases,
+                        PF_KEY_HOLD_STEPS,
+                        args.force_key_irq,
+                    );
+                    last_key = Some("PF1".to_string());
+                    last_key_step = executed;
+                    auto_init_pending = false;
+                    dirty = true;
+                    continue;
+                }
+                if auto_main_pf1_pending && row0.contains("S1(MAIN):NEW CARD") {
+                    auto_main_pf1_step = Some(executed.saturating_add(args.auto_basic_delay));
+                    auto_main_pf1_pending = false;
+                    dirty = true;
+                    continue;
+                }
+                if auto_menu_pf1_pending && display_text.contains("MAIN MENU") {
+                    auto_menu_pf1_step = Some(executed.saturating_add(args.auto_basic_delay));
+                    auto_menu_pf1_pending = false;
+                    dirty = true;
+                    continue;
+                }
+                if auto_type_next_step.is_none()
+                    && !auto_type_queue.is_empty()
+                    && display_text.contains('>')
+                {
+                    auto_type_next_step = Some(executed.saturating_add(args.auto_type_delay));
+                    dirty = true;
+                    continue;
+                }
+                let row_has_menu = row0.contains("S2(CARD):") || row0.contains("S1(MAIN):");
+                if jump_basic_pending
+                    && auto_basic_step.is_none()
+                    && !auto_init_pending
+                    && (fast_init_cleared
+                        || (!args.auto_init && row_has_menu)
+                        || (row_has_menu && !row0.contains("NEW CARD")))
+                {
+                    jump_to_basic_loop(&mut runtime);
+                    jump_basic_pending = false;
+                    if auto_type_next_step.is_none() && !auto_type_queue.is_empty() {
+                        auto_type_next_step = Some(executed.saturating_add(args.auto_basic_delay));
+                    }
+                    dirty = true;
+                } else if auto_basic_pending
+                    && auto_basic_step.is_none()
+                    && !auto_init_pending
+                    && row_has_menu
+                    && !row0.contains("NEW CARD")
+                {
+                    auto_basic_step = Some(executed.saturating_add(args.auto_basic_delay));
+                    auto_basic_pending = false;
                 }
             }
 
@@ -1424,6 +1601,17 @@ fn main() -> Result<(), Box<dyn Error>> {
             _ => Vec::new(),
         };
         let lines = normalize_lines(lines, line_count, width);
+        if !snapshot_saved {
+            if let (Some(path), Some(needle)) =
+                (args.snapshot_out.as_ref(), args.snapshot_on_text.as_ref())
+            {
+                if lines.join("\n").contains(needle) {
+                    runtime.save_snapshot(path)?;
+                    eprintln!("[snapshot] saved to {}", path.display());
+                    snapshot_saved = true;
+                }
+            }
+        }
         if first_draw || dirty || lines != last_lines {
             let status = format_status(
                 &runtime,
@@ -1462,6 +1650,13 @@ fn main() -> Result<(), Box<dyn Error>> {
             let json = serde_json::to_string_pretty(report)?;
             fs::write(&path, json)?;
             eprintln!("[loop] report saved to {}", path.display());
+        }
+    }
+
+    if !snapshot_saved {
+        if let Some(path) = args.snapshot_out.as_ref() {
+            runtime.save_snapshot(path)?;
+            eprintln!("[snapshot] saved to {}", path.display());
         }
     }
 

--- a/sc62015/core/src/bin/sc62015_lcd.rs
+++ b/sc62015/core/src/bin/sc62015_lcd.rs
@@ -33,6 +33,10 @@ const BASIC_WARM_START_PC: u32 = 0x00F9C94;
 const AUTO_TYPE_START_DELAY_STEPS: u64 = 20_000;
 const AUTO_TYPE_GAP_STEPS: u64 = 20_000;
 const BASIC_KEY_CODE: u8 = 0x04;
+const ENTER_KEY_CODE: u8 = 0x27;
+const DELETE_KEY_CODE: u8 = 0x4C;
+const BACKSPACE_KEY_CODE: u8 = 0x4D;
+const CLEAR_EXTERNAL_RAM_ROUTINES: &[(u32, u32)] = &[(0x0F0DD9, 0x0F0DEE), (0x0F0DEE, 0x0F0E1F)];
 const IMR_MASTER: u8 = 0x80;
 const IMR_KEY: u8 = 0x04;
 const ISR_KEYI: u8 = 0x04;
@@ -117,7 +121,7 @@ struct Args {
     #[arg(long, default_value_t = false)]
     fast_init: bool,
 
-    /// Jump to the BASIC entry point after the PF1 flow (debug helper).
+    /// Jump to the BASIC entry point after an initialized menu is available (debug helper).
     #[arg(long, default_value_t = false)]
     jump_basic: bool,
 
@@ -125,11 +129,7 @@ struct Args {
     #[arg(long)]
     auto_type: Option<String>,
 
-    /// Auto-press PF1 at the new-card initialization prompt (debug helper).
-    #[arg(long, default_value_t = false)]
-    auto_init: bool,
-
-    /// Auto-press the BASIC key after PF1 completes (debug helper).
+    /// Auto-press the BASIC key after an initialized menu is available (debug helper).
     #[arg(long, default_value_t = false)]
     auto_basic: bool,
 
@@ -682,12 +682,25 @@ fn in_sio_routine(runtime: &CoreRuntime, symbols: Option<&SymbolMap>) -> bool {
 
 fn in_clear_external_ram(runtime: &CoreRuntime, symbols: Option<&SymbolMap>) -> bool {
     let pc = runtime.state.pc() & 0x000f_ffff;
+    if CLEAR_EXTERNAL_RAM_ROUTINES
+        .iter()
+        .any(|(start, end)| pc >= *start && pc < *end)
+    {
+        return true;
+    }
     if let Some((_base, name, _)) = resolve_symbol(pc, symbols) {
         if name.starts_with("clear_external_ram_") {
             return true;
         }
     }
     if let Some(frame) = runtime.state.call_stack().last().copied() {
+        let frame = frame & 0x000f_ffff;
+        if CLEAR_EXTERNAL_RAM_ROUTINES
+            .iter()
+            .any(|(start, end)| frame >= *start && frame < *end)
+        {
+            return true;
+        }
         if let Some((_base, name, _)) = resolve_symbol(frame, symbols) {
             if name.starts_with("clear_external_ram_") {
                 return true;
@@ -697,11 +710,11 @@ fn in_clear_external_ram(runtime: &CoreRuntime, symbols: Option<&SymbolMap>) -> 
     false
 }
 
-fn fast_clear_pce500_ram(runtime: &mut CoreRuntime, cleared: &mut bool, zero_buf: &[u8]) {
+fn fast_clear_pce500_ram(runtime: &mut CoreRuntime, cleared: &mut bool, fill_buf: &[u8]) {
     if *cleared {
         return;
     }
-    runtime.memory.write_external_slice(0, zero_buf);
+    runtime.memory.write_external_slice(0, fill_buf);
     *cleared = true;
 }
 
@@ -800,7 +813,7 @@ struct StubReturnConfig<'a> {
     fast_delay: bool,
     stub_sio: bool,
     fast_init: bool,
-    ram_zero_buf: Option<&'a [u8]>,
+    ram_fill_buf: Option<&'a [u8]>,
 }
 
 fn apply_stub_returns(
@@ -825,7 +838,7 @@ fn apply_stub_returns(
         return true;
     }
     if config.fast_init {
-        if let Some(buf) = config.ram_zero_buf {
+        if let Some(buf) = config.ram_fill_buf {
             if in_clear_external_ram(runtime, config.symbols) {
                 fast_clear_pce500_ram(runtime, ram_cleared, buf);
                 force_return_auto(runtime);
@@ -850,6 +863,11 @@ struct PendingPress {
     code: u8,
     due_step: u64,
     hold_steps: u64,
+    force_key_irq: bool,
+}
+
+struct KeyEventOptions<'a> {
+    pending_on_release: &'a mut Option<u64>,
     force_key_irq: bool,
 }
 
@@ -1125,8 +1143,7 @@ fn handle_key_event(
     executed: u64,
     pending_releases: &mut Vec<PendingRelease>,
     pending_presses: &mut Vec<PendingPress>,
-    pending_on_release: &mut Option<u64>,
-    force_key_irq: bool,
+    options: KeyEventOptions<'_>,
 ) -> KeyFeedback {
     if key.kind != KeyEventKind::Press {
         return KeyFeedback {
@@ -1144,7 +1161,7 @@ fn handle_key_event(
             }
             if ch == 'o' || ch == 'O' {
                 runtime.press_on_key();
-                *pending_on_release =
+                *options.pending_on_release =
                     Some(runtime.cycle_count().saturating_add(ON_AUTO_HOLD_CYCLES));
                 return KeyFeedback {
                     label: Some("ON".to_string()),
@@ -1158,7 +1175,7 @@ fn handle_key_event(
                     executed,
                     pending_releases,
                     PF_KEY_HOLD_STEPS,
-                    force_key_irq,
+                    options.force_key_irq,
                 );
                 return KeyFeedback {
                     label: Some(format!("PF{}", ch)),
@@ -1171,25 +1188,25 @@ fn handle_key_event(
         KeyCode::Enter => {
             inject_key(
                 runtime,
-                0x4F,
+                ENTER_KEY_CODE,
                 executed,
                 pending_releases,
                 CHAR_KEY_HOLD_STEPS,
-                force_key_irq,
+                options.force_key_irq,
             );
             return KeyFeedback {
-                label: Some("=".to_string()),
+                label: Some("ENTER".to_string()),
                 quit: false,
             };
         }
         KeyCode::Backspace => {
             inject_key(
                 runtime,
-                0x4D,
+                BACKSPACE_KEY_CODE,
                 executed,
                 pending_releases,
                 CHAR_KEY_HOLD_STEPS,
-                force_key_irq,
+                options.force_key_irq,
             );
             return KeyFeedback {
                 label: Some("BS".to_string()),
@@ -1199,11 +1216,11 @@ fn handle_key_event(
         KeyCode::Delete => {
             inject_key(
                 runtime,
-                0x4C,
+                DELETE_KEY_CODE,
                 executed,
                 pending_releases,
                 CHAR_KEY_HOLD_STEPS,
-                force_key_irq,
+                options.force_key_irq,
             );
             return KeyFeedback {
                 label: Some("DEL".to_string()),
@@ -1217,7 +1234,7 @@ fn handle_key_event(
                 executed,
                 pending_releases,
                 PF_KEY_HOLD_STEPS,
-                force_key_irq,
+                options.force_key_irq,
             );
             return KeyFeedback {
                 label: Some("PF1".to_string()),
@@ -1231,7 +1248,7 @@ fn handle_key_event(
                 executed,
                 pending_releases,
                 PF_KEY_HOLD_STEPS,
-                force_key_irq,
+                options.force_key_irq,
             );
             return KeyFeedback {
                 label: Some("PF2".to_string()),
@@ -1245,7 +1262,7 @@ fn handle_key_event(
                 executed,
                 pending_releases,
                 PF_KEY_HOLD_STEPS,
-                force_key_irq,
+                options.force_key_irq,
             );
             return KeyFeedback {
                 label: Some("PF3".to_string()),
@@ -1259,7 +1276,7 @@ fn handle_key_event(
                 executed,
                 pending_releases,
                 PF_KEY_HOLD_STEPS,
-                force_key_irq,
+                options.force_key_irq,
             );
             return KeyFeedback {
                 label: Some("PF4".to_string()),
@@ -1273,7 +1290,7 @@ fn handle_key_event(
                 executed,
                 pending_releases,
                 PF_KEY_HOLD_STEPS,
-                force_key_irq,
+                options.force_key_irq,
             );
             return KeyFeedback {
                 label: Some("PF5".to_string()),
@@ -1281,6 +1298,20 @@ fn handle_key_event(
             };
         }
         KeyCode::Char(ch) => {
+            if ch == '\u{8}' || ch == '\u{7f}' {
+                inject_key(
+                    runtime,
+                    BACKSPACE_KEY_CODE,
+                    executed,
+                    pending_releases,
+                    CHAR_KEY_HOLD_STEPS,
+                    options.force_key_irq,
+                );
+                return KeyFeedback {
+                    label: Some("BS".to_string()),
+                    quit: false,
+                };
+            }
             if pf_numbers {
                 if let Some(code) = matrix_code_for_ctrl_digit(ch) {
                     inject_key(
@@ -1289,7 +1320,7 @@ fn handle_key_event(
                         executed,
                         pending_releases,
                         PF_KEY_HOLD_STEPS,
-                        force_key_irq,
+                        options.force_key_irq,
                     );
                     return KeyFeedback {
                         label: Some(format!("PF{}", ch)),
@@ -1304,7 +1335,7 @@ fn handle_key_event(
                 pending_releases,
                 pending_presses,
                 CHAR_KEY_HOLD_STEPS,
-                force_key_irq,
+                options.force_key_irq,
             ) {
                 return KeyFeedback {
                     label: Some(ch.to_string()),
@@ -1383,11 +1414,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         args.auto_type.clone().unwrap_or_default().chars().collect();
     let mut auto_type_next_step: Option<u64> = None;
     let mut auto_basic_step: Option<u64> = None;
-    let mut auto_main_pf1_step: Option<u64> = None;
-    let mut auto_menu_pf1_step: Option<u64> = None;
-    let mut auto_init_pending = args.auto_init;
-    let mut auto_main_pf1_pending = args.auto_init;
-    let mut auto_menu_pf1_pending = args.auto_init;
     let mut auto_basic_pending = args.auto_basic;
     let mut jump_basic_pending = args.jump_basic;
     let mut halted_steps: u64 = 0;
@@ -1395,7 +1421,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut snapshot_saved = false;
     let mut fast_init_cleared = false;
     let fast_init_buf = if args.fast_init && args.model.is_pce500_family() {
-        Some(vec![0u8; ROM_WINDOW_START])
+        Some(vec![0x9F; ROM_WINDOW_START])
     } else {
         None
     };
@@ -1454,7 +1480,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     fast_delay: args.fast_delay,
                     stub_sio: args.stub_sio,
                     fast_init: args.fast_init,
-                    ram_zero_buf: fast_init_buf.as_deref(),
+                    ram_fill_buf: fast_init_buf.as_deref(),
                 },
             ) {
                 executed = executed.saturating_add(1);
@@ -1515,7 +1541,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                             '\n' | '\r' => {
                                 inject_key(
                                     &mut runtime,
-                                    0x4F,
+                                    ENTER_KEY_CODE,
                                     executed,
                                     &mut pending_releases,
                                     CHAR_KEY_HOLD_STEPS,
@@ -1548,49 +1574,12 @@ fn main() -> Result<(), Box<dyn Error>> {
                     }
                 }
             }
-            if let Some(step) = auto_main_pf1_step {
-                if executed >= step {
-                    inject_key(
-                        &mut runtime,
-                        0x56,
-                        executed,
-                        &mut pending_releases,
-                        PF_KEY_HOLD_STEPS,
-                        args.force_key_irq,
-                    );
-                    last_key = Some("PF1".to_string());
-                    last_key_step = executed;
-                    auto_main_pf1_step = None;
-                    dirty = true;
-                }
-            }
-            if let Some(step) = auto_menu_pf1_step {
-                if executed >= step {
-                    inject_key(
-                        &mut runtime,
-                        0x56,
-                        executed,
-                        &mut pending_releases,
-                        PF_KEY_HOLD_STEPS,
-                        args.force_key_irq,
-                    );
-                    last_key = Some("PF1".to_string());
-                    last_key_step = executed;
-                    auto_menu_pf1_step = None;
-                    dirty = true;
-                }
-            }
             if runtime.state.is_halted() {
                 halted_steps = halted_steps.saturating_add(chunk);
             } else {
                 halted_steps = 0;
             }
-            let should_check_lcd = (auto_init_pending
-                || auto_main_pf1_pending
-                || auto_menu_pf1_pending
-                || auto_main_pf1_step.is_some()
-                || auto_menu_pf1_step.is_some()
-                || auto_basic_pending
+            let should_check_lcd = (auto_basic_pending
                 || jump_basic_pending
                 || (auto_type_next_step.is_none() && !auto_type_queue.is_empty()))
                 && auto_basic_step.is_none();
@@ -1609,33 +1598,6 @@ fn main() -> Result<(), Box<dyn Error>> {
                         }
                     }
                 }
-                if auto_init_pending && row0.contains("S2(CARD):NEW CARD") {
-                    inject_key(
-                        &mut runtime,
-                        0x56,
-                        executed,
-                        &mut pending_releases,
-                        PF_KEY_HOLD_STEPS,
-                        args.force_key_irq,
-                    );
-                    last_key = Some("PF1".to_string());
-                    last_key_step = executed;
-                    auto_init_pending = false;
-                    dirty = true;
-                    continue;
-                }
-                if auto_main_pf1_pending && row0.contains("S1(MAIN):NEW CARD") {
-                    auto_main_pf1_step = Some(executed.saturating_add(args.auto_basic_delay));
-                    auto_main_pf1_pending = false;
-                    dirty = true;
-                    continue;
-                }
-                if auto_menu_pf1_pending && display_text.contains("MAIN MENU") {
-                    auto_menu_pf1_step = Some(executed.saturating_add(args.auto_basic_delay));
-                    auto_menu_pf1_pending = false;
-                    dirty = true;
-                    continue;
-                }
                 if auto_type_next_step.is_none()
                     && !auto_type_queue.is_empty()
                     && display_text.contains('>')
@@ -1647,9 +1609,8 @@ fn main() -> Result<(), Box<dyn Error>> {
                 let row_has_menu = row0.contains("S2(CARD):") || row0.contains("S1(MAIN):");
                 if jump_basic_pending
                     && auto_basic_step.is_none()
-                    && !auto_init_pending
                     && (fast_init_cleared
-                        || (!args.auto_init && row_has_menu)
+                        || (!args.fast_init && row_has_menu)
                         || (row_has_menu && !row0.contains("NEW CARD")))
                 {
                     jump_to_basic_loop(&mut runtime);
@@ -1660,7 +1621,6 @@ fn main() -> Result<(), Box<dyn Error>> {
                     dirty = true;
                 } else if auto_basic_pending
                     && auto_basic_step.is_none()
-                    && !auto_init_pending
                     && row_has_menu
                     && !row0.contains("NEW CARD")
                 {
@@ -1679,8 +1639,10 @@ fn main() -> Result<(), Box<dyn Error>> {
                             executed,
                             &mut pending_releases,
                             &mut pending_presses,
-                            &mut pending_on_release,
-                            args.force_key_irq,
+                            KeyEventOptions {
+                                pending_on_release: &mut pending_on_release,
+                                force_key_irq: args.force_key_irq,
+                            },
                         );
                         if feedback.quit {
                             running = false;

--- a/sc62015/core/src/bin/sc62015_lcd.rs
+++ b/sc62015/core/src/bin/sc62015_lcd.rs
@@ -934,11 +934,32 @@ fn matrix_code_for_ctrl_digit(digit: char) -> Option<u8> {
 }
 
 fn char_key_for_tui(ch: char) -> Option<CharKey> {
+    let shifted = |code| CharKey::Shifted {
+        modifier: 0x06, // SHIFT
+        code,
+    };
     match ch {
-        '"' => Some(CharKey::Shifted {
-            modifier: 0x06, // SHIFT
-            code: 0x08,     // W
-        }),
+        '!' => Some(shifted(0x01)),               // Q
+        '"' => Some(shifted(0x08)),               // W
+        '#' => Some(shifted(0x09)),               // E
+        '$' => Some(shifted(0x10)),               // R
+        '%' => Some(shifted(0x11)),               // T
+        '&' => Some(shifted(0x18)),               // Y
+        '\'' => Some(shifted(0x19)),              // U
+        '<' => Some(shifted(0x20)),               // I
+        '>' => Some(shifted(0x21)),               // O
+        '@' => Some(shifted(0x50)),               // P
+        '[' => Some(shifted(0x03)),               // A
+        ']' => Some(shifted(0x0A)),               // S
+        '{' => Some(shifted(0x0B)),               // D
+        '}' => Some(shifted(0x12)),               // F
+        '\\' | '\u{00A5}' => Some(shifted(0x13)), // G: backslash on EN, yen on JP
+        '|' => Some(shifted(0x1A)),               // H
+        '~' => Some(shifted(0x1B)),               // J
+        '_' => Some(shifted(0x22)),               // K
+        '^' => Some(shifted(0x23)),               // L
+        '?' => Some(shifted(0x24)),               // ,
+        ':' => Some(shifted(0x25)),               // ;
         _ => matrix_code_for_char(ch).map(CharKey::Single),
     }
 }

--- a/sc62015/core/src/bin/sc62015_lcd.rs
+++ b/sc62015/core/src/bin/sc62015_lcd.rs
@@ -26,6 +26,7 @@ const IQ7000_TEXT_COLS: usize = 16;
 const STATUS_UPDATE_INTERVAL: Duration = Duration::from_millis(100);
 const PF_KEY_HOLD_STEPS: u64 = 40_000;
 const CHAR_KEY_HOLD_STEPS: u64 = 10_000;
+const SHIFTED_CHORD_LEAD_STEPS: u64 = 8_000;
 const ON_AUTO_HOLD_CYCLES: u64 = 20_000;
 const BASIC_REPL_HUB_PC: u32 = 0x00FFE09;
 const BASIC_WARM_START_PC: u32 = 0x00F9C94;
@@ -845,6 +846,18 @@ struct PendingRelease {
     due_step: u64,
 }
 
+struct PendingPress {
+    code: u8,
+    due_step: u64,
+    hold_steps: u64,
+    force_key_irq: bool,
+}
+
+enum CharKey {
+    Single(u8),
+    Shifted { modifier: u8, code: u8 },
+}
+
 type SymbolMap = BTreeMap<u32, String>;
 type FunctionSet = BTreeSet<u32>;
 
@@ -920,6 +933,25 @@ fn matrix_code_for_ctrl_digit(digit: char) -> Option<u8> {
     }
 }
 
+fn char_key_for_tui(ch: char) -> Option<CharKey> {
+    match ch {
+        '"' => Some(CharKey::Shifted {
+            modifier: 0x06, // SHIFT
+            code: 0x08,     // W
+        }),
+        _ => matrix_code_for_char(ch).map(CharKey::Single),
+    }
+}
+
+fn auto_type_gap_for_char(ch: char) -> u64 {
+    match char_key_for_tui(ch) {
+        Some(CharKey::Shifted { .. }) => SHIFTED_CHORD_LEAD_STEPS
+            .saturating_add(CHAR_KEY_HOLD_STEPS)
+            .saturating_add(AUTO_TYPE_GAP_STEPS),
+        _ => AUTO_TYPE_GAP_STEPS,
+    }
+}
+
 fn inject_key(
     runtime: &mut CoreRuntime,
     code: u8,
@@ -969,6 +1001,78 @@ fn inject_key(
     }
 }
 
+fn inject_char_key(
+    runtime: &mut CoreRuntime,
+    ch: char,
+    executed: u64,
+    pending_releases: &mut Vec<PendingRelease>,
+    pending_presses: &mut Vec<PendingPress>,
+    hold_steps: u64,
+    force_key_irq: bool,
+) -> bool {
+    match char_key_for_tui(ch) {
+        Some(CharKey::Single(code)) => {
+            inject_key(
+                runtime,
+                code,
+                executed,
+                pending_releases,
+                hold_steps,
+                force_key_irq,
+            );
+            true
+        }
+        Some(CharKey::Shifted { modifier, code }) => {
+            let modifier_hold = hold_steps
+                .saturating_add(SHIFTED_CHORD_LEAD_STEPS)
+                .saturating_add(1_000);
+            inject_key(
+                runtime,
+                modifier,
+                executed,
+                pending_releases,
+                modifier_hold,
+                force_key_irq,
+            );
+            pending_presses.push(PendingPress {
+                code,
+                due_step: executed.saturating_add(SHIFTED_CHORD_LEAD_STEPS),
+                hold_steps,
+                force_key_irq,
+            });
+            true
+        }
+        None => false,
+    }
+}
+
+fn apply_pending_presses(
+    runtime: &mut CoreRuntime,
+    pending_presses: &mut Vec<PendingPress>,
+    pending_releases: &mut Vec<PendingRelease>,
+    executed: u64,
+) -> bool {
+    let mut pressed = false;
+    let mut idx = 0;
+    while idx < pending_presses.len() {
+        if pending_presses[idx].due_step <= executed {
+            let pending = pending_presses.swap_remove(idx);
+            inject_key(
+                runtime,
+                pending.code,
+                executed,
+                pending_releases,
+                pending.hold_steps,
+                pending.force_key_irq,
+            );
+            pressed = true;
+        } else {
+            idx += 1;
+        }
+    }
+    pressed
+}
+
 fn apply_pending_releases(
     runtime: &mut CoreRuntime,
     pending_releases: &mut Vec<PendingRelease>,
@@ -999,6 +1103,7 @@ fn handle_key_event(
     pf_numbers: bool,
     executed: u64,
     pending_releases: &mut Vec<PendingRelease>,
+    pending_presses: &mut Vec<PendingPress>,
     pending_on_release: &mut Option<u64>,
     force_key_irq: bool,
 ) -> KeyFeedback {
@@ -1171,15 +1276,15 @@ fn handle_key_event(
                     };
                 }
             }
-            if let Some(code) = matrix_code_for_char(ch) {
-                inject_key(
-                    runtime,
-                    code,
-                    executed,
-                    pending_releases,
-                    CHAR_KEY_HOLD_STEPS,
-                    force_key_irq,
-                );
+            if inject_char_key(
+                runtime,
+                ch,
+                executed,
+                pending_releases,
+                pending_presses,
+                CHAR_KEY_HOLD_STEPS,
+                force_key_irq,
+            ) {
                 return KeyFeedback {
                     label: Some(ch.to_string()),
                     quit: false,
@@ -1251,6 +1356,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut last_key: Option<String> = None;
     let mut last_key_step: u64 = 0;
     let mut pending_releases: Vec<PendingRelease> = Vec::new();
+    let mut pending_presses: Vec<PendingPress> = Vec::new();
     let mut pending_on_release: Option<u64> = None;
     let mut auto_type_queue: Vec<char> =
         args.auto_type.clone().unwrap_or_default().chars().collect();
@@ -1345,6 +1451,14 @@ fn main() -> Result<(), Box<dyn Error>> {
                 executed = executed.saturating_add(chunk);
                 remaining = remaining.saturating_sub(chunk);
             }
+            if apply_pending_presses(
+                &mut runtime,
+                &mut pending_presses,
+                &mut pending_releases,
+                executed,
+            ) {
+                dirty = true;
+            }
             apply_pending_releases(&mut runtime, &mut pending_releases, executed);
             if let Some(release_cycle) = pending_on_release {
                 if runtime.cycle_count() >= release_cycle {
@@ -1388,27 +1502,21 @@ fn main() -> Result<(), Box<dyn Error>> {
                                 );
                                 true
                             }
-                            _ => {
-                                if let Some(code) = matrix_code_for_char(ch) {
-                                    inject_key(
-                                        &mut runtime,
-                                        code,
-                                        executed,
-                                        &mut pending_releases,
-                                        CHAR_KEY_HOLD_STEPS,
-                                        args.force_key_irq,
-                                    );
-                                    true
-                                } else {
-                                    false
-                                }
-                            }
+                            _ => inject_char_key(
+                                &mut runtime,
+                                ch,
+                                executed,
+                                &mut pending_releases,
+                                &mut pending_presses,
+                                CHAR_KEY_HOLD_STEPS,
+                                args.force_key_irq,
+                            ),
                         };
                         if did_inject {
                             last_key = Some(ch.to_string());
                             last_key_step = executed;
                             auto_type_next_step =
-                                Some(executed.saturating_add(AUTO_TYPE_GAP_STEPS));
+                                Some(executed.saturating_add(auto_type_gap_for_char(ch)));
                             sent = true;
                             dirty = true;
                             break;
@@ -1549,6 +1657,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                             args.pf_numbers,
                             executed,
                             &mut pending_releases,
+                            &mut pending_presses,
                             &mut pending_on_release,
                             args.force_key_irq,
                         );

--- a/sc62015/core/src/llama/eval.rs
+++ b/sc62015/core/src/llama/eval.rs
@@ -269,6 +269,13 @@ fn mode_for_operand(pre: Option<&PreModes>, operand_index: usize) -> AddressingM
     }
 }
 
+fn operand_uses_pre_mode(op: &OperandKind) -> bool {
+    matches!(
+        op,
+        OperandKind::IMem(_) | OperandKind::IMemWidth(_) | OperandKind::EMemIMemWidth(_)
+    )
+}
+
 fn imem_offset_for_mode<B: LlamaBus>(bus: &mut B, mode: AddressingMode, raw: u8) -> u32 {
     let bp = read_imem_byte(bus, IMEM_BP_OFFSET) as u32;
     let px = read_imem_byte(bus, IMEM_PX_OFFSET) as u32;
@@ -927,6 +934,12 @@ impl LlamaExecutor {
         let mut offset = 1u32; // opcode consumed
         let mut decoded = DecodedOperands::default();
         let single_pre = SINGLE_ADDRESSABLE_OPCODES.contains(&entry.opcode);
+        let single_pre_operand = entry
+            .operands
+            .iter()
+            .filter(|op| operand_uses_pre_mode(op))
+            .count()
+            == 1;
         // Opcode-specific decoding quirks
         if entry.opcode == 0xE3 {
             // Encoding order is EMemReg mode byte then IMem8.
@@ -968,7 +981,11 @@ impl LlamaExecutor {
                     } else {
                         &mut decoded.mem2
                     };
-                    let mode_index = if single_pre { 0 } else { operand_index };
+                    let mode_index = if single_pre || single_pre_operand {
+                        0
+                    } else {
+                        operand_index
+                    };
                     *slot = Some(MemOperand {
                         addr: imem_addr_for_mode(bus, mode_for_operand(pre, mode_index), raw as u8),
                         bits: *bits,
@@ -984,7 +1001,11 @@ impl LlamaExecutor {
                     } else {
                         &mut decoded.mem2
                     };
-                    let mode_index = if single_pre { 0 } else { operand_index };
+                    let mode_index = if single_pre || single_pre_operand {
+                        0
+                    } else {
+                        operand_index
+                    };
                     *slot = Some(MemOperand {
                         addr: imem_addr_for_mode(bus, mode_for_operand(pre, mode_index), raw as u8),
                         bits,
@@ -1027,7 +1048,11 @@ impl LlamaExecutor {
                     offset += consumed;
                 }
                 OperandKind::EMemIMemWidth(bytes) => {
-                    let mode_index = if single_pre { 0 } else { operand_index };
+                    let mode_index = if single_pre || single_pre_operand {
+                        0
+                    } else {
+                        operand_index
+                    };
                     let mode = mode_for_operand(pre, mode_index);
                     let (mem, consumed) = self.decode_imem_ptr(bus, pc + offset, *bytes, mode)?;
                     if decoded.mem.is_none() {
@@ -4785,6 +4810,59 @@ mod tests {
         assert_eq!(state.get_reg(RegName::A), 0x66);
         assert_eq!(state.get_reg(RegName::X), 0x1F);
         assert_eq!(state.pc(), 2);
+    }
+
+    #[test]
+    fn mvw_reg_imem_offset_round_trips_internal_pair_through_u_stack() {
+        let mut bus = MemBus::with_size(0x300);
+        // PRE30 E9 36 D4: MVW [--U], (D4)
+        bus.mem[0] = 0x30;
+        bus.mem[1] = 0xE9;
+        bus.mem[2] = 0x36;
+        bus.mem[3] = 0xD4;
+        // PRE30 E1 26 D4: MVW (D4), [U++]
+        bus.mem[4] = 0x30;
+        bus.mem[5] = 0xE1;
+        bus.mem[6] = 0x26;
+        bus.mem[7] = 0xD4;
+        bus.store(INTERNAL_MEMORY_START + 0xD4, 16, 0x0100);
+
+        let mut state = LlamaState::new();
+        state.set_reg(RegName::U, 0x210);
+        let mut exec = LlamaExecutor::new();
+
+        let len = exec.execute(0x30, &mut state, &mut bus).unwrap();
+        assert_eq!(len, 4);
+        assert_eq!(state.get_reg(RegName::U), 0x20E);
+        assert_eq!(bus.load(0x20E, 16), 0x0100);
+
+        bus.store(INTERNAL_MEMORY_START + 0xD4, 16, 0x9F9F);
+        let len = exec.execute(0x30, &mut state, &mut bus).unwrap();
+        assert_eq!(len, 4);
+        assert_eq!(state.get_reg(RegName::U), 0x210);
+        assert_eq!(bus.load(INTERNAL_MEMORY_START + 0xD4, 16), 0x0100);
+    }
+
+    #[test]
+    fn mvw_external_absolute_uses_first_pre_mode_for_lone_imem_source() {
+        let mut bus = MemBus::with_size(0x300);
+        // PRE30 D9 00 02 00 D4: MVW [0x200], (D4)
+        bus.mem[0] = 0x30;
+        bus.mem[1] = 0xD9;
+        bus.mem[2] = 0x00;
+        bus.mem[3] = 0x02;
+        bus.mem[4] = 0x00;
+        bus.mem[5] = 0xD4;
+        bus.store(INTERNAL_MEMORY_START + 0xEC, 8, 0xAF);
+        bus.store(INTERNAL_MEMORY_START + 0xD4, 16, 0x0101);
+        bus.store(INTERNAL_MEMORY_START + 0x83, 16, 0x9F9F);
+
+        let mut state = LlamaState::new();
+        let mut exec = LlamaExecutor::new();
+        let len = exec.execute(0x30, &mut state, &mut bus).unwrap();
+
+        assert_eq!(len, 6);
+        assert_eq!(bus.load(0x200, 16), 0x0101);
     }
 
     #[test]

--- a/sc62015/pysc62015/instr/opcodes.py
+++ b/sc62015/pysc62015/instr/opcodes.py
@@ -911,6 +911,19 @@ class Instruction:
         if self.opcode in SINGLE_ADDRESSABLE_OPCODES:
             src_mode = dst_mode
 
+        # Absolute external-memory forms such as MVW [addr], (n) have two
+        # logical operands but only one operand that consumes the PRE latch.
+        # Hardware applies PRE1 to that lone internal-memory selector.
+        if self._pre is not None:
+            operands = tuple(self.operands())
+            pre_operand_indexes = [
+                index
+                for index, operand in enumerate(operands)
+                if self._operand_uses_pre_mode(operand)
+            ]
+            if len(pre_operand_indexes) == 1 and pre_operand_indexes[0] == 1:
+                src_mode = dst_mode
+
         # RegIMemOffset IMEM selector follows PRE1 as well.
         # Keep no-PRE behavior unchanged (operand 2 defaults to BP+n rendering).
         if (
@@ -921,6 +934,13 @@ class Instruction:
             src_mode = dst_mode
 
         return dst_mode, src_mode
+
+    def _operand_uses_pre_mode(self, operand: Operand) -> bool:
+        if isinstance(operand, (IMem8, IMemOperand)):
+            return True
+        if isinstance(operand, EMemValueOffsetHelper):
+            return isinstance(operand.value, (IMem8, IMemOperand))
+        return False
 
     def render(self) -> List[Token]:
         dst_mode, src_mode = self._addressing_modes()

--- a/sc62015/pysc62015/test_emulator.py
+++ b/sc62015/pysc62015/test_emulator.py
@@ -1051,6 +1051,28 @@ instruction_test_cases: List[InstructionTestCase] = [
         expected_asm_str="MVW   [X], (BL)",
     ),
     InstructionTestCase(
+        test_id="MVW_abs_ext_from_direct_imem_PRE30_D9",
+        instr_bytes=bytes.fromhex("30D9000200D4"),  # PRE30; MVW [00200], (BL)
+        init_mem={
+            INTERNAL_MEMORY_START + IMEMRegisters.BL: 0x01,
+            INTERNAL_MEMORY_START + IMEMRegisters.BH: 0x01,
+            INTERNAL_MEMORY_START + IMEMRegisters.BP: 0xCB,
+            INTERNAL_MEMORY_START + 0x9F: 0x9F,
+            INTERNAL_MEMORY_START + 0xA0: 0x9F,
+            0x000200: 0x00,
+            0x000201: 0x00,
+        },
+        expected_mem_writes=[
+            (0x000200, 0x01),
+            (0x000201, 0x01),
+        ],
+        expected_mem_state={
+            0x000200: 0x01,
+            0x000201: 0x01,
+        },
+        expected_asm_str="MVW   [00200], (BL)",
+    ),
+    InstructionTestCase(
         test_id="MV_Y_from_E6_PRE30",
         instr_bytes=bytes.fromhex("3085E6"),
         init_mem={


### PR DESCRIPTION
## Summary

This PR collects the PC-E500 public emulator fixes from the current work session.

- updates the TUI keyboard handling so BASIC input sends the real Enter, Backspace, Delete, and shifted letter punctuation key codes
- removes the unused auto-init PF1 flow while keeping faster initialized-menu startup support
- fixes Rust LLAMA PRE decoding for instructions with one PRE-sensitive internal-memory operand behind an absolute external-memory operand
- fixes the same PRE addressing bug in the Python CPU path and adds a regression for `PRE30 D9 ... D4`

## Root Cause

The BASIC `PRINT1+2` failure was caused by `MVW [external], (D4)` under `PRE30` using PRE slot 2 for `(D4)`. That made the emulator read from `BP+D4` instead of direct `(D4)`, corrupting the ROM display state and moving the result/prompt to the wrong rows.

## Validation

- `FORCE_BINJA_MOCK=1 uv run --project public-src pytest public-src/sc62015/pysc62015/test_emulator.py -q`
- `RUSTC="$(rustup which --toolchain 1.89.0 rustc)" rustup run 1.89.0 cargo test --manifest-path public-src/sc62015/core/Cargo.toml mvw -- --nocapture`
- `RUSTC="$(rustup which --toolchain 1.89.0 rustc)" rustup run 1.89.0 cargo check --manifest-path public-src/sc62015/core/Cargo.toml --bin pce500 --bin sc62015-lcd`
- `uv run ruff format --check sc62015/pysc62015/instr/opcodes.py sc62015/pysc62015/test_emulator.py`
- `git diff --check`