### PR TITLE
Add card-ROM payload execution regression

### DIFF
--- a/sc62015/pysc62015/test_card_rom_payload_execution.py
+++ b/sc62015/pysc62015/test_card_rom_payload_execution.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from textwrap import dedent
+
+import pytest
+
+from binja_test_mocks import binja_api  # noqa: F401  # pyright: ignore
+from binja_test_mocks.eval_llil import Memory
+
+from sc62015.pysc62015 import CPU, RegisterName, available_backends
+from sc62015.pysc62015.constants import ADDRESS_SPACE_SIZE
+from sc62015.pysc62015.sc_asm import Assembler
+
+
+CARD_ROM_PAYLOAD_SOURCE = dedent(
+    """
+    .ORG 0x10100
+
+    start:
+        PUSHU F
+        PUSHU A
+        PUSHU X
+        MV X, message
+
+    emit_next:
+        MV A, [X++]
+        CMP A, 0x00
+        JPZ emit_done
+        MV [0x1FFF1], A
+        JP emit_next
+
+    emit_done:
+        POPU X
+        POPU A
+        POPU F
+        RETF
+
+    message:
+        defm "HELLO FROM CE6"
+        defb 0x0D, 0x0A, 0x00
+    """
+).strip()
+
+# Exact assembler output for the payload above. The destination address is an
+# observed memory-write sink; this test does not model or validate a peripheral.
+CARD_ROM_PAYLOAD_BYTES = bytes.fromhex(
+    "2E 28 2C 0C 19 01 01 90 24 60 00 14 15 01 "
+    "A8 F1 FF 01 02 07 01 3C 38 3E 07 "
+    "48 45 4C 4C 4F 20 46 52 4F 4D 20 43 45 36 0D 0A 00"
+)
+
+ENTRY_POINT = 0x10100
+WRAPPER_ADDR = 0x10000
+OUTPUT_SINK_ADDR = 0x1FFF1
+INITIAL_SYSTEM_SP = 0x2000
+INITIAL_USER_SP = 0x3000
+EXPECTED_OUTPUT = b"HELLO FROM CE6\r\n"
+MAX_STEPS = 128
+
+
+def _assemble_payload() -> bytes:
+    bin_file = Assembler().assemble(CARD_ROM_PAYLOAD_SOURCE)
+    assert len(bin_file.segments) == 1
+    segment = bin_file.segments[0]
+    assert segment.minimum_address == ENTRY_POINT
+    return bytes(segment.data)
+
+
+def _make_memory(program: bytes) -> tuple[Memory, list[int]]:
+    raw = bytearray(ADDRESS_SPACE_SIZE)
+    output_writes: list[int] = []
+
+    # CALLF 0x10100; HALT
+    raw[WRAPPER_ADDR : WRAPPER_ADDR + 5] = bytes((0x05, 0x00, 0x01, 0x01, 0xDE))
+    raw[ENTRY_POINT : ENTRY_POINT + len(program)] = program
+
+    def read(addr: int) -> int:
+        if addr < 0 or addr >= len(raw):
+            raise IndexError(f"Read address {addr:#x} out of bounds")
+        return raw[addr]
+
+    def write(addr: int, value: int) -> None:
+        if addr < 0 or addr >= len(raw):
+            raise IndexError(f"Write address {addr:#x} out of bounds")
+        raw[addr] = value & 0xFF
+        if addr == OUTPUT_SINK_ADDR:
+            output_writes.append(value & 0xFF)
+
+    memory = Memory(read, write)
+    setattr(memory, "_raw", raw)
+    return memory, output_writes
+
+
+@pytest.mark.parametrize("backend", available_backends())
+def test_card_rom_payload_assembles_and_executes(backend: str) -> None:
+    program = _assemble_payload()
+    assert program == CARD_ROM_PAYLOAD_BYTES
+
+    memory, output_writes = _make_memory(program)
+    cpu = CPU(memory, reset_on_init=False, backend=backend)
+    cpu.regs.set(RegisterName.PC, WRAPPER_ADDR)
+    cpu.regs.set(RegisterName.S, INITIAL_SYSTEM_SP)
+    cpu.regs.set(RegisterName.U, INITIAL_USER_SP)
+    cpu.regs.set(RegisterName.A, 0x5A)
+    cpu.regs.set(RegisterName.X, 0x123456)
+    cpu.regs.set(RegisterName.F, 0xA4)
+    initial_a = cpu.regs.get(RegisterName.A)
+    initial_x = cpu.regs.get(RegisterName.X)
+    initial_f = cpu.regs.get(RegisterName.F)
+
+    for _ in range(MAX_STEPS):
+        cpu.execute_instruction(cpu.regs.get(RegisterName.PC))
+        if cpu.state.halted:
+            break
+    else:
+        pytest.fail("card-ROM payload wrapper did not halt within the step budget")
+
+    assert cpu.state.halted is True
+    assert bytes(output_writes) == EXPECTED_OUTPUT
+    assert cpu.regs.get(RegisterName.S) == INITIAL_SYSTEM_SP
+    assert cpu.regs.get(RegisterName.U) == INITIAL_USER_SP
+    assert cpu.regs.get(RegisterName.A) == initial_a
+    assert cpu.regs.get(RegisterName.X) == initial_x
+    assert cpu.regs.get(RegisterName.F) == initial_f


### PR DESCRIPTION
## Summary
- add a card-ROM payload fixture with exact expected assembler bytes
- execute it through each available SC62015 CPU backend and verify CALLF/RETF, register and stack preservation, and captured memory writes
- treat address `0x1FFF1` only as an observed output sink; this test deliberately makes no UART or peripheral-correctness claim

This salvages only the useful test from closed PR #358. It does not add the branch's `FORCE_BINJA_MOCK` mutations to production modules.

## Validation
- `FORCE_BINJA_MOCK=1 uv run pytest sc62015/pysc62015/test_card_rom_payload_execution.py -q` (1 passed locally; one backend available)
- `uv run ruff check sc62015/pysc62015/test_card_rom_payload_execution.py`
- `uv run ruff format --check sc62015/pysc62015/test_card_rom_payload_execution.py`
