### PR TITLE
Ground interrupt correctness tests in ROM behavior

### DIFF
--- a/docs/test_evidence_levels.md
+++ b/docs/test_evidence_levels.md
@@ -1,0 +1,41 @@
+# Test evidence levels
+
+Tests in this repository make different kinds of claims. A passing parity or
+model test is useful, but it is not automatically evidence of real firmware or
+hardware behaviour. Use these labels when adding or interpreting correctness
+tests.
+
+| Evidence level | What it establishes | Representative coverage |
+| --- | --- | --- |
+| ROM-grounded | Executes stock ROM instructions and asserts their observable state changes. The external ROM fixture must be present. | `pce500/tests/test_keyboard_interrupt_rom.py` |
+| Architecture/ISA contract | Pins documented instruction or register semantics without depending on a particular ROM. | RETI and interrupt layout tests in `pce500/tests/test_memory_alias_and_irq.py` and `sc62015/core/src/lib.rs` |
+| Cross-backend parity | Shows that two implementations agree. Agreement alone does not prove either implementation matches hardware. | CPU backend and WAIT/Perfetto parity tests |
+| ROM-informed model | Pins a higher-level model whose addresses or data flow follow firmware, while timing or host-event policy remains emulated. | Keyboard handler/FIFO tests |
+| Emulator model contract | Protects intentionally synthetic scheduling, delivery, wake, peripheral, or host-bridge behaviour. | `test_interrupts.py`, `test_key_irq_latch.py`, and `test_peripherals.py` |
+| Smoke/instrumentation | Establishes that a path runs or emits trace data, not that the represented device behaviour is correct. | IRQ and execution tracing tests |
+
+## Interrupt ground truth currently encoded
+
+The optional PC-E500 ROM fixture is executed directly by the dispatcher tests.
+They establish these firmware facts:
+
+- `interrupt_vector` at `0xF1FB5` selects `ISR & IMR` in RX, EX, TX, ON,
+  KEY, ST, MT order.
+- The selected handler returns through the dispatcher epilogue, which
+  acknowledges the source with `AND (ISR), A` at `0xF2059`.
+- RETI at `0xF2060` restores IMR, F, and PC; it does not acknowledge ISR.
+- The default KEY handler at `0xF2061` clears KEYM in the saved IMR frame.
+
+The architecture-level tests therefore pin TX=`0x10`, RX=`0x20`, EX=`0x40`
+and require RETI to preserve ISR. The Python scheduler, debounce, key-event
+latch, and peripheral-manager policies remain model contracts unless a test is
+explicitly promoted with ROM or hardware evidence.
+
+## Review rule
+
+Name and document each test at the narrowest evidence level it actually proves.
+Do not use “hardware”, “ROM”, “timer cadence”, or “parity” in a test claim when
+the test only injects a register value, calls a shared host scheduler, or runs a
+synthetic handler. When ROM-grounded and model tests cover the same boundary,
+keep both: the former establishes the behaviour and the latter provides a fast
+regression test.

--- a/pce500/emulator.py
+++ b/pce500/emulator.py
@@ -90,6 +90,22 @@ class IRQSource(Enum):
     ONK = 3  # On-key interrupt     → ISR bit 3
 
 
+_IRQ_PRIORITY = (
+    IRQSource.ONK,
+    IRQSource.KEY,
+    IRQSource.STI,
+    IRQSource.MTI,
+)
+
+
+def _highest_pending_irq_source(isr: int) -> Optional[IRQSource]:
+    """Return the highest-priority low interrupt source selected by the ROM."""
+    for source in _IRQ_PRIORITY:
+        if isr & (1 << source.value):
+            return source
+    return None
+
+
 # Define constants locally to avoid heavy imports
 INTERNAL_MEMORY_START = 0x100000
 KOL, KOH, KIL = IMEMRegisters.KOL, IMEMRegisters.KOH, IMEMRegisters.KIL
@@ -678,15 +694,7 @@ class PCE500Emulator:
                 if isr_val_chk != 0:
                     # Cancel HALT and arm a pending interrupt; infer a plausible source
                     self.cpu.state.halted = False
-                    for b in (
-                        IRQSource.MTI.value,
-                        IRQSource.STI.value,
-                        IRQSource.KEY.value,
-                        IRQSource.ONK.value,
-                    ):
-                        if isr_val_chk & (1 << b):
-                            self._irq_source = IRQSource(b)
-                            break
+                    self._irq_source = _highest_pending_irq_source(isr_val_chk)
                     setattr(self, "_irq_pending", True)
                     _log_irq_debug(
                         f"HALT wake IRQ pending (ISR=0x{isr_val_chk:02X}) source={self._irq_source}"
@@ -793,16 +801,7 @@ class PCE500Emulator:
                 imr_probe = self.memory.read_byte(imr_addr_chk) & 0xFF
                 isr_probe = self.memory.read_byte(isr_addr_chk) & 0xFF
 
-            pending_src = None
-            for b, src in (
-                (IRQSource.KEY.value, IRQSource.KEY),
-                (IRQSource.ONK.value, IRQSource.ONK),
-                (IRQSource.MTI.value, IRQSource.MTI),
-                (IRQSource.STI.value, IRQSource.STI),
-            ):
-                if isr_probe & (1 << b):
-                    pending_src = src
-                    break
+            pending_src = _highest_pending_irq_source(isr_probe & imr_probe)
 
             if (
                 getattr(self, "_in_interrupt", False)
@@ -862,18 +861,9 @@ class PCE500Emulator:
                     imr_reg_val = self.cpu.regs.get(RegisterName.IMR) & 0xFF
                 except Exception:
                     pass
+                pending_src = _highest_pending_irq_source(isr_val_chk & imr_val_chk)
                 # Trace the pending check to see if KEYI is masked/cleared.
                 try:
-                    pending_src = None
-                    for b, src in (
-                        (IRQSource.KEY.value, IRQSource.KEY),
-                        (IRQSource.ONK.value, IRQSource.ONK),
-                        (IRQSource.MTI.value, IRQSource.MTI),
-                        (IRQSource.STI.value, IRQSource.STI),
-                    ):
-                        if isr_val_chk & (1 << b):
-                            pending_src = src
-                            break
                     self._trace_irq_instant(
                         "IRQ_PendingCheck",
                         pending_src,
@@ -890,15 +880,9 @@ class PCE500Emulator:
                     )
                 except Exception:
                     pass
-                # If we have a pending source but no latched irq_source, adopt it.
-                # Prefer a newly pending KEY/ONK over an existing latched source so keyboard IRQs are not starved by timers.
+                # Label delivery with the highest-priority enabled source selected by ROM.
                 if pending_src is not None:
-                    if getattr(self, "_irq_source", None) is None:
-                        self._irq_source = pending_src
-                    elif pending_src in (IRQSource.KEY, IRQSource.ONK) and getattr(
-                        self, "_irq_source", None
-                    ) not in (IRQSource.KEY, IRQSource.ONK):
-                        self._irq_source = pending_src
+                    self._irq_source = pending_src
                 # Trace unexpected IMR=0 reads to spot masking.
                 if imr_val_chk == 0:
                     self._trace_irq_instant(

--- a/pce500/tests/test_interrupts.py
+++ b/pce500/tests/test_interrupts.py
@@ -1,3 +1,9 @@
+"""Synthetic SC62015 interrupt-model tests using generated handler programs.
+
+These pin emulator delivery, wake, and accounting behavior. They do not execute
+the stock ROM dispatcher or establish real-device peripheral timing.
+"""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/pce500/tests/test_key_irq_latch.py
+++ b/pce500/tests/test_key_irq_latch.py
@@ -1,3 +1,5 @@
+"""Host keyboard-bridge latch policy; not a stock-ROM or hardware contract."""
+
 from __future__ import annotations
 
 from sc62015.pysc62015.constants import ISRFlag
@@ -10,6 +12,7 @@ INTERNAL_MEMORY_START = 0x100000
 
 
 def test_key_latch_survives_release_until_irq_delivered():
+    """Preserve a synthetic host key event until the emulator can deliver it."""
     emu = PCE500Emulator(perfetto_trace=False, save_lcd_on_exit=False)
     emu._timer_enabled = False  # type: ignore[attr-defined]
 

--- a/pce500/tests/test_keyboard_cpu_integration.py
+++ b/pce500/tests/test_keyboard_cpu_integration.py
@@ -1,4 +1,4 @@
-"""Integration tests for keyboard to CPU communication."""
+"""Synthetic CPU-to-keyboard-model integration tests (no stock ROM execution)."""
 
 import unittest
 import sys

--- a/pce500/tests/test_keyboard_handler.py
+++ b/pce500/tests/test_keyboard_handler.py
@@ -1,4 +1,4 @@
-"""Tests for the high-level keyboard handler and FIFO buffering."""
+"""ROM-informed high-level keyboard-model and FIFO contracts."""
 
 from __future__ import annotations
 

--- a/pce500/tests/test_keyboard_interrupt_rom.py
+++ b/pce500/tests/test_keyboard_interrupt_rom.py
@@ -5,7 +5,19 @@ from pathlib import Path
 import pytest
 
 from pce500 import PCE500Emulator
+from pce500.emulator import IMRFlag, ISRFlag, IRQSource
+from sc62015.pysc62015 import RegisterName
 from sc62015.pysc62015.instr.opcodes import IMEMRegisters
+
+
+DISPATCHER = 0xF1FB5
+DISPATCHER_ACK = 0xF2059
+KEY_HANDLER = 0xF2061
+ROM_VECTOR_TABLE = 0xF0C44
+RAM_VECTOR_TABLE = 0xBFCC6
+RETURN_PC = 0xB8000
+SYSTEM_FRAME = 0xBFE00
+USER_STACK = 0xBFF00
 
 
 def _rom_image() -> bytes:
@@ -18,16 +30,15 @@ def _rom_image() -> bytes:
     return data
 
 
-def _warm_until_key_interrupt(
+def _warm_until_host_key_event(
     emu: PCE500Emulator, target: int, chunk_steps: int = 20_000, max_chunks: int = 10
 ) -> None:
-    """Run the emulator in chunks until KEY interrupts reach the target."""
+    """Run in chunks until the host keyboard bridge observes a scan event."""
     for _ in range(max_chunks):
         emu.run(chunk_steps)
-        stats = emu.get_interrupt_stats()
-        if stats["by_source"]["KEY"] >= target:
+        if emu._kb_irq_count >= target:
             return
-    pytest.fail("Keyboard interrupt count did not increase as expected")
+    pytest.fail("Host keyboard event count did not increase as expected")
 
 
 def _warm_until_keyboard_strobes(
@@ -41,36 +52,47 @@ def _warm_until_keyboard_strobes(
     pytest.fail("Keyboard strobe count did not increase as expected")
 
 
-def _run_with_mask_until(
-    emu: PCE500Emulator,
-    *,
-    imr_addr: int,
-    isr_addr: int,
-    target_strobes: int,
-    max_steps: int,
-) -> None:
-    """Single-step with IMR/ISR masked until keyboard strobe progress is observed."""
-    for _ in range(max_steps):
-        emu.memory.write_byte(imr_addr, 0x00)
-        emu.memory.write_byte(isr_addr, 0x00)
+def _run_dispatcher(
+    rom_image: bytes, *, active_imr: int, saved_imr: int, isr: int
+) -> tuple[PCE500Emulator, list[int]]:
+    """Execute the stock interrupt dispatcher from a hardware-shaped frame."""
+    emu = PCE500Emulator(save_lcd_on_exit=False, perfetto_trace=False)
+    emu.load_rom(rom_image[0xC0000:0x100000], start_address=0xC0000)
+    emu._timer_enabled = False
+    emu._in_interrupt = True
+    emu._irq_pending = False
+    emu._irq_source = IRQSource.KEY
+    emu._key_irq_latched = False
+
+    vector_bytes = rom_image[ROM_VECTOR_TABLE : ROM_VECTOR_TABLE + 24]
+    for offset, value in enumerate(vector_bytes):
+        emu.memory.write_byte(RAM_VECTOR_TABLE + offset, value)
+
+    imr_addr = 0x100000 + IMEMRegisters.IMR
+    isr_addr = 0x100000 + IMEMRegisters.ISR
+    emu.memory.write_byte(imr_addr, active_imr)
+    emu.memory.write_byte(isr_addr, isr)
+
+    # Hardware frame at S: saved IMR, saved F, saved 24-bit return PC.
+    emu.memory.write_byte(SYSTEM_FRAME, saved_imr)
+    emu.memory.write_byte(SYSTEM_FRAME + 1, 0)
+    emu.memory.write_bytes(3, SYSTEM_FRAME + 2, RETURN_PC)
+    emu.memory.write_byte(RETURN_PC, 0x00)
+    emu.cpu.regs.set(RegisterName.S, SYSTEM_FRAME)
+    emu.cpu.regs.set(RegisterName.U, USER_STACK)
+    emu.cpu.regs.set(RegisterName.PC, DISPATCHER)
+
+    visited: list[int] = []
+    for _ in range(80):
+        visited.append(emu.cpu.regs.get(RegisterName.PC))
         emu.step()
-        if emu._kb_strobe_count >= target_strobes:
-            return
-    pytest.fail("Keyboard strobe count did not advance under masked execution")
+        if emu.cpu.regs.get(RegisterName.PC) == RETURN_PC:
+            return emu, visited
+    pytest.fail("ROM interrupt dispatcher did not return within 80 instructions")
 
 
-def _run_with_mask_steps(
-    emu: PCE500Emulator, *, imr_addr: int, isr_addr: int, steps: int
-) -> None:
-    """Advance a bounded number of masked single steps without trace overhead."""
-    for _ in range(steps):
-        emu.memory.write_byte(imr_addr, 0x00)
-        emu.memory.write_byte(isr_addr, 0x00)
-        emu.step()
-
-
-def test_keyboard_interrupt_delivery_from_rom():
-    """Verify the ROM fast-timer ISR raises KEY interrupts after bootstrap."""
+def test_rom_keyboard_scan_path_observes_host_key_without_key_irq_delivery():
+    """Separate ROM scan activity from the masked host KEYI bridge."""
     rom_image = _rom_image()
 
     # Create emulator with ROM code loaded and restore the runtime RAM snapshot.
@@ -80,7 +102,7 @@ def test_keyboard_interrupt_delivery_from_rom():
     emu._trace_execution = lambda *_args, **_kwargs: None
     emu._emit_instruction_trace_event = lambda *_args, **_kwargs: None
 
-    # Ensure IMR/ISR match the expected defaults even if the caller overrides arguments.
+    # Defaults are IRM | EXM | STM | MTM; KEYM is intentionally disabled.
     imr_addr = 0x100000 + IMEMRegisters.IMR
     isr_addr = 0x100000 + IMEMRegisters.ISR
     assert emu.memory.read_byte(imr_addr) == 0x43
@@ -98,7 +120,7 @@ def test_keyboard_interrupt_delivery_from_rom():
 
     # Drive a key press long enough for the ROM to observe it.
     emu.press_key("KEY_A")
-    _warm_until_key_interrupt(emu, key_before + 1)
+    _warm_until_host_key_event(emu, kb_irq_before + 1)
 
     # Release without waiting for the trailing edge; this test only asserts
     # positive KEY interrupt delivery from the press path.
@@ -108,53 +130,61 @@ def test_keyboard_interrupt_delivery_from_rom():
     key_after = stats_after["by_source"]["KEY"]
     kb_irq_after = emu._kb_irq_count
 
-    assert key_after > key_before, "Keyboard interrupt counter did not increment"
-    assert kb_irq_after > kb_irq_before, "Emulator-level IRQ accounting did not advance"
+    assert key_after == key_before, "Masked KEYM must not be reported as delivered"
+    assert kb_irq_after > kb_irq_before, "Host keyboard scan bridge did not observe key"
     assert emu._kb_strobe_count > 0, "ROM never toggled keyboard columns"
     assert emu.memory.read_byte(0xBFD34) & 0x80, (
         "Keyboard scanner gate should stay enabled"
     )
 
 
-def test_keyboard_interrupt_blocked_when_masked():
-    """Ensure masking the KEY bit suppresses delivery even after bootstrap."""
+def test_rom_dispatcher_acknowledges_key_and_disables_key_mask_on_return():
+    """The ROM, rather than RETI, clears KEYI and disables its default vector."""
     rom_image = _rom_image()
-    emu = PCE500Emulator(save_lcd_on_exit=False, perfetto_trace=False)
-    emu.load_rom(rom_image[0xC0000:0x100000], start_address=0xC0000)
-    emu.bootstrap_from_rom_image(rom_image)
-    # This assertion does not depend on trace output; disabling per-instruction
-    # trace callbacks keeps the masked single-step loop within pytest-timeout.
-    emu._trace_execution = lambda *_args, **_kwargs: None
-    emu._emit_instruction_trace_event = lambda *_args, **_kwargs: None
-
-    imr_addr = 0x100000 + IMEMRegisters.IMR
-    emu.memory.write_byte(0xBFD1D, 0x02)
-    emu.memory.write_byte(0xBFD1E, 0x00)
-
-    # Mask out all sources and clear pending bits before any warm-up.
-    emu.memory.write_byte(imr_addr, 0x00)
-    isr_addr = 0x100000 + IMEMRegisters.ISR
-    emu.memory.write_byte(isr_addr, 0x00)
-
-    _run_with_mask_until(
-        emu,
-        imr_addr=imr_addr,
-        isr_addr=isr_addr,
-        target_strobes=emu._kb_strobe_count + 2,
-        max_steps=25_000,
+    emu, visited = _run_dispatcher(
+        rom_image,
+        active_imr=int(IMRFlag.KEYM),
+        saved_imr=int(IMRFlag.IRM | IMRFlag.KEYM),
+        isr=int(ISRFlag.KEYI),
     )
-    stats_before = emu.get_interrupt_stats()
-    key_before = stats_before["by_source"]["KEY"]
-    kb_irq_before = emu._kb_irq_count
+    imr_addr = 0x100000 + IMEMRegisters.IMR
+    isr_addr = 0x100000 + IMEMRegisters.ISR
+    assert KEY_HANDLER in visited
+    assert DISPATCHER_ACK in visited
+    assert emu.memory.read_byte(isr_addr) & int(ISRFlag.KEYI) == 0
+    assert emu.memory.read_byte(imr_addr) == int(IMRFlag.IRM)
+    assert emu.cpu.regs.get(RegisterName.S) == SYSTEM_FRAME + 5
+    assert emu.cpu.regs.get(RegisterName.U) == USER_STACK
 
-    emu.press_key("KEY_A")
-    _run_with_mask_steps(emu, imr_addr=imr_addr, isr_addr=isr_addr, steps=12_000)
-    emu.release_key("KEY_A")
-    _run_with_mask_steps(emu, imr_addr=imr_addr, isr_addr=isr_addr, steps=8_000)
 
-    stats_after = emu.get_interrupt_stats()
-    key_after = stats_after["by_source"]["KEY"]
-    kb_irq_after = emu._kb_irq_count
+def test_rom_dispatcher_leaves_masked_key_status_pending():
+    """A masked KEYI takes the no-dispatch RETI path and remains pending."""
+    rom_image = _rom_image()
+    emu, visited = _run_dispatcher(
+        rom_image,
+        active_imr=0,
+        saved_imr=int(IMRFlag.IRM),
+        isr=int(ISRFlag.KEYI),
+    )
+    isr_addr = 0x100000 + IMEMRegisters.ISR
+    assert KEY_HANDLER not in visited
+    assert DISPATCHER_ACK not in visited
+    assert emu.memory.read_byte(isr_addr) & int(ISRFlag.KEYI)
 
-    assert key_after == key_before, "All-masked IMR should block dispatcher delivery"
-    assert kb_irq_after == kb_irq_before, "Hardware IRQ count should remain unchanged"
+
+def test_rom_dispatcher_prioritizes_key_over_main_timer():
+    """KEYI wins over MTI, matching the stock RX→EX→TX→ON→KEY→ST→MT order."""
+    rom_image = _rom_image()
+    enabled = IMRFlag.IRM | IMRFlag.KEYM | IMRFlag.MTM
+    pending = ISRFlag.KEYI | ISRFlag.MTI
+    emu, visited = _run_dispatcher(
+        rom_image,
+        active_imr=int(enabled & ~IMRFlag.IRM),
+        saved_imr=int(enabled),
+        isr=int(pending),
+    )
+    imr_addr = 0x100000 + IMEMRegisters.IMR
+    isr_addr = 0x100000 + IMEMRegisters.ISR
+    assert KEY_HANDLER in visited
+    assert emu.memory.read_byte(isr_addr) == int(ISRFlag.MTI)
+    assert emu.memory.read_byte(imr_addr) == int(IMRFlag.IRM | IMRFlag.MTM)

--- a/pce500/tests/test_memory_alias_and_irq.py
+++ b/pce500/tests/test_memory_alias_and_irq.py
@@ -1,3 +1,9 @@
+"""Emulator memory, interrupt-instruction, and Python scheduler contracts.
+
+These tests do not execute the stock ROM dispatcher. ROM-grounded dispatcher
+coverage lives in ``test_keyboard_interrupt_rom.py``.
+"""
+
 from __future__ import annotations
 
 from contextlib import contextmanager
@@ -71,46 +77,15 @@ def test_internal_memory_alias_writes(alias_base: int) -> None:
     assert alias_val == 0xAA
 
 
-def test_reti_keeps_isr_bit_until_firmware_clears_python() -> None:
-    # Use Python emulator as reference: set ISR key bit, deliver IRQ, ensure RETI does not auto-clear.
-    with _backend("python"):
-        emu = Emulator()
-
-    mem = emu.memory
-
-    # Mock an ISR bit and IMR enabling KEY
-    mem.write_byte(INTERNAL_MEMORY_START + IMEMRegisters.ISR, 0x04)  # KEYI
-    mem.write_byte(INTERNAL_MEMORY_START + IMEMRegisters.IMR, 0x84)  # IRM+KEY
-
-    # Force IRQ delivery bookkeeping
-    emu._irq_source = IRQSource.KEY
-    emu._in_interrupt = True
-
-    # Prepare stack for RETI: IMR, F, PC bytes
-    sp = 0x0100
-    mem.write_byte(sp, 0x84)
-    mem.write_byte(sp + 1, 0x7C)
-    mem.write_byte(sp + 2, 0x12)
-    mem.write_byte(sp + 3, 0x34)
-    mem.write_byte(sp + 4, 0x05)
-    emu.cpu.regs.set(RegisterName.S, sp)
-
-    mem.write_byte(0x0000, 0x01)  # RETI opcode
-    emu.cpu.regs.set(RegisterName.PC, 0x0000)
-
-    emu.step()
-
-    isr_after = mem.read_byte(INTERNAL_MEMORY_START + IMEMRegisters.ISR)
-    assert isr_after & 0x04 == 0x04
-    imr_after = mem.read_byte(INTERNAL_MEMORY_START + IMEMRegisters.IMR)
-    assert imr_after == 0x84
-
-
-def test_reti_keeps_isr_bit_until_firmware_clears_llama() -> None:
-    if "llama" not in available_backends():
+@pytest.mark.parametrize("backend", ["python", "llama"])
+def test_reti_restores_interrupt_frame_without_acknowledging_isr(
+    backend: str,
+) -> None:
+    """Match the ROM contract: firmware acknowledges ISR before executing RETI."""
+    if backend == "llama" and "llama" not in available_backends():
         pytest.skip("LLAMA backend not available")
 
-    with _backend("llama"):
+    with _backend(backend if backend != "python" else None):
         emu = Emulator()
 
     mem = emu.memory
@@ -174,6 +149,37 @@ def test_imr_masks_irq_pending(backend: str) -> None:
     assert emu._irq_pending
 
 
+@pytest.mark.parametrize(
+    ("pending", "expected"),
+    [
+        (ISRFlag.ONKI | ISRFlag.KEYI | ISRFlag.STI | ISRFlag.MTI, IRQSource.ONK),
+        (ISRFlag.STI | ISRFlag.MTI, IRQSource.STI),
+    ],
+)
+def test_pending_source_bookkeeping_matches_rom_priority(
+    pending: ISRFlag, expected: IRQSource
+) -> None:
+    emu = Emulator()
+    emu._timer_enabled = False
+    emu._in_interrupt = True
+    emu._irq_pending = False
+    emu._irq_source = None
+    emu.memory.write_byte(0x0000, 0x00)
+    emu.cpu.regs.set(RegisterName.PC, 0x0000)
+    emu.memory.write_byte(
+        INTERNAL_MEMORY_START + IMEMRegisters.IMR,
+        int(IMRFlag.IRM) | int(pending),
+    )
+    emu.memory.write_byte(
+        INTERNAL_MEMORY_START + IMEMRegisters.ISR,
+        int(pending),
+    )
+
+    emu.step()
+
+    assert emu._irq_source is expected
+
+
 @pytest.mark.parametrize("backend", ["python", "llama"])
 def test_timer_irq_arms_only_when_imr_allows(backend: str) -> None:
     if backend == "llama" and "llama" not in available_backends():
@@ -197,7 +203,6 @@ def test_timer_irq_arms_only_when_imr_allows(backend: str) -> None:
     emu.cycle_count = emu._scheduler.next_mti
     emu.step()
     assert emu.memory.read_byte(isr_addr) & int(ISRFlag.MTI)
-    assert emu.memory.read_byte(isr_addr) & int(ISRFlag.MTI)
 
     # Enable IRM+MTI and fire again: IRQ should either arm pending or deliver.
     emu.memory.write_byte(imr_addr, int(IMRFlag.IRM) | int(IMRFlag.MTI))
@@ -208,6 +213,7 @@ def test_timer_irq_arms_only_when_imr_allows(backend: str) -> None:
 
 
 def test_timer_advances_while_interrupt_handler_is_active() -> None:
+    """Pin the Python scheduler model; real-device ISR relatch timing is unverified."""
     emu = Emulator()
     emu._timer_enabled = True
     emu._timer_mti_period = 2

--- a/pce500/tests/test_peripherals.py
+++ b/pce500/tests/test_peripherals.py
@@ -1,3 +1,5 @@
+"""PeripheralManager model contracts; these are not real-device conformance tests."""
+
 from __future__ import annotations
 
 from pce500.memory import PCE500Memory, INTERNAL_MEMORY_START

--- a/sc62015/core/src/bin/pce500.rs
+++ b/sc62015/core/src/bin/pce500.rs
@@ -1671,25 +1671,20 @@ impl StandaloneBus {
                 self.last_irq_src = Some("ONK".to_string());
             }
         }
-        // If we have a pending source but no latched irq_source, adopt one from ISR bits.
-        let pending_src = if (isr & ISR_KEYI) != 0 {
-            Some("KEY")
-        } else if (isr & ISR_ONKI) != 0 {
+        // Track the highest-priority pending low source in the ROM's order.
+        let pending_src = if (isr & ISR_ONKI) != 0 {
             Some("ONK")
-        } else if (isr & ISR_MTI) != 0 {
-            Some("MTI")
+        } else if (isr & ISR_KEYI) != 0 {
+            Some("KEY")
         } else if (isr & ISR_STI) != 0 {
             Some("STI")
+        } else if (isr & ISR_MTI) != 0 {
+            Some("MTI")
         } else {
             None
         };
         if let Some(src) = pending_src {
-            if self.last_irq_src.is_none()
-                || (matches!(src, "KEY" | "ONK")
-                    && !matches!(self.last_irq_src.as_deref(), Some("KEY" | "ONK")))
-            {
-                self.last_irq_src = Some(src.to_string());
-            }
+            self.last_irq_src = Some(src.to_string());
         }
         if isr != 0 {
             self.irq_pending = true;
@@ -1758,10 +1753,10 @@ impl StandaloneBus {
             (Some("ONK"), ISR_ONKI)
         } else if (isr & ISR_KEYI != 0) && (imr & IMR_KEY) != 0 {
             (Some("KEY"), ISR_KEYI)
-        } else if (isr & ISR_MTI != 0) && (imr & IMR_MTI) != 0 {
-            (Some("MTI"), ISR_MTI)
         } else if (isr & ISR_STI != 0) && (imr & IMR_STI) != 0 {
             (Some("STI"), ISR_STI)
+        } else if (isr & ISR_MTI != 0) && (imr & IMR_MTI) != 0 {
+            (Some("MTI"), ISR_MTI)
         } else {
             // No deliverable IRQ because of masks; unwind stack effects to avoid corruption.
             let _ = self.memory.store(imr_addr, 8, imr as u32);
@@ -4565,10 +4560,10 @@ fn run(mut args: Args) -> Result<(), Box<dyn Error>> {
                 bus.irq_pending = true;
                 bus.last_irq_src = None;
                 for (mask, src) in [
-                    (ISR_MTI, "MTI"),
-                    (ISR_STI, "STI"),
-                    (ISR_KEYI, "KEY"),
                     (ISR_ONKI, "ONK"),
+                    (ISR_KEYI, "KEY"),
+                    (ISR_STI, "STI"),
+                    (ISR_MTI, "MTI"),
                 ] {
                     if (isr & mask) != 0 {
                         bus.last_irq_src = Some(src.to_string());
@@ -5350,6 +5345,35 @@ mod tests {
             "masked ONK must not override the ROM-visible unmasked timer source"
         );
         assert_eq!(bus.last_irq_src.as_deref(), Some("MTI"));
+    }
+
+    #[test]
+    fn deliver_irq_prefers_sub_timer_over_main_timer() {
+        let mut bus = StandaloneBus::new(
+            MemoryImage::new(),
+            create_lcd(sc62015_core::LcdKind::Hd61202),
+            TimerContext::new(true, 0, 0),
+            false,
+            0,
+            false,
+            None,
+            None,
+            None,
+        );
+        let mut state = LlamaState::new();
+        state.set_reg(RegName::S, 0x0200);
+        bus.memory.write_internal_byte(
+            super::IMEM_IMR_OFFSET,
+            super::IMR_MASTER | super::IMR_STI | super::IMR_MTI,
+        );
+        bus.memory
+            .write_internal_byte(super::IMEM_ISR_OFFSET, super::ISR_STI | super::ISR_MTI);
+        bus.irq_pending = true;
+
+        bus.deliver_irq(&mut state);
+
+        assert_eq!(bus.active_irq_mask, super::ISR_STI);
+        assert_eq!(bus.last_irq_src.as_deref(), Some("STI"));
     }
 
     #[test]

--- a/sc62015/core/src/lib.rs
+++ b/sc62015/core/src/lib.rs
@@ -884,18 +884,18 @@ impl CoreRuntime {
         // or the source mask is currently disabled. Delivery is still gated later.
         let src = if (isr_effective & ISR_RXI) != 0 {
             Some("RX")
+        } else if (isr_effective & ISR_EXI) != 0 {
+            Some("EX")
         } else if (isr_effective & ISR_TXI) != 0 {
             Some("TX")
-        } else if (isr_effective & ISR_IRQ10) != 0 {
-            Some("IRQ10")
         } else if (isr_effective & ISR_ONKI) != 0 {
             Some("ONK")
         } else if (isr_effective & ISR_KEYI) != 0 {
             Some("KEY")
-        } else if (isr_effective & ISR_MTI) != 0 {
-            Some("MTI")
         } else if (isr_effective & ISR_STI) != 0 {
             Some("STI")
+        } else if (isr_effective & ISR_MTI) != 0 {
+            Some("MTI")
         } else {
             None
         };
@@ -1298,18 +1298,18 @@ impl CoreRuntime {
                     .or_else(|| {
                         if (isr & ISR_RXI) != 0 {
                             Some("RX".to_string())
+                        } else if (isr & ISR_EXI) != 0 {
+                            Some("EX".to_string())
                         } else if (isr & ISR_TXI) != 0 {
                             Some("TX".to_string())
-                        } else if (isr & ISR_IRQ10) != 0 {
-                            Some("IRQ10".to_string())
                         } else if (isr & ISR_ONKI) != 0 {
                             Some("ONK".to_string())
                         } else if (isr & ISR_KEYI) != 0 {
                             Some("KEY".to_string())
-                        } else if (isr & ISR_MTI) != 0 {
-                            Some("MTI".to_string())
                         } else if (isr & ISR_STI) != 0 {
                             Some("STI".to_string())
+                        } else if (isr & ISR_MTI) != 0 {
+                            Some("MTI".to_string())
                         } else {
                             None
                         }
@@ -1353,18 +1353,18 @@ impl CoreRuntime {
                             if self.timer.irq_source.is_none() {
                                 let src = if (isr & ISR_RXI) != 0 {
                                     "RX"
+                                } else if (isr & ISR_EXI) != 0 {
+                                    "EX"
                                 } else if (isr & ISR_TXI) != 0 {
                                     "TX"
-                                } else if (isr & ISR_IRQ10) != 0 {
-                                    "IRQ10"
                                 } else if (isr & ISR_ONKI) != 0 {
                                     "ONK"
                                 } else if (isr & ISR_KEYI) != 0 {
                                     "KEY"
-                                } else if (isr & ISR_MTI) != 0 {
-                                    "MTI"
                                 } else if (isr & ISR_STI) != 0 {
                                     "STI"
+                                } else if (isr & ISR_MTI) != 0 {
+                                    "MTI"
                                 } else {
                                     "IRQ"
                                 };
@@ -1593,51 +1593,16 @@ impl CoreRuntime {
                 self.metadata.cycle_count = new_cycle;
                 if opcode == 0x01 {
                     let irq_src = self.timer.irq_source.clone();
-                    // If irq_source was lost, fall back to the delivered mask stack or live ISR bits.
-                    let stack_mask = self.timer.delivered_masks.pop();
-                    let clear_mask = irq_src
-                        .as_deref()
-                        .and_then(src_mask_for_name)
-                        .or(stack_mask)
-                        .or_else(|| {
-                            self.memory
-                                .read_internal_byte(IMEM_ISR_OFFSET)
-                                .and_then(|isr| {
-                                    if (isr & ISR_RXI) != 0 {
-                                        Some(ISR_RXI)
-                                    } else if (isr & ISR_TXI) != 0 {
-                                        Some(ISR_TXI)
-                                    } else if (isr & ISR_IRQ10) != 0 {
-                                        Some(ISR_IRQ10)
-                                    } else if (isr & ISR_ONKI) != 0 {
-                                        Some(ISR_ONKI)
-                                    } else if (isr & ISR_KEYI) != 0 {
-                                        Some(ISR_KEYI)
-                                    } else if (isr & ISR_MTI) != 0 {
-                                        Some(ISR_MTI)
-                                    } else if (isr & ISR_STI) != 0 {
-                                        Some(ISR_STI)
-                                    } else {
-                                        None
-                                    }
-                                })
-                        });
+                    // RETI restores the hardware interrupt frame but does not acknowledge ISR.
+                    // The ROM dispatcher explicitly clears the selected ISR bit before RETI.
+                    let delivered_mask = self.timer.delivered_masks.pop();
                     self.timer.in_interrupt = false;
-                    if irq_src.as_deref().is_some_and(|s| s == "KEY") {
+                    if irq_src.as_deref().is_some_and(|source| source == "KEY") {
+                        // Retire the synthetic host-key delivery latch. This is emulator bridge
+                        // bookkeeping, not an architectural ISR acknowledgement.
                         self.timer.key_irq_latched = false;
                     }
                     self.timer.irq_source = None;
-                    // Clear the delivered ISR bit, preferring explicit source but falling back to the saved mask.
-                    if let Some(src_mask) = clear_mask {
-                        let isr_addr = INTERNAL_MEMORY_START + IMEM_ISR_OFFSET;
-                        if let Some(isr_val) = self.memory.load(isr_addr, 8) {
-                            let prev = isr_val as u8;
-                            let cleared = prev & (!src_mask);
-                            let _ = self.memory.store(isr_addr, 8, cleared as u32);
-                            self.timer
-                                .record_bit_watch_transition("ISR", prev, cleared, pc_before);
-                        }
-                    }
                     // Drop any stale interrupt-stack frames (used only for bookkeeping).
                     let _ = self.timer.interrupt_stack.pop();
                     let mut guard = PERFETTO_TRACER.enter();
@@ -1655,7 +1620,7 @@ impl CoreRuntime {
                             "src".to_string(),
                             perfetto::AnnotationValue::Str(irq_src.unwrap_or_default()),
                         );
-                        if let Some(mask) = clear_mask {
+                        if let Some(mask) = delivered_mask {
                             payload.insert(
                                 "mask".to_string(),
                                 perfetto::AnnotationValue::UInt(mask as u64),
@@ -1883,18 +1848,18 @@ impl CoreRuntime {
             .or_else(|| {
                 if (isr & ISR_RXI) != 0 {
                     Some("RX".to_string())
+                } else if (isr & ISR_EXI) != 0 {
+                    Some("EX".to_string())
                 } else if (isr & ISR_TXI) != 0 {
                     Some("TX".to_string())
-                } else if (isr & ISR_IRQ10) != 0 {
-                    Some("IRQ10".to_string())
                 } else if (isr & ISR_ONKI) != 0 {
                     Some("ONK".to_string())
                 } else if (isr & ISR_KEYI) != 0 {
                     Some("KEY".to_string())
-                } else if (isr & ISR_MTI) != 0 {
-                    Some("MTI".to_string())
                 } else if (isr & ISR_STI) != 0 {
                     Some("STI".to_string())
+                } else if (isr & ISR_MTI) != 0 {
+                    Some("MTI".to_string())
                 } else {
                     None
                 }
@@ -1932,18 +1897,18 @@ impl CoreRuntime {
         // Match the IQ-7000 ROM interrupt dispatcher priority.
         let src = if (isr & ISR_RXI != 0) && (imr & IMR_RX != 0) {
             Some((ISR_RXI, "RX"))
+        } else if (isr & ISR_EXI != 0) && (imr & IMR_EX != 0) {
+            Some((ISR_EXI, "EX"))
         } else if (isr & ISR_TXI != 0) && (imr & IMR_TX != 0) {
             Some((ISR_TXI, "TX"))
-        } else if (isr & ISR_IRQ10 != 0) && (imr & IMR_IRQ10 != 0) {
-            Some((ISR_IRQ10, "IRQ10"))
         } else if (isr & ISR_ONKI != 0) && (imr & IMR_ONK != 0) {
             Some((ISR_ONKI, "ONK"))
         } else if (isr & ISR_KEYI != 0) && (imr & IMR_KEY != 0) {
             Some((ISR_KEYI, "KEY"))
-        } else if (isr & ISR_MTI != 0) && (imr & IMR_MTI != 0) {
-            Some((ISR_MTI, "MTI"))
         } else if (isr & ISR_STI != 0) && (imr & IMR_STI != 0) {
             Some((ISR_STI, "STI"))
+        } else if (isr & ISR_MTI != 0) && (imr & IMR_MTI != 0) {
+            Some((ISR_MTI, "MTI"))
         } else {
             None
         };
@@ -2162,17 +2127,17 @@ const IMR_MTI: u8 = 0x01;
 const IMR_STI: u8 = 0x02;
 const IMR_KEY: u8 = 0x04;
 const IMR_ONK: u8 = 0x08;
-const IMR_IRQ10: u8 = 0x10;
+const IMR_TX: u8 = 0x10;
 const IMR_RX: u8 = 0x20;
-const IMR_TX: u8 = 0x40;
+const IMR_EX: u8 = 0x40;
 const ISR_MTI: u8 = 0x01;
 const ISR_STI: u8 = 0x02;
 const ISR_KEYI: u8 = 0x04;
 const ISR_ONKI: u8 = 0x08;
-const ISR_IRQ10: u8 = 0x10;
+const ISR_TXI: u8 = 0x10;
 const ISR_RXI: u8 = 0x20;
-const ISR_TXI: u8 = 0x40;
-const ISR_KNOWN_MASK: u8 = ISR_MTI | ISR_STI | ISR_KEYI | ISR_ONKI | ISR_IRQ10 | ISR_RXI | ISR_TXI;
+const ISR_EXI: u8 = 0x40;
+const ISR_KNOWN_MASK: u8 = ISR_MTI | ISR_STI | ISR_KEYI | ISR_ONKI | ISR_TXI | ISR_RXI | ISR_EXI;
 const USR_RX_READY: u8 = 0x20;
 const SSR_ONK_VISIBLE: u8 = 0x02;
 const SSR_ONK_LEGACY_VISIBLE: u8 = 0x08;
@@ -2182,26 +2147,13 @@ const INTERRUPT_VECTOR_ADDR: u32 = 0xFFFFA;
 fn irq_source_priority(name: &str) -> u8 {
     match name {
         "RX" => 0,
-        "TX" => 1,
-        "IRQ10" => 2,
+        "EX" => 1,
+        "TX" => 2,
         "ONK" => 3,
         "KEY" => 4,
         "STI" => 5,
         "MTI" => 6,
         _ => u8::MAX,
-    }
-}
-
-fn src_mask_for_name(name: &str) -> Option<u8> {
-    match name {
-        "RX" => Some(ISR_RXI),
-        "TX" => Some(ISR_TXI),
-        "IRQ10" => Some(ISR_IRQ10),
-        "KEY" => Some(ISR_KEYI),
-        "ONK" => Some(ISR_ONKI),
-        "MTI" => Some(ISR_MTI),
-        "STI" => Some(ISR_STI),
-        _ => None,
     }
 }
 
@@ -2813,12 +2765,40 @@ mod tests {
         assert_ne!(
             rt.memory.read_internal_byte(IMEM_ISR_OFFSET).unwrap_or(0) & ISR_TXI,
             0,
-            "TXI should be visible to the ROM TX handler after it clears ISR.0x40"
+            "TXI should be visible to the ROM TX handler after it clears ISR.0x10"
         );
         assert!(
             !rt.timer.irq_pending,
             "refreshing TXI while already in an interrupt must not request nested delivery"
         );
+    }
+
+    #[test]
+    fn interrupt_layout_and_priority_match_rom_dispatcher() {
+        assert_eq!((ISR_TXI, ISR_RXI, ISR_EXI), (0x10, 0x20, 0x40));
+        assert_eq!((IMR_TX, IMR_RX, IMR_EX), (0x10, 0x20, 0x40));
+
+        let mut rt = CoreRuntime::new();
+        rt.memory.write_internal_byte(
+            IMEM_ISR_OFFSET,
+            ISR_RXI | ISR_EXI | ISR_TXI | ISR_STI | ISR_MTI,
+        );
+        rt.arm_pending_irq_from_isr();
+        assert_eq!(rt.timer.irq_source.as_deref(), Some("RX"));
+
+        rt.timer.irq_pending = false;
+        rt.timer.irq_source = None;
+        rt.memory
+            .write_internal_byte(IMEM_ISR_OFFSET, ISR_EXI | ISR_TXI | ISR_STI | ISR_MTI);
+        rt.arm_pending_irq_from_isr();
+        assert_eq!(rt.timer.irq_source.as_deref(), Some("EX"));
+
+        rt.timer.irq_pending = false;
+        rt.timer.irq_source = None;
+        rt.memory
+            .write_internal_byte(IMEM_ISR_OFFSET, ISR_STI | ISR_MTI);
+        rt.arm_pending_irq_from_isr();
+        assert_eq!(rt.timer.irq_source.as_deref(), Some("STI"));
     }
 
     #[test]
@@ -3384,7 +3364,7 @@ mod tests {
     }
 
     #[test]
-    fn reti_clears_interrupt_state_and_isr_bit() {
+    fn reti_clears_bookkeeping_but_preserves_isr_bit() {
         let mut rt = CoreRuntime::new();
         // Prepare stack and vector to a RETI instruction.
         rt.state.set_reg(RegName::S, 0x0200);
@@ -3405,7 +3385,7 @@ mod tests {
         assert!(rt.timer.in_interrupt, "interrupt flag should set on entry");
         assert_eq!(rt.state.get_reg(RegName::PC) & ADDRESS_MASK, 0x0010);
 
-        // Second step: execute RETI, clear bookkeeping and ISR bit.
+        // Second step: RETI restores state and clears emulator bookkeeping only.
         rt.step(1).expect("execute reti");
         assert!(!rt.timer.in_interrupt, "RETI should clear in_interrupt");
         assert!(
@@ -3417,11 +3397,15 @@ mod tests {
             "irq source should clear after RETI"
         );
         let isr = rt.memory.read_internal_byte(IMEM_ISR_OFFSET).unwrap_or(0);
-        assert_eq!(isr & ISR_KEYI, 0, "RETI should clear delivered ISR bit");
+        assert_eq!(
+            isr & ISR_KEYI,
+            ISR_KEYI,
+            "firmware, not RETI, must acknowledge the delivered ISR bit"
+        );
     }
 
     #[test]
-    fn reti_uses_interrupt_stack_mask_when_source_missing() {
+    fn reti_preserves_isr_when_interrupt_source_bookkeeping_is_missing() {
         let mut rt = CoreRuntime::new();
         // Fake a pending interrupt state with a delivered mask stored separately.
         rt.state.set_reg(RegName::S, 0x0030);
@@ -3434,7 +3418,7 @@ mod tests {
         rt.memory.write_external_byte(0x0032, 0x34);
         rt.memory.write_external_byte(0x0033, 0x12);
         rt.memory.write_external_byte(0x0034, 0x00);
-        // ISR has ONK bit set; irq_source unknown but delivered_masks carries mask.
+        // ISR has ONK set; irq_source is unknown but bookkeeping retains the mask.
         rt.memory.write_internal_byte(IMEM_ISR_OFFSET, ISR_ONKI);
         rt.timer.in_interrupt = true;
         rt.timer.interrupt_stack = vec![1]; // flow id placeholder
@@ -3444,11 +3428,7 @@ mod tests {
         rt.step(1).expect("execute reti without source");
 
         let isr = rt.memory.read_internal_byte(IMEM_ISR_OFFSET).unwrap_or(0);
-        assert_eq!(
-            isr & ISR_ONKI,
-            0,
-            "RETI should clear ISR using delivered mask when source is None"
-        );
+        assert_eq!(isr & ISR_ONKI, ISR_ONKI, "RETI must not acknowledge ISR");
         assert!(rt.timer.interrupt_stack.is_empty());
         assert!(rt.timer.delivered_masks.is_empty());
     }

--- a/sc62015/pysc62015/test_timer_irq_parity.py
+++ b/sc62015/pysc62015/test_timer_irq_parity.py
@@ -1,11 +1,11 @@
-"""Parity tests for timer/IRQ events across Python and LLAMA backends."""
+"""CPU-store and shared Python scheduler contracts across CPU backends."""
 
 from __future__ import annotations
 
 import pytest
 from typing import Any, cast
 
-from sc62015.pysc62015 import CPU, RegisterName
+from sc62015.pysc62015 import CPU, RegisterName, available_backends
 from sc62015.pysc62015.constants import (
     ADDRESS_SPACE_SIZE,
     INTERNAL_MEMORY_START,
@@ -16,8 +16,10 @@ from pce500.emulator import PCE500Emulator
 
 
 @pytest.mark.parametrize("backend", ("python", "llama"))
-def test_timer_irq_sets_isr_and_traces(backend: str) -> None:
-    # Minimal memory; scheduler lives in Python emulator, but LLAMA backend should still mirror IRQ writes.
+def test_isr_immediate_store_is_visible_and_traced_by_backend(backend: str) -> None:
+    """Execute ``MV (ISR), #1``; this is an instruction test, not a timer test."""
+    if backend == "llama" and "llama" not in available_backends():
+        pytest.skip("LLAMA backend not available")
     raw = bytearray(ADDRESS_SPACE_SIZE)
     # Place a NOP so execute_instruction doesn't crash.
     raw[0] = 0x00
@@ -69,7 +71,10 @@ def test_timer_irq_sets_isr_and_traces(backend: str) -> None:
         assert mem.irq_traces != []
 
 
-def test_timer_irq_cadence_matches_between_backends(monkeypatch) -> None:
+def test_python_scheduler_irq_sequence_is_cpu_backend_independent(monkeypatch) -> None:
+    """The shared Python scheduler emits the same events around either CPU backend."""
+    if "llama" not in available_backends():
+        pytest.skip("LLAMA backend not available")
     backends = ("python", "llama")
     results = {}
 
@@ -107,7 +112,7 @@ def test_timer_irq_cadence_matches_between_backends(monkeypatch) -> None:
             isr_addr = INTERNAL_MEMORY_START + IMEMRegisters.ISR
             results[backend] = {
                 "irq_events": captured.copy(),
-                "imr": emu.memory.read_byte(imr_addr - 1) & 0xFF,
+                "imr": emu.memory.read_byte(imr_addr) & 0xFF,
                 "isr": emu.memory.read_byte(isr_addr) & 0xFF,
             }
         finally:


### PR DESCRIPTION
## Summary
- make RETI preserve ISR and correct TX/RX/EX bit layout plus ROM priority
- replace the all-masked keyboard experiment with direct stock-ROM dispatcher executions
- correct Python and standalone Rust interrupt-source accounting
- label model, parity, ROM-informed, and ROM-grounded tests by what they actually prove

## Ground truth
PC-E500 interrupt_vector at 0xF1FB5 explicitly acknowledges ISR at 0xF2059 before RETI. IQ-7000 independently does the same at 0xF5236. Both use RX -> EX -> TX -> ON -> KEY -> ST -> MT priority.

## Validation
- 666 Python tests passed; 3 skipped
- cargo test core --all-targets --all-features passed
- Ruff check and format passed
- rustfmt passed
- Clippy core and Python bindings passed
- PyO3 extension rebuilt; focused Python/LLAMA audit tests passed