### PR TITLE
Finalize SC62015 hardware-backed semantics and trim PR CI

### DIFF
--- a/.github/workflows/extended-tests.yml
+++ b/.github/workflows/extended-tests.yml
@@ -1,0 +1,45 @@
+name: Extended tests
+
+on:
+  schedule:
+    - cron: "17 3 * * 0"
+  workflow_dispatch:
+
+jobs:
+  stress-parity:
+    name: stress parity
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+
+      - name: Install dependencies
+        run: uv sync --extra dev --extra pce500
+
+      - name: Build Rust LLAMA backend
+        env:
+          FORCE_BINJA_MOCK: 1
+        run: |
+          uv pip install maturin
+          uv run maturin develop --manifest-path sc62015/rustcore/Cargo.toml
+
+      - name: Run exhaustive immediate parity sweep
+        env:
+          FORCE_BINJA_MOCK: 1
+        run: |
+          uv run python tools/llama_parity_sweep.py --limit 1024 --stress-immediates --emit-traces --trace-prefix extended_stress
+          uv run python scripts/compare_perfetto_traces.py --compare-irq extended_stress_python.trace extended_stress_llama.trace

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,13 +47,6 @@ jobs:
         uv run python tools/llama_parity_sweep.py --emit-traces --trace-prefix trace_ref
         uv run python scripts/compare_perfetto_traces.py --compare-irq trace_ref_python.trace trace_ref_llama.trace
 
-    - name: Run stress parity sweep (immediates)
-      env:
-        FORCE_BINJA_MOCK: 1
-      run: |
-        uv run python tools/llama_parity_sweep.py --limit 1024 --stress-immediates --emit-traces --trace-prefix ci_stress
-        uv run python scripts/compare_perfetto_traces.py --compare-irq ci_stress_python.trace ci_stress_llama.trace
-
     - name: Run contract harness parity tests
       env:
         FORCE_BINJA_MOCK: 1

--- a/docs/sc62015_asm_llil_audit.md
+++ b/docs/sc62015_asm_llil_audit.md
@@ -47,7 +47,13 @@ address matrix,
 D0-D3/D8-DB transfer matrix,
 and `sc62015_hardware_wait_flags_2026-08-30.md` the HW-003 C/Z matrix. The later
 `sc62015_hardware_zero_wait_2026-08-30.md` records the HW-002 zero-count WAIT
-result. The private `sc62015_hardware_instruction_closure_2026-09-01.md`
+result. The 2026-09-02 follow-up records low-S frame wrapping and
+frame-before-vector order in `sc62015_hardware_interrupt_frame_wrap_2026-09-02.md`,
+raw matrix KEYI level/latch behavior in `sc62015_hardware_key_irq_2026-09-02.md`,
+and continued MTI/STI latching during interrupt service in
+`sc62015_hardware_mti_during_interrupt_2026-09-02.md` and
+`sc62015_hardware_sti_during_interrupt_2026-09-02.md`. The private
+`sc62015_hardware_instruction_closure_2026-09-01.md`
 reconciles the later TCL, zero-count block, far-control, PRE, RETI, IR,
 WAIT/IRQ, HALT/OFF, and software RESET captures and separates valid-instruction
 closure from residual peripheral or malformed-encoding work. The connected
@@ -160,7 +166,9 @@ is promoted to an ISA fact.
 | LLIL operand widths and masks | The mock evaluator accepted mixed-width near jumps, returns, dynamic IMEM addresses, `MV IL`, ROM-valid `FD 24`/`FD 42`, and `ED` exchanges that real Binary Ninja rejects; some control/address consumers retained unmodeled high bits | Emit explicit unsigned `ZERO_EXT`/`LOW_PART` conversions, snapshot both exchange directions, and apply the 8-bit IMEM or 20-bit external/control mask at every consumer; verify through a width-strict LLIL facade |
 | Control/address immediate high byte | Text assembly could turn an out-of-range literal into a self-fulfilling raw alias; table bytes at PC-E500 `F003A` were incorrectly treated as executed `CALLF` evidence | Raw JPF/CALLF probes for every upper nibble `1..F` transfer to the same low-20-bit target as canonical form. Raw 62/66/6A/72/7A, 88-8F, A8-AF, D0-D3, and D8-DB forms with tested upper nibble `8` are likewise device-verified low-20-bit data-address aliases. Fresh text assembly remains canonical; untested absolute-memory families and synthetic vectors remain fail-closed rather than promoted by analogy. Register-immediate `MV X/Y/U/S,lmn` separately discards bits 23-20 |
 | Reset-vector selection | Python read the interrupt vector at `FFFFA` | Read the distinct reset-vector slot at `FFFFD`. Software-RESET capture verifies low-first reads through `FFFFF`, no system-stack frame, and the first target fetch. Detailed SFR/general-register retention remains manual-derived because reset ROM initialization starts immediately |
-| Vector-transfer failure ordering | Software `IR`, RESET, and synthetic IRQ paths could push a frame, clear `IMR.IRM`, reset SFRs, or clear wrapper state before discovering a noncanonical vector, rejected destination, failed bus read, volatile mismatch, or late observer failure | For software `IR`, RESET, and Python/PCE synthetic delivery, require explicit callback-free metadata for each selected transfer, bind the one matching architectural vector fetch plus target length and memory provenance into a non-forgeable, one-shot prepared operation, and consume it before transfer mutation. The Python/PCE wrapper does not inspect the IRQ vector on the HALT/OFF wake step, for masked status, with an active handler, or on a timer-only pass. On a following deliverable pass, both runtime paths preserve the measured opcode fetch at the saved/fall-through PC before frame writes and vector fetch; that discarded opcode is neither decoded nor executed. Generic Rust `CoreRuntime` additionally defers a source first armed after its no-speculative-vector gate. Machine reset is stricter: the reset-vector and decoded target bytes must be declared immutable before RAM/LCD reset can begin. Destination `I`, stack, and other data-dependent checks remain the destination instruction's job, and vector targets that are themselves `IR`/RESET do not recurse during preflight |
+| Vector-transfer and frame ordering | IR/IRQ paths fetched the interrupt vector before constructing the frame, while some runtimes decoded a discarded fall-through instruction or omitted its fetch | For software `IR` and asynchronous IRQ delivery, silently validate the vector/destination first, then perform the measured bus sequence: one opcode-byte fetch for asynchronous delivery without operand decode, five independently wrapped frame writes (PC high/middle/low, F, IMR), and exactly one low-to-high `FFFFA..FFFFC` architectural vector fetch. A failed or changed post-frame vector poisons the machine because the hardware-visible frame is already committed. RESET remains distinct and fetches/validates `FFFFD..FFFFF` before reset mutation. The HALT/OFF wake step, masked status, active-handler nested check, and timer-only pass do not speculatively read the IRQ vector |
+| Raw matrix KEYI | Python and Rust tied KEYI assertion/reassertion to debounced events, FIFO contents, host enable policy, and sometimes `in_interrupt` | Sample selected physical KIL independently of debounce/repeat/FIFO bookkeeping. `KIL != 0` asserts or reasserts `ISR.KEYI` regardless of `IMR`, host event generation, or handler-in-service state; release lowers KIL without acknowledging an existing status bit, and a firmware clear remains clear after release. FIFO-only/input-event injection cannot manufacture raw KEYI. Nested delivery remains deferred |
+| Timers during interrupt service | Generic Rust and several Python timing paths froze MTI/STI phase while `in_interrupt` | Continue MTI/STI phase advancement and status latching while a handler is active. Preserve pending status but defer nested delivery until service returns and the normal mask checks select it |
 | Software interrupt `IR` | The saved PC pointed after the opcode | Save the `IR` opcode address; the ROM dispatcher tests `FE` there and advances the saved frame |
 | Stacked `F` byte | Rust preserved six opaque upper bits while Python modeled only carry/zero; `POPS F` advanced `S` before its lazy validation node; an initial quarantine also rejected arbitrary `POPU F`/`RETI` input | PC-E500 matrices establish `POPU F`, `POPS F`, and `RETI` as `F = raw & 03`, followed by their normal pointer/frame advance. Pushes and interrupt entry can therefore emit only the normalized architectural C/Z byte. Keep the one-byte frame field and snapshot each input once |
 | `TEST` | Some LLIL paths used a 24-bit operation for a byte instruction | Use byte-width logic |
@@ -170,7 +178,7 @@ is promoted to an ISA fact.
 | Decimal shifts | Direction, pointer walk, and carried nibble disagreed | `DSLL` starts at the LSB and decrements; `DSRL` starts at the MSB and increments |
 | Wide memory access | A word/pointer could spill outside 8-bit IMEM or 20-bit external memory, an overlapping store could mutate the register used to calculate later destination bytes, and bridge buses could collapse a wide access into one callback | Fix effective bases before writes; fixed-width moves also fix their source values, while `EXP` applies its separately documented ordered byte-exchange semantics. Expand every wide load/store into ordered wrapped byte operations so hardware/host hooks run once per byte. Device captures verify wrapped IMEM byte mapping and external read bus order for the tested `MVW`/`MVP` and `[X++]` forms. Read-only CE1 overlap traces further verify that direct and both displaced `F1`/`F2`/`F3` modes fix their initial effective source and read two/three ordered external bytes from it before overlapping writes. An address-only write trace verifies all direct and displaced `F8`/`F9`/`FA`/`FB` modes select the expected effective destination and emit exactly one/two/three/I low-to-high write phases. These traces exposed and now prevent Rust's former non-boundary wide-callback collapse. The loaded gateware sampled and read every write as zero, so exact write data, partial visibility, boundary order, and invisible IMEM temporal order remain model contracts |
 | `CALL`/`CALLF` LLIL | The lifter performed the explicit wrapped stack-frame writes but represented the control-flow edge as a jump | Keep the explicit architectural frame writes and emit a Binary Ninja call edge; the mock evaluator treats that call node as control flow only so it cannot add a second synthetic frame |
-| Interrupt-frame boundary access | Synthetic delivery paths could read or write a five-byte system frame past the 20-bit external bus when `S < 5` | Snapshot the frame inputs and wrap every byte at `FFFFF -> 00000`; exact silicon bus order at that boundary remains hardware-trace work |
+| Interrupt-frame boundary access | Synthetic delivery paths could read or write a five-byte system frame past the 20-bit external bus when `S < 5` | Snapshot the frame inputs and decrement/wrap each byte independently on the 20-bit bus. A real S=5..0 matrix verifies PC-high/middle/low, F, IMR time order, modulo-20-bit addresses, and completion of all five writes before the vector read |
 | External pointers and control flow | Some paths advanced in a 24-bit space, while LLIL register consumers could retain a high nibble that the runtime facade masks | Mask effective addresses, pointer updates, register jumps, and far-return targets to 20 bits; near control flow explicitly widens its 16-bit component before page composition |
 | `PMDF` | Implemented as packed BCD | Use 8-bit wrapping binary pointer addition and preserve incoming `C`/`Z`; both immediate and A-source forms, wrap/zero cases, and deliberately contradictory incoming flags are verified on a PC-E500 |
 | `TCL` | Could execute as a silent no-op | Device traces establish independent main/sub divider-phase restart selected by `LCC.MTCL`/`LCC.STCL`, without clearing LCC or already-latched ISR; require the timer-phase-clear hook and fail closed if a host cannot implement it |
@@ -273,13 +281,13 @@ missing events are errors.  These guarantees make failures visible, but a
 matching trace still establishes only cross-implementation agreement.
 
 IRQ-boundary parity remains an emulator-integrity follow-up for source-specific
-peripheral edges. Hardware now establishes HALT/OFF fall-through resume and
-interrupt-atomic WAIT with delivery after the fall-through fetch. The narrowed
-generic Rust `CoreRuntime` gate additionally prevents speculative vector reads
-and leaves a source first armed after that gate for a later step. Key, ON-key,
-external, SIO, and timer re-latching still need small cross-runtime traces and,
-where electrical timing matters, source-specific device evidence; those are
-peripheral-scheduler questions rather than unresolved instruction semantics.
+peripheral edges. Hardware establishes HALT/OFF fall-through resume,
+interrupt-atomic WAIT, the asynchronous discarded-opcode fetch, complete
+frame-before-vector order with 20-bit stack wrapping, raw selected-KIL KEYI
+re-latching (including in-service), and continued MTI/STI latching in a
+handler. ON-key, external, and SIO edge latency still benefit from small
+cross-runtime traces; those are peripheral-scheduler questions rather than
+unresolved instruction semantics.
 
 ## Explicit model contracts
 
@@ -355,17 +363,15 @@ outside that closure:
    gateware establishes write addresses/count/order but not trustworthy write
    data. Architectural values and effective-base rules are already covered by
    device round trips and the documented instruction contract.
-4. A real interrupt-frame write with `S < 5`. Such a probe can corrupt low live
-   memory, so the cores use byte-wise 20-bit wrapping established independently
-   rather than claiming direct boundary-trace evidence.
-5. Detailed software/external/power-on RESET SFR retention. Software FF's
+4. Detailed software/external/power-on RESET SFR retention. Software FF's
    vector order, no-frame transfer, and target fetch are device-verified; reset
    ROM code immediately overwrites SFRs, so remaining retention stays labeled
    manual-derived.
-6. ON-key, general-key, timer-re-latch, peripheral-ready, debounce/repeat, and
-   asynchronous latency questions. These belong to device scheduling and
+5. ON-key, external/SIO peripheral-ready, debounce/repeat, and exact
+   asynchronous latency questions. Raw matrix KEYI and MTI/STI-in-handler
+   latching are resolved; the remaining items belong to device scheduling and
    peripherals, not alternate meanings of HALT/OFF/WAIT/RETI.
-7. Preserve equivalent raw artifacts for any older cited report that still has
+6. Preserve equivalent raw artifacts for any older cited report that still has
    only a decoded event table. This is evidence reproducibility, not a silicon
    semantic question.
 

--- a/pce500/emulator.py
+++ b/pce500/emulator.py
@@ -14,7 +14,10 @@ from enum import Enum
 
 # Import the SC62015 emulator
 from sc62015.pysc62015 import CPU, RegisterName, Registers
-from sc62015.pysc62015.emulator import fetch_validated_vector_transfer
+from sc62015.pysc62015.emulator import (
+    fetch_validated_vector_transfer,
+    prepare_validated_vector_transfer,
+)
 from sc62015.pysc62015.instr.instructions import (
     CALL,
     RetInstruction,
@@ -559,7 +562,8 @@ class PCE500Emulator:
         self.keyboard = KeyboardHandler(
             self.memory, columns_active_high=keyboard_columns_active_high
         )
-        # Match Rust PC-E500: assert KEYI on first visible scan.
+        # Keep host-event delivery responsive. Raw KEYI is sampled separately
+        # from the selected physical KIL level at instruction boundaries.
         try:
             if hasattr(self.keyboard, "_matrix"):
                 self.keyboard._matrix.press_threshold = 1
@@ -750,7 +754,7 @@ class PCE500Emulator:
         self.memory.set_imem_access_callback(self._default_imem_access_callback)
         self.memory._mark_snapshot_baseline()
         try:
-            # Tap into keyboard scan events to surface KEYI progression in logs/perfetto.
+            # Trace host scan/debounce events separately from raw KIL/KEYI.
             if hasattr(self.keyboard, "_matrix"):
                 matrix = self.keyboard._matrix  # type: ignore[attr-defined]
                 matrix._trace_hook = self._trace_key_event  # type: ignore[attr-defined]
@@ -1064,7 +1068,10 @@ class PCE500Emulator:
             return False
         was_halted = bool(getattr(self.cpu.state, "halted", False))
         in_interrupt = bool(getattr(self, "_in_interrupt", False))
-        key_will_reassert = bool(self._key_irq_latched) and not in_interrupt
+        raw_kil_level = 0
+        if self.keyboard is not None:
+            raw_kil_level = self.keyboard.peek_physical_keyboard_input(pc) & 0xFF
+        key_will_reassert = raw_kil_level != 0
         onk_will_reassert = (
             bool(getattr(self, "_pending_onk", False)) and not in_interrupt
         )
@@ -1111,19 +1118,19 @@ class PCE500Emulator:
             # timer state can change. Interrupt delivery may replace this PC,
             # so the selected handler is validated again below.
             self.cpu.validate_before_scheduling(pc)
-        # Reassert latched KEY/ONK interrupts even when timers are disabled so
-        # firmware ISR clearing does not drop pending keyboard events.
-        if self._key_irq_latched and not getattr(self, "_in_interrupt", False):
+        # The raw KEYI source follows the undebounced selected KIL level. It is
+        # independent of IMR, the ROM FIFO, and handler in-service state.
+        if raw_kil_level:
             isr_addr = INTERNAL_MEMORY_START + IMEMRegisters.ISR
             isr_val = self.memory.read_byte(isr_addr) & 0xFF
             if (isr_val & int(ISRFlag.KEYI)) == 0:
                 self._set_isr_bits(int(ISRFlag.KEYI))
-                self._irq_pending = True
-                if getattr(self, "_irq_source", None) not in (
-                    IRQSource.KEY,
-                    IRQSource.ONK,
-                ):
-                    self._irq_source = IRQSource.KEY
+            self._irq_pending = True
+            if not in_interrupt and getattr(self, "_irq_source", None) not in (
+                IRQSource.KEY,
+                IRQSource.ONK,
+            ):
+                self._irq_source = IRQSource.KEY
         # Honor low-power state without collapsing OFF into HALT. Device traces
         # verify STI wake for HALT and ONKI wake for firmware-prepared OFF; the
         # remaining source combinations are peripheral integration policy.
@@ -1131,11 +1138,7 @@ class PCE500Emulator:
             power_state = getattr(self.cpu.state, "power_state", "halted")
             is_off = power_state == "off"
             # Mirror Rust: tick timers while halted to allow ISR bits to wake the CPU.
-            if (
-                not is_off
-                and self._timer_enabled
-                and not getattr(self, "_in_interrupt", False)
-            ):
+            if not is_off and self._timer_enabled:
                 try:
                     self._tick_timers()
                 except Exception as exc:
@@ -1405,16 +1408,16 @@ class PCE500Emulator:
                         raise RuntimeError(
                             "failed architectural pre-IRQ opcode fetch"
                         ) from exc
-                    # Resolve and statically preflight the handler silently,
-                    # then perform exactly one architectural vector fetch and
-                    # require it to match before the frame changes.  This
-                    # catches a failing/volatile bus without leaving a partial
-                    # stack frame or cleared IMR.
-                    vector_addr = self._fetch_validated_vector(
-                        INTERRUPT_VECTOR_ADDR, source_pc=cur_pc
+                    # Resolve and statically preflight the handler silently.
+                    # HW-014 requires the observable vector reads after all
+                    # five frame writes, so retain the opaque proof until then.
+                    vector_transfer = prepare_validated_vector_transfer(
+                        self.memory,
+                        self.cpu.regs,
+                        INTERRUPT_VECTOR_ADDR,
+                        source_pc=cur_pc,
+                        require_stability_metadata=True,
                     )
-                    # Commit wrapper metadata only after the vector read has
-                    # proved that delivery can begin atomically.
                     if pending_src is not None:
                         self._irq_source = pending_src
                     _log_irq_debug(
@@ -1438,10 +1441,17 @@ class PCE500Emulator:
                         print(
                             f"[irq-stack] deliver start pc=0x{cur_pc:06X} s=0x{s:06X} f=0x{int(self.cpu.regs.get(RegisterName.F)) & 0xFF:02X} imr=0x{imr_val_chk:02X}"
                         )
-                    # push PC (little-endian 3 bytes)
-                    s_new = (s - 3) & 0xFFFFF
+                    # Push saved PC high/middle/low while pre-decrementing S
+                    # once per byte. The final image is little-endian, but the
+                    # externally visible write order is descending.
                     irq_delivery_started = True
-                    self.memory.write_bytes(3, s_new, cur_pc)
+                    s_new = s & 0xFFFFF
+                    for byte_index in reversed(range(3)):
+                        s_new = (s_new - 1) & 0xFFFFF
+                        self.memory.write_byte(
+                            s_new,
+                            (cur_pc >> (byte_index * 8)) & 0xFF,
+                        )
                     if IRQ_STACK_TRACE_ENABLED:
                         print(
                             f"[irq-stack] push_pc from 0x{s:06X} to 0x{s_new:06X} value=0x{cur_pc & 0xFFFFFF:06X}"
@@ -1473,9 +1483,26 @@ class PCE500Emulator:
                         print(
                             f"[irq-stack] deliver done s=0x{int(self.cpu.regs.get(RegisterName.S)):06X}"
                         )
+                    # Perform exactly one low-to-high architectural vector
+                    # fetch after the complete frame and require it to match
+                    # the silent proof retained above.
+                    raw_vector = 0
+                    for byte_index in range(3):
+                        raw_vector |= (
+                            self.memory.read_byte(
+                                INTERRUPT_VECTOR_ADDR + byte_index,
+                                cpu_pc=cur_pc,
+                            )
+                            & 0xFF
+                        ) << (byte_index * 8)
+                    vector_addr = vector_transfer.consume_after_architectural_fetch(
+                        self.memory,
+                        INTERRUPT_VECTOR_ADDR,
+                        cur_pc,
+                        raw_vector,
+                    )
                     # ISR status was set by the triggering source (device/timer)
-                    # Do not modify ISR here; only deliver the interrupt.
-                    # Jump to the already validated interrupt vector candidate.
+                    # and is not acknowledged by entry itself.
                     if self._irq_source == IRQSource.KEY:
                         # Mark keyboard IRQ delivery explicitly on irq.key track.
                         try:
@@ -3636,7 +3663,7 @@ class PCE500Emulator:
         """Advance cycle count and timers for simulated WAIT loops."""
         for _ in range(int(cycles)):
             self.cycle_count += 1
-            if self._timer_enabled and not getattr(self, "_in_interrupt", False):
+            if self._timer_enabled:
                 self._tick_timers()
 
     def _build_register_annotations(self) -> Dict[str, Any]:
@@ -3996,30 +4023,6 @@ class PCE500Emulator:
         target.write_text(json.dumps(payload, indent=2))
         return target
 
-    def notify_lcd_interrupt(
-        self, address: int, value: int, pc: Optional[int] = None
-    ) -> None:
-        """Handle a pure-Rust LCD write that should nudge the KEY interrupt."""
-
-        if not getattr(self, "_llama_pure_lcd", False):
-            return
-        if not getattr(self, "_kb_irq_enabled", True):
-            return
-        self._set_isr_bits(int(ISRFlag.KEYI))
-        self._key_irq_latched = True
-        self._irq_pending = True
-        self._irq_source = IRQSource.KEY
-        try:
-            self.irq_counts["KEY"] += 1
-            self.irq_counts["total"] += 1
-        except Exception:
-            pass
-        if IRQ_DEBUG_ENABLED:
-            pc_str = f"0x{pc:06X}" if pc is not None else "N/A"
-            _log_irq_debug(
-                f"lcd-notify irq addr=0x{address:06X} value=0x{value:02X} pc={pc_str}"
-            )
-
     def press_key(self, key_code: str) -> bool:
         result = self.keyboard.press_key(key_code) if self.keyboard else False
         # The handler commits SSR.ONK and ISR.ONKI first (transactionally in
@@ -4192,37 +4195,11 @@ class PCE500Emulator:
                 pass
 
         if key_events:
-            if self._kb_irq_enabled:
-                self._key_irq_latched = True
-                self._set_isr_bits(int(ISRFlag.KEYI))
-                self._irq_pending = True
-                self._irq_source = IRQSource.KEY
-                self._kb_irq_count += len(key_events)
-                if IRQ_DEBUG_ENABLED:
-                    _log_irq_debug(
-                        f"key_events_irq count={len(key_events)} cycle={self.cycle_count}"
-                    )
-                # Emit a delivery marker for perfetto parity when scan raises KEYI.
-                try:
-                    self._trace_irq_instant(
-                        "KeyIRQ",
-                        self._irq_source,
-                        {
-                            "pc": self.cpu.regs.get(RegisterName.PC),
-                            "y": self.cpu.regs.get(RegisterName.Y),
-                            "events": len(key_events),
-                            "imr": self.memory.read_byte(
-                                INTERNAL_MEMORY_START + IMEMRegisters.IMR
-                            )
-                            & 0xFF,
-                            "isr": self.memory.read_byte(
-                                INTERNAL_MEMORY_START + IMEMRegisters.ISR
-                            )
-                            & 0xFF,
-                        },
-                    )
-                except Exception:
-                    pass
+            # Debounced events and the ROM-facing FIFO are bookkeeping only.
+            # Real hardware drives KEYI from the selected raw KIL matrix
+            # level, sampled at the scheduling boundary above.
+            self._key_irq_latched = True
+            self._kb_irq_count += len(key_events)
         # Trace scan outcome to perfetto to understand KEYI assertion cadence.
         try:
             pressed = len(getattr(self.keyboard, "_pressed_keys", []))
@@ -4278,16 +4255,12 @@ class PCE500Emulator:
                 pass
         if events:
             self._kb_irq_count += len(events)
-        if self._kb_irq_enabled and (events or fifo_pending):
+        if events or fifo_pending:
             self._key_irq_latched = True
-            self._set_isr_bits(int(ISRFlag.KEYI))
-            self._irq_pending = True
-            if not getattr(self, "_in_interrupt", False):
-                self._irq_source = IRQSource.KEY
             if events:
                 try:
                     self._trace_irq_instant(
-                        "KeyIRQ",
+                        "KeyEvent",
                         self._irq_source,
                         {
                             "pc": self.cpu.regs.get(RegisterName.PC),

--- a/pce500/keyboard_handler.py
+++ b/pce500/keyboard_handler.py
@@ -264,6 +264,28 @@ class PCE500KeyboardHandler:
     def peek_keyboard_input(self) -> int:
         return self._matrix.peek_kil()
 
+    def peek_physical_keyboard_input(self, pc: int | None = None) -> int:
+        """Return raw selected matrix level without advancing debounce/FIFO."""
+
+        if not self._scan_enabled:
+            return 0
+        if self._memory is not None:
+            try:
+                from sc62015.pysc62015.instr.opcodes import IMEMRegisters
+
+                address = INTERNAL_MEMORY_START + IMEMRegisters.LCC
+                peek = getattr(self._memory, "peek_byte_for_preflight", None)
+                lcc = (
+                    peek(address, pc)
+                    if callable(peek)
+                    else self._memory.read_byte(address)
+                )
+                if int(lcc) & 0x04:
+                    return 0
+            except Exception:
+                return 0
+        return self._matrix.peek_physical_kil()
+
     def get_debug_info(self) -> dict[str, object]:
         return {
             "pressed_keys": self.get_pressed_keys(),

--- a/pce500/keyboard_matrix.py
+++ b/pce500/keyboard_matrix.py
@@ -327,6 +327,21 @@ class KeyboardMatrix:
         self.trace_kio("peek_kil", pc=pc)
         return val
 
+    def peek_physical_kil(self) -> int:
+        """Return the undebounced electrical matrix level.
+
+        SC62015 `KIL` and the raw KEYI source are driven by the selected
+        column/pressed-row level. Debounce and repeat belong to firmware/event
+        handling and must not suppress this physical source.
+        """
+
+        value = 0
+        active_cols = set(self._active_columns())
+        for state in self._key_states.values():
+            if state.pressed and state.location.column in active_cols:
+                value |= 1 << state.location.row
+        return value & 0xFF
+
     def get_active_columns(self) -> List[int]:
         return list(self._active_columns())
 
@@ -394,7 +409,7 @@ class KeyboardMatrix:
         if base == 0:
             return 0
 
-        buffer_offset = self._memory.read_byte(base + PCE500_KEY_FIFO_BASE_OFFSET)
+        buffer_offset = self._memory.read_word(base + PCE500_KEY_FIFO_BASE_OFFSET)
         tail = self._memory.read_byte(base + PCE500_KEY_FIFO_TAIL_OFFSET)
         head = self._memory.read_byte(base + PCE500_KEY_FIFO_HEAD_OFFSET)
         written = 0

--- a/pce500/memory.py
+++ b/pce500/memory.py
@@ -919,18 +919,6 @@ class PCE500Memory:
             print(
                 f"[ext-write] pc=0x{effective_pc:06X} addr=0x{address:06X} value=0x{value:02X}"
             )
-        if getattr(self, "_emulator", None) is not None and getattr(
-            self._emulator, "_llama_pure_lcd", False
-        ):
-            if (
-                effective_pc is not None
-                and 0x0BFCE0 <= address <= 0x0BFCFF
-                and 0x0F2040 <= (effective_pc & 0xFFFFFF) <= 0x0F205F
-            ):
-                notify = getattr(self._emulator, "notify_lcd_interrupt", None)
-                if callable(notify):
-                    notify(address, value, effective_pc)
-
         # Check for SC62015 internal memory (0x100000-0x1000FF)
         if address >= 0x100000:
             offset = (address - 0x100000) & 0xFF

--- a/pce500/tests/test_fail_closed_scheduling.py
+++ b/pce500/tests/test_fail_closed_scheduling.py
@@ -781,7 +781,7 @@ def test_hardware_irq_callback_vector_rejects_before_mutation(
 
 
 @pytest.mark.parametrize("failure_mode", ("read_error", "mismatch"))
-def test_hardware_irq_architectural_vector_failure_is_atomic_and_poisoning(
+def test_hardware_irq_vector_failure_occurs_after_frame_and_poisons(
     failure_mode: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -818,29 +818,8 @@ def test_hardware_irq_architectural_vector_failure_is_atomic_and_poisoning(
         )
         emu._timer_enabled = False
         emu._irq_pending = True
-        # Deliberately differ from the pending ISR source so the assertion
-        # proves failed vector delivery does not relabel wrapper metadata.
         emu._irq_source = IRQSource.MTI
         emu._in_interrupt = False
-        before = (
-            emu.cpu.regs.get(RegisterName.PC),
-            emu.cpu.regs.get(RegisterName.S),
-            emu.cpu.regs.get(RegisterName.F),
-            emu.memory.peek_byte_for_preflight(
-                INTERNAL_MEMORY_START + IMEMRegisters.IMR
-            ),
-            bytes(
-                emu.memory.peek_byte_for_preflight(stack - offset)
-                for offset in range(1, 6)
-            ),
-            emu._irq_pending,
-            emu._in_interrupt,
-            emu._irq_source,
-            emu.cycle_count,
-            emu.instruction_count,
-            dict(emu.irq_counts),
-            dict(emu.last_irq),
-        )
         error = (
             "architectural IRQ-vector read failed"
             if failure_mode == "read_error"
@@ -850,26 +829,28 @@ def test_hardware_irq_architectural_vector_failure_is_atomic_and_poisoning(
         with pytest.raises(RuntimeError, match=error):
             emu.step()
 
-        assert (
-            emu.cpu.regs.get(RegisterName.PC),
-            emu.cpu.regs.get(RegisterName.S),
-            emu.cpu.regs.get(RegisterName.F),
-            emu.memory.peek_byte_for_preflight(
-                INTERNAL_MEMORY_START + IMEMRegisters.IMR
-            ),
-            bytes(
-                emu.memory.peek_byte_for_preflight(stack - offset)
-                for offset in range(1, 6)
-            ),
-            emu._irq_pending,
-            emu._in_interrupt,
-            emu._irq_source,
-            emu.cycle_count,
-            emu.instruction_count,
-            dict(emu.irq_counts),
-            dict(emu.last_irq),
-        ) == before
-        assert architectural_vector_reads
+        # HW-014 places the architectural vector read after all five frame
+        # writes. A failure there is therefore deliberately non-atomic and
+        # must poison the machine rather than roll the frame back.
+        assert emu.cpu.regs.get(RegisterName.PC) == 0x1000
+        assert emu.cpu.regs.get(RegisterName.S) == stack - 5
+        assert emu.cpu.regs.get(RegisterName.F) == 0x03
+        assert bytes(
+            emu.memory.peek_byte_for_preflight(stack - offset) for offset in range(1, 6)
+        ) == bytes((0x00, 0x10, 0x00, 0x03, int(IMRFlag.IRM | IMRFlag.KEYM)))
+        assert emu.memory.peek_byte_for_preflight(
+            INTERNAL_MEMORY_START + IMEMRegisters.IMR
+        ) == int(IMRFlag.KEYM)
+        assert emu._irq_pending is True
+        assert emu._in_interrupt is False
+        assert emu._irq_source is IRQSource.KEY
+        assert emu.cycle_count == 0
+        assert emu.instruction_count == 0
+        assert architectural_vector_reads == (
+            [0xFFFFA, 0xFFFFB]
+            if failure_mode == "read_error"
+            else [0xFFFFA, 0xFFFFB, 0xFFFFC]
+        )
         assert emu._poisoned is not None
     finally:
         emu.close()

--- a/pce500/tests/test_interrupts.py
+++ b/pce500/tests/test_interrupts.py
@@ -94,6 +94,7 @@ handler:
     PUSHU A
     MV A, (ISR)
     PUSHU A
+    MV (ISR), 0x00
     RETI
 """
 
@@ -271,6 +272,20 @@ def _run_and_observe(g: Given, e: Expect) -> Observed:
     elif g.trigger is Trigger.KEY_OFF:
         emu.press_key(g.trigger.value)
 
+    # These synthetic scenarios test one interrupt delivery, not held-key
+    # retriggering.  Give F1 one scheduler sample at the selected KIL level,
+    # then release it.  The handler acknowledges ISR after recording it so a
+    # latched source cannot manufacture additional deliveries.  Dedicated
+    # hardware-backed keyboard tests cover the real held-level behaviour.
+    key_pulse_pending = g.trigger is Trigger.KEY_F1
+
+    def step_once() -> None:
+        nonlocal key_pulse_pending
+        emu.step()
+        if key_pulse_pending:
+            emu.release_key(g.trigger.value)
+            key_pulse_pending = False
+
     # Execute program to the delivery point
     if g.program is Program.HALT:
         if g.timers_enabled:
@@ -281,33 +296,33 @@ def _run_and_observe(g: Given, e: Expect) -> Observed:
             else:
                 steps = 24
             for _ in range(int(steps)):
-                emu.step()
+                step_once()
         else:
             for _ in range(24):
-                emu.step()
+                step_once()
     elif g.program is Program.OFF:
         # Timers remain off; ON unmasked should wake, others shouldn't
         if e.deliver:
             # One step to cancel OFF and deliver, plus a few for handler
-            emu.step()
+            step_once()
             for _ in range(5):
-                emu.step()
+                step_once()
         else:
             # Exceed the longest timer period to be robust to off-by-one
             longest = max(mti_period, sti_period)
             for _ in range(int(longest + 200)):
-                emu.step()
+                step_once()
     else:
         # WAIT program
         for _ in range(max(1, wait_chunks)):
-            emu.step()  # MV I
-            emu.step()  # WAIT
-        emu.step()  # Attempt delivery
+            step_once()  # MV I
+            step_once()  # WAIT
+        step_once()  # Attempt delivery
         if e.deliver:
             for _ in range(5):  # Full handler
-                emu.step()
+                step_once()
         else:
-            emu.step()  # NOP
+            step_once()  # NOP
 
     u_after = emu.cpu.regs.get(RegisterName.U)
     u_delta = u_after - u_before
@@ -908,7 +923,9 @@ def test_partial_irq_frame_failure_poisons_until_reset(
         emu.step()
 
     assert emu.cpu.regs.get(RegisterName.PC) == 0x1000
-    assert emu.cpu.regs.get(RegisterName.S) == 0x01FD
+    # PC high/middle/low commit first, followed by F.  The injected failure is
+    # the IMR frame write, so four bytes have observably reached the stack.
+    assert emu.cpu.regs.get(RegisterName.S) == 0x01FC
     assert emu.instruction_count == 0
     assert "IRQ delivery failed" in str(emu._poisoned)  # type: ignore[attr-defined]
 
@@ -950,7 +967,7 @@ def test_pending_irq_stack_underflow_wraps_in_20_bit_space(
 
     emu.step()
 
-    assert external_writes[:5] == [0xFFFFF, 0x00000, 0x00001, 0xFFFFE, 0xFFFFD]
+    assert external_writes[:5] == [0x00001, 0x00000, 0xFFFFF, 0xFFFFE, 0xFFFFD]
     assert emu.memory.read_byte(0xFFFFF) == 0x00  # saved PC low
     assert emu.memory.read_byte(0x00000) == 0x10  # saved PC middle
     assert emu.memory.read_byte(0x00001) == 0x00  # saved PC high

--- a/pce500/tests/test_key_irq_latch.py
+++ b/pce500/tests/test_key_irq_latch.py
@@ -1,4 +1,4 @@
-"""Host keyboard-bridge latch policy; not a stock-ROM or hardware contract."""
+"""Hardware-backed raw KIL/KEYI and separate host-event bookkeeping."""
 
 from __future__ import annotations
 
@@ -11,8 +11,7 @@ from pce500 import PCE500Emulator
 INTERNAL_MEMORY_START = 0x100000
 
 
-def test_key_latch_survives_release_until_irq_delivered():
-    """Preserve a synthetic host key event until the emulator can deliver it."""
+def test_raw_keyi_survives_release_until_firmware_acknowledges_it():
     emu = PCE500Emulator(perfetto_trace=False, save_lcd_on_exit=False)
     emu._timer_enabled = False  # type: ignore[attr-defined]
 
@@ -23,22 +22,55 @@ def test_key_latch_survives_release_until_irq_delivered():
 
     assert emu.press_key("KEY_F1") is True
     emu.step()
-    assert emu._key_irq_latched is True  # type: ignore[attr-defined]
     assert (
         emu.memory.read_byte(INTERNAL_MEMORY_START + IMEMRegisters.ISR)
         & int(ISRFlag.KEYI)
         != 0
     )
 
-    # User releases the key before firmware unmasks IRQs; latch must remain.
+    # Releasing the key removes the electrical level but does not itself clear
+    # the status bit already latched by hardware.
     emu.release_key("KEY_F1")
-    assert emu._key_irq_latched is True  # type: ignore[attr-defined]
+    assert (
+        emu.memory.read_byte(INTERNAL_MEMORY_START + IMEMRegisters.ISR)
+        & int(ISRFlag.KEYI)
+        != 0
+    )
 
-    # Firmware clears ISR while still masked; step() should reassert KEYI from the latch.
+    # Firmware acknowledgement after physical release clears raw KEYI. The
+    # host FIFO latch is separate and must not manufacture another silicon
+    # level request.
     emu.memory.write_byte(INTERNAL_MEMORY_START + IMEMRegisters.ISR, 0x00)
     emu.step()
     assert (
         emu.memory.read_byte(INTERNAL_MEMORY_START + IMEMRegisters.ISR)
         & int(ISRFlag.KEYI)
+        == 0
+    )
+
+
+def test_selected_held_key_relatches_keyi_while_handler_is_active():
+    emu = PCE500Emulator(perfetto_trace=False, save_lcd_on_exit=False)
+    emu._timer_enabled = False  # type: ignore[attr-defined]
+    emu.memory.write_byte(INTERNAL_MEMORY_START + IMEMRegisters.IMR, 0x00)
+    emu.memory.write_byte(INTERNAL_MEMORY_START + IMEMRegisters.KOH, 0x04)
+    assert emu.press_key("KEY_F1") is True
+
+    emu._in_interrupt = True  # type: ignore[attr-defined]
+    emu.memory.write_byte(INTERNAL_MEMORY_START + IMEMRegisters.ISR, 0x00)
+    emu.step()
+
+    assert (
+        emu.memory.read_byte(INTERNAL_MEMORY_START + IMEMRegisters.ISR)
+        & int(ISRFlag.KEYI)
         != 0
+    )
+
+    emu.release_key("KEY_F1")
+    emu.memory.write_byte(INTERNAL_MEMORY_START + IMEMRegisters.ISR, 0x00)
+    emu.step()
+    assert (
+        emu.memory.read_byte(INTERNAL_MEMORY_START + IMEMRegisters.ISR)
+        & int(ISRFlag.KEYI)
+        == 0
     )

--- a/pce500/tests/test_keyboard_handler.py
+++ b/pce500/tests/test_keyboard_handler.py
@@ -69,7 +69,7 @@ class TestKeyboardHandler:
     def test_fifo_drains_into_rom_iocs_workspace(self) -> None:
         workspace = 0x0BFC80
         self.memory.write_long(0x1000E6, workspace)
-        self.memory.write_byte(workspace + 0x02, 0x50)
+        self.memory.write_word(workspace + 0x02, 0x0150)
         self.memory.write_byte(workspace + 0x04, 0)
         self.memory.write_byte(workspace + 0x05, 0)
 
@@ -79,7 +79,7 @@ class TestKeyboardHandler:
         assert self.handler.scan_tick()
 
         assert self.handler.drain_fifo_to_pce500_iocs_workspace(True) == 1
-        assert self.memory.read_byte(workspace + 0x50) == (
+        assert self.memory.read_byte(workspace + 0x0150) == (
             KEY_LOCATIONS["KEY_F1"].column << 3 | KEY_LOCATIONS["KEY_F1"].row
         )
         assert self.memory.read_byte(workspace + 0x04) == 1

--- a/pce500/tests/test_memory_alias_and_irq.py
+++ b/pce500/tests/test_memory_alias_and_irq.py
@@ -220,7 +220,7 @@ def test_timer_irq_arms_only_when_imr_allows(backend: str) -> None:
 
 
 def test_timer_advances_while_interrupt_handler_is_active() -> None:
-    """Pin the Python scheduler model; real-device ISR relatch timing is unverified."""
+    """HW-014: timers latch status in a handler without nested delivery."""
     emu = Emulator()
     emu._timer_enabled = True
     emu._timer_mti_period = 2
@@ -235,6 +235,9 @@ def test_timer_advances_while_interrupt_handler_is_active() -> None:
     emu.step()
 
     assert emu.memory.read_byte(isr_addr) & int(ISRFlag.MTI)
+    assert emu.cpu.regs.get(RegisterName.PC) == 1
+    assert emu.cpu.regs.get(RegisterName.S) == 0x0200
+    assert emu._in_interrupt is True
 
 
 @pytest.mark.parametrize("backend", ["python", "llama"])

--- a/sc62015/arch.py
+++ b/sc62015/arch.py
@@ -72,6 +72,10 @@ class SC62015(Architecture):
         "OFF": IntrinsicInfo(inputs=[], outputs=[]),
         "RESET": IntrinsicInfo(inputs=[], outputs=[]),
         "VALIDATE_F": IntrinsicInfo(inputs=[Type.int(1, False)], outputs=[]),
+        "PREFLIGHT_VECTOR_TRANSFER": IntrinsicInfo(
+            inputs=[Type.int(3, False), Type.int(3, False)],
+            outputs=[],
+        ),
         "VALIDATE_VECTOR_TRANSFER": IntrinsicInfo(
             inputs=[
                 Type.int(3, False),

--- a/sc62015/core/src/bin/pce500.rs
+++ b/sc62015/core/src/bin/pce500.rs
@@ -15,8 +15,9 @@ use sc62015_core::{
     llama::{
         async_eval::{AsyncLlamaExecutor, TickHelper},
         eval::{
-            fetch_validated_vector, perfetto_next_substep, power_on_reset, set_perf_instr_counter,
-            validate_vector_transfer_with_length, LlamaBus, TimerTrace, ValidatedVectorTransfer,
+            fetch_validated_vector, perfetto_next_substep, power_on_reset,
+            prepare_validated_vector, set_perf_instr_counter, validate_vector_transfer_with_length,
+            LlamaBus, TimerTrace, ValidatedVectorTransfer,
         },
         opcodes::RegName,
         state::{mask_for, validate_f_image, CallMetricsSnapshot, LlamaState, PowerState},
@@ -54,8 +55,11 @@ use serde_json::{json, Value};
 #[cfg(test)]
 use sc62015_core::memory::IMEM_EIH_OFFSET;
 
-const FIFO_BASE_ADDR: u32 = 0x00BFC96;
-const FIFO_TAIL_ADDR: u32 = 0x00BFC9E;
+const PCE500_IOCS_WS_PTR_ADDR: u32 = 0x00BFD17;
+const PCE500_KEY_FIFO_BASE_OFFSET: u32 = 0x02;
+const PCE500_KEY_FIFO_TAIL_OFFSET: u32 = 0x04;
+const PCE500_KEY_FIFO_HEAD_OFFSET: u32 = 0x05;
+const PCE500_KEY_FIFO_CAPACITY: u32 = 0x10;
 const VEC_RANGE_START: u32 = 0x00BFCC6;
 const VEC_RANGE_END: u32 = 0x00BFCCC;
 const ISR_KEYI: u8 = 0x04;
@@ -1451,11 +1455,37 @@ impl StandaloneBus {
         }
     }
 
+    fn keyboard_fifo_addresses(&self) -> Option<(u32, u32, u32)> {
+        let read = |address| self.memory.read_byte_silent(address).map(u32::from);
+        let workspace_base = read(PCE500_IOCS_WS_PTR_ADDR)?
+            | (read(PCE500_IOCS_WS_PTR_ADDR + 1)? << 8)
+            | (read(PCE500_IOCS_WS_PTR_ADDR + 2)? << 16);
+        if workspace_base == 0 {
+            return None;
+        }
+        let fifo_offset = read(workspace_base + PCE500_KEY_FIFO_BASE_OFFSET)?
+            | (read(workspace_base + PCE500_KEY_FIFO_BASE_OFFSET + 1)? << 8);
+        Some((
+            (workspace_base + fifo_offset) & ADDRESS_MASK,
+            (workspace_base + PCE500_KEY_FIFO_TAIL_OFFSET) & ADDRESS_MASK,
+            (workspace_base + PCE500_KEY_FIFO_HEAD_OFFSET) & ADDRESS_MASK,
+        ))
+    }
+
+    fn is_keyboard_fifo_address(&self, addr: u32) -> bool {
+        let Some((fifo_base, fifo_tail, fifo_head)) = self.keyboard_fifo_addresses() else {
+            return false;
+        };
+        addr == fifo_tail
+            || addr == fifo_head
+            || (fifo_base..fifo_base + PCE500_KEY_FIFO_CAPACITY).contains(&addr)
+    }
+
     fn trace_fifo_access(&self, kind: &str, addr: u32, bits: u8, value: u32) {
         if !self.trace_kbd {
             return;
         }
-        if !(FIFO_BASE_ADDR..=FIFO_TAIL_ADDR).contains(&addr) {
+        if !self.is_keyboard_fifo_address(addr) {
             return;
         }
         println!(
@@ -1494,7 +1524,8 @@ impl StandaloneBus {
     }
 
     fn tick_keyboard(&mut self) {
-        // Parity: scan only when called by timer cadence; assert KEYI when events are queued.
+        // Scan only on timer cadence. Events feed host/ROM FIFO bookkeeping;
+        // raw KEYI is sampled separately from selected physical KIL.
         let events = self.keyboard.scan_tick(&mut self.memory, true);
         let fifo_pending = self.keyboard.fifo_len() > 0;
         let pending = events > 0 || fifo_pending;
@@ -1544,29 +1575,12 @@ impl StandaloneBus {
                 .write_fifo_to_memory(&mut self.memory, kb_irq_enabled);
         }
         self.pending_kil = true;
-        self.raise_key_irq();
-        if kb_irq_enabled {
-            self.timer.key_irq_latched = true;
-            self.irq_pending = true;
-            if !self.in_interrupt {
-                self.last_irq_src = Some("KEY".to_string());
-            }
-        }
-    }
-
-    fn raise_key_irq(&mut self) {
-        if !self.timer.keyboard_irq_enabled() {
-            return;
-        }
-        if let Some(cur) = self.memory.read_internal_byte(IMEM_ISR_OFFSET) {
-            let new = cur | ISR_KEYI;
-            self.memory.write_internal_byte(IMEM_ISR_OFFSET, new);
-        }
+        self.timer.key_irq_latched = true;
     }
 
     fn press_key(&mut self, code: u8) {
-        // Parity: auto-key presses update the matrix state and let the timer-driven scan
-        // Correctness: enqueue FIFO/KEYI timing.
+        // Auto-key presses update physical matrix state. Timer-driven scans
+        // handle host FIFO timing; CPU boundaries sample raw KIL/KEYI.
         self.keyboard.press_matrix_code(code, &mut self.memory);
     }
 
@@ -1582,12 +1596,7 @@ impl StandaloneBus {
             .inject_input_event(code, &mut self.memory, kb_irq_enabled);
         if events > 0 {
             self.pending_kil = true;
-            self.raise_key_irq();
-            if kb_irq_enabled {
-                self.timer.key_irq_latched = true;
-                self.irq_pending = true;
-                self.last_irq_src = Some("KEY".to_string());
-            }
+            self.timer.key_irq_latched = true;
         }
     }
 
@@ -1598,12 +1607,7 @@ impl StandaloneBus {
                 .inject_matrix_event(code, release, &mut self.memory, kb_irq_enabled);
         if events > 0 {
             self.pending_kil = true;
-            self.raise_key_irq();
-            if kb_irq_enabled {
-                self.timer.key_irq_latched = true;
-                self.irq_pending = true;
-                self.last_irq_src = Some("KEY".to_string());
-            }
+            self.timer.key_irq_latched = true;
         }
     }
 
@@ -1689,13 +1693,26 @@ impl StandaloneBus {
         let mut isr = self.memory.read_internal_byte(IMEM_ISR_OFFSET).unwrap_or(0);
         let imr = self.memory.read_internal_byte(IMEM_IMR_OFFSET).unwrap_or(0);
         let in_interrupt = self.in_interrupt;
-        // Reassert latched KEYI if firmware clears ISR while key IRQ latch remains set.
-        if self.timer.key_irq_latched && (isr & ISR_KEYI) == 0 {
+        let raw_kil = if self
+            .memory
+            .read_internal_byte_silent(IMEM_LCC_OFFSET)
+            .unwrap_or(0)
+            & 0x04
+            == 0
+        {
+            self.keyboard.compute_physical_kil()
+        } else {
+            0
+        };
+        // KEYI follows the selected, undebounced physical KIL level. This
+        // remains active while servicing an interrupt; only nested delivery
+        // is deferred below.
+        if raw_kil != 0 && (isr & ISR_KEYI) == 0 {
             self.memory
                 .write_internal_byte(IMEM_ISR_OFFSET, isr | ISR_KEYI);
             isr |= ISR_KEYI;
             self.irq_pending = true;
-            if !matches!(self.last_irq_src.as_deref(), Some("KEY" | "ONK")) {
+            if !self.in_interrupt && !matches!(self.last_irq_src.as_deref(), Some("KEY" | "ONK")) {
                 self.last_irq_src = Some("KEY".to_string());
             }
         }
@@ -1786,11 +1803,12 @@ impl StandaloneBus {
             return Ok(());
         };
 
-        let vec = fetch_validated_vector(INTERRUPT_VECTOR_ADDR, state, self)?.target();
+        let vector_transfer = prepare_validated_vector(INTERRUPT_VECTOR_ADDR, state, self)?;
         self.maybe_patch_vectors();
 
-        // Only now is the vector transfer committed: construct the frame and
-        // clear IRM after every rejectable condition has passed.
+        // Hardware writes the complete frame before the one low-to-high
+        // architectural vector fetch. Silent validation above is deliberately
+        // unobservable and does not substitute for those reads.
         push_stack(&mut self.memory, state, RegName::S, pc, 24);
         let f = state.get_reg(RegName::F) & 0xFF;
         push_stack(&mut self.memory, state, RegName::S, f, 8);
@@ -1798,6 +1816,12 @@ impl StandaloneBus {
         let cleared_imr = imr & 0x7F;
         let _ = self.memory.store(imr_addr, 8, cleared_imr as u32);
         state.set_reg(RegName::IMR, u32::from(cleared_imr));
+
+        let vec = vector_transfer.consume_after_architectural_fetch(
+            INTERRUPT_VECTOR_ADDR,
+            state,
+            self,
+        )?;
 
         state.set_pc(vec);
         state.set_halted(false);
@@ -1924,47 +1948,34 @@ impl StandaloneBus {
             self.irq_pending = true;
             self.last_irq_src = Some("STI".to_string());
         }
-        if scan_on_timer {
-            if mti && key_events > 0 {
-                self.pending_kil = pending_kil;
-                if self.pending_kil {
-                    self.raise_key_irq();
-                    if kb_irq_enabled {
-                        self.timer.key_irq_latched = true;
-                        self.irq_pending = true;
-                        self.last_irq_src = Some("KEY".to_string());
-                    }
-                }
-                self.last_kbd_access = Some("scan".to_string());
-                self.log_irq_event(
-                    "KeyScan",
-                    Some("KEY"),
-                    [
-                        (
-                            "isr",
-                            AnnotationValue::UInt(
-                                self.memory.read_internal_byte(IMEM_ISR_OFFSET).unwrap_or(0) as u64,
-                            ),
-                        ),
-                        (
-                            "imr",
-                            AnnotationValue::UInt(
-                                self.memory.read_internal_byte(IMEM_IMR_OFFSET).unwrap_or(0) as u64,
-                            ),
-                        ),
-                        ("pc", AnnotationValue::Pointer(self.last_pc as u64)),
-                    ],
-                );
+        if scan_on_timer && mti && key_events > 0 {
+            self.pending_kil = pending_kil;
+            if self.pending_kil {
+                self.timer.key_irq_latched = true;
             }
-            if sti && self.keyboard.fifo_len() > 0 {
-                if let Some(cur) = self.memory.read_internal_byte(IMEM_ISR_OFFSET) {
-                    if (cur & ISR_KEYI) == 0 {
-                        self.memory
-                            .write_internal_byte(IMEM_ISR_OFFSET, cur | ISR_KEYI);
-                    }
-                }
-            }
+            self.last_kbd_access = Some("scan".to_string());
+            self.log_irq_event(
+                "KeyScan",
+                Some("KEY"),
+                [
+                    (
+                        "isr",
+                        AnnotationValue::UInt(
+                            self.memory.read_internal_byte(IMEM_ISR_OFFSET).unwrap_or(0) as u64,
+                        ),
+                    ),
+                    (
+                        "imr",
+                        AnnotationValue::UInt(
+                            self.memory.read_internal_byte(IMEM_IMR_OFFSET).unwrap_or(0) as u64,
+                        ),
+                    ),
+                    ("pc", AnnotationValue::Pointer(self.last_pc as u64)),
+                ],
+            );
         }
+        // Host FIFO occupancy is not an electrical KEYI source. Raw selected
+        // KIL is sampled by refresh_raw_key_irq().
     }
 
     fn advance_cycle(&mut self) {
@@ -2591,9 +2602,7 @@ impl LlamaBus for StandaloneBus {
                     }
                     return self.lcd.read_placeholder(addr);
                 }
-                if (FIFO_BASE_ADDR..=FIFO_TAIL_ADDR).contains(&addr) {
-                    self.trace_fifo_access("read", addr, bits, val);
-                }
+                self.trace_fifo_access("read", addr, bits, val);
                 val & mask_bits(bits)
             })
             .unwrap_or(0);
@@ -2807,9 +2816,7 @@ impl LlamaBus for StandaloneBus {
             }
             return;
         }
-        if (FIFO_BASE_ADDR..=FIFO_TAIL_ADDR).contains(&addr) {
-            self.trace_fifo_access("write", addr, bits, value);
-        }
+        self.trace_fifo_access("write", addr, bits, value);
         if self.memory.requires_python(addr) {
             if let Some(cb) = self.host_write.as_mut() {
                 (cb)(addr, value as u8);
@@ -2916,7 +2923,7 @@ fn load_rom(path: &Path) -> Result<Vec<u8>, Box<dyn Error>> {
 
 fn configure_bus_for_model(bus: &mut StandaloneBus, model: DeviceModel) {
     if model.is_pce500_family() {
-        // Baseline emulator key scanning asserts KEYI on the first visible scan.
+        // Keep host debounce responsive; raw KEYI is sampled independently.
         bus.keyboard.set_press_threshold(1);
         // Baseline PC-E500 scans the key matrix each instruction (not just on MTI).
         bus.scan_on_timer = false;
@@ -4057,7 +4064,18 @@ fn current_instruction_requires_silent_preflight(state: &LlamaState, bus: &Stand
         .memory
         .read_internal_byte_silent(IMEM_ISR_OFFSET)
         .unwrap_or(0);
-    if bus.timer.key_irq_latched {
+    let raw_kil = if bus
+        .memory
+        .read_internal_byte_silent(IMEM_LCC_OFFSET)
+        .unwrap_or(0)
+        & 0x04
+        == 0
+    {
+        bus.keyboard.compute_physical_kil()
+    } else {
+        0
+    };
+    if raw_kil != 0 {
         isr |= ISR_KEYI;
     }
     if bus.pending_onk {
@@ -4065,14 +4083,6 @@ fn current_instruction_requires_silent_preflight(state: &LlamaState, bus: &Stand
     }
     let irq_replaces_pc = !bus.in_interrupt && (imr & IMR_MASTER) != 0 && (imr & isr) != 0;
     !irq_replaces_pc
-}
-
-fn fetch_replaced_irq_opcode(state: &LlamaState, bus: &mut StandaloneBus) -> u8 {
-    let pc = state.pc() & ADDRESS_MASK;
-    // Hardware performs exactly one architectural opcode fetch at the saved
-    // PC before an already-selected interrupt writes its frame. The byte is
-    // discarded, so it must not be decoded or silently stability-checked.
-    bus.load(pc, 8) as u8
 }
 
 fn preflight_and_tick_instruction(
@@ -4096,7 +4106,7 @@ fn preflight_and_tick_instruction(
     let transfer = match opcode {
         0xFE => {
             validate_stable_vector_transfer(INTERRUPT_VECTOR_ADDR, state, bus)?;
-            Some(fetch_validated_vector(INTERRUPT_VECTOR_ADDR, state, bus)?)
+            Some(prepare_validated_vector(INTERRUPT_VECTOR_ADDR, state, bus)?)
         }
         0xFF => {
             validate_stable_vector_transfer(ROM_RESET_VECTOR_ADDR, state, bus)?;
@@ -4907,17 +4917,6 @@ fn run(mut args: Args) -> Result<(), Box<dyn Error>> {
             } else {
                 None
             };
-            let (_irq_target, _irq_target_len) =
-                match validate_stable_vector_transfer(INTERRUPT_VECTOR_ADDR, &state, &mut bus) {
-                    Ok(validated) => validated,
-                    Err(error) => {
-                        eprintln!(
-                            "error preflighting IRQ vector at PC=0x{:05X}: {error}",
-                            state.pc()
-                        );
-                        break;
-                    }
-                };
             if use_key_seq {
                 let screen_state = if needs_screen_state || needs_screen_text {
                     capture_screen_state(bus.lcd(), text_decoder.as_ref(), needs_screen_text)
@@ -4986,9 +4985,13 @@ fn run(mut args: Args) -> Result<(), Box<dyn Error>> {
             }
 
             if bus.irq_pending() {
+                // A deliverable asynchronous IRQ replaces, but does not erase,
+                // the fall-through opcode fetch. Hardware performs exactly one
+                // byte read here and does not decode operands.
+                let irq_pc = state.pc() & ADDRESS_MASK;
+                let _discarded_opcode = bus.load(irq_pc, 8);
                 // S is a 20-bit external pointer. Interrupt-frame bytes wrap
                 // independently at FFFFF -> 00000 even when S starts below 5.
-                let _discarded_opcode = fetch_replaced_irq_opcode(&state, &mut bus);
                 if let Err(error) = bus.deliver_irq(&mut state) {
                     eprintln!("error delivering IRQ at PC=0x{:05X}: {error}", state.pc());
                     break;
@@ -5897,60 +5900,6 @@ mod tests {
     }
 
     #[test]
-    fn selected_irq_fetches_discarded_callback_opcode_once_without_preflight() {
-        use std::sync::atomic::{AtomicUsize, Ordering};
-        use std::sync::Arc;
-
-        let mut bus = test_standalone_bus();
-        let current_pc = 0x02000;
-        let handler_pc = 0x03000;
-        let mut state = LlamaState::new();
-        state.set_pc(current_pc);
-        state.set_reg(RegName::S, 0x00400);
-        bus.memory.write_external_byte(current_pc, 0x20);
-        bus.memory.write_external_byte(handler_pc, 0x00);
-        bus.memory
-            .write_external_byte(INTERRUPT_VECTOR_ADDR, handler_pc as u8);
-        bus.memory
-            .write_external_byte(INTERRUPT_VECTOR_ADDR + 1, (handler_pc >> 8) as u8);
-        bus.memory
-            .write_external_byte(INTERRUPT_VECTOR_ADDR + 2, (handler_pc >> 16) as u8);
-        bus.memory
-            .write_internal_byte(IMEM_IMR_OFFSET, IMR_MASTER | IMR_KEY);
-        bus.memory.write_internal_byte(IMEM_ISR_OFFSET, ISR_KEYI);
-        bus.irq_pending = true;
-        bus.timer.irq_pending = true;
-        bus.last_irq_src = Some("KEY".to_string());
-        bus.memory.set_python_ranges(vec![(current_pc, current_pc)]);
-
-        let architectural_reads = Arc::new(AtomicUsize::new(0));
-        let silent_peeks = Arc::new(AtomicUsize::new(0));
-        let read_count = Arc::clone(&architectural_reads);
-        bus.host_read = Some(Box::new(move |addr| {
-            assert_eq!(addr, current_pc);
-            read_count.fetch_add(1, Ordering::Relaxed);
-            Some(0x20)
-        }));
-        let peek_count = Arc::clone(&silent_peeks);
-        bus.host_peek = Some(Box::new(move |addr| {
-            assert_eq!(addr, current_pc);
-            peek_count.fetch_add(1, Ordering::Relaxed);
-            Some(0x20)
-        }));
-
-        assert!(!current_instruction_requires_silent_preflight(&state, &bus));
-        assert_eq!(fetch_replaced_irq_opcode(&state, &mut bus), 0x20);
-        bus.deliver_irq(&mut state)
-            .expect("selected IRQ must replace a reserved callback opcode");
-
-        assert_eq!(architectural_reads.load(Ordering::Relaxed), 1);
-        assert_eq!(silent_peeks.load(Ordering::Relaxed), 0);
-        assert_eq!(state.pc(), handler_pc);
-        assert_eq!(state.get_reg(RegName::S), 0x003FB);
-        assert!(bus.in_interrupt);
-    }
-
-    #[test]
     fn on_key_sets_isr_and_triggers_pending_irq() {
         let mut bus = StandaloneBus::new(
             MemoryImage::new(),
@@ -6031,7 +5980,7 @@ mod tests {
     }
 
     #[test]
-    fn auto_key_press_defers_keyi_until_scan() {
+    fn selected_auto_key_asserts_raw_keyi_at_scheduling_boundary() {
         let mut bus = StandaloneBus::new(
             MemoryImage::new(),
             create_lcd(sc62015_core::LcdKind::Hd61202),
@@ -6077,7 +6026,7 @@ mod tests {
             "auto key press should not mark KIL pending before scan"
         );
 
-        bus.advance_cycles(6);
+        let _delivery_selected = bus.irq_pending();
 
         let isr_scan = bus
             .memory
@@ -6086,13 +6035,7 @@ mod tests {
         assert_ne!(
             isr_scan & super::ISR_KEYI,
             0,
-            "scan tick should assert KEYI after debounce"
-        );
-        assert!(bus.timer.key_irq_latched, "scan tick should latch KEYI");
-        assert!(bus.pending_kil, "scan tick should mark KIL pending");
-        assert!(
-            bus.keyboard.fifo_len() > 0,
-            "scan tick should enqueue FIFO event"
+            "raw selected KIL should assert KEYI before debounce"
         );
     }
 
@@ -6139,7 +6082,7 @@ mod tests {
     }
 
     #[test]
-    fn exact_input_event_sets_key_irq_without_matrix_release_masking() {
+    fn exact_input_event_does_not_manufacture_raw_matrix_keyi() {
         let mut bus = StandaloneBus::new(
             MemoryImage::new(),
             create_lcd(sc62015_core::LcdKind::Iq7000Vram),
@@ -6160,9 +6103,9 @@ mod tests {
             .memory
             .read_internal_byte(super::IMEM_ISR_OFFSET)
             .unwrap_or(0);
-        assert_ne!(isr & super::ISR_KEYI, 0);
+        assert_eq!(isr & super::ISR_KEYI, 0);
         assert!(bus.pending_kil);
-        assert!(bus.irq_pending);
+        assert!(!bus.irq_pending);
     }
 
     #[test]
@@ -6193,7 +6136,47 @@ mod tests {
     }
 
     #[test]
-    fn per_instruction_scan_sets_keyi_when_enabled() {
+    fn raw_keyi_reasserts_in_handler_until_physical_release() {
+        let mut bus = StandaloneBus::new(
+            MemoryImage::new(),
+            create_lcd(sc62015_core::LcdKind::Hd61202),
+            TimerContext::new(true, 0, 0),
+            false,
+            0,
+            false,
+            None,
+            None,
+            None,
+        );
+        bus.strobe_all_columns();
+        bus.press_key(super::PF1_CODE);
+        bus.in_interrupt = true;
+        bus.memory.write_internal_byte(super::IMEM_ISR_OFFSET, 0);
+
+        assert!(!bus.irq_pending(), "nested delivery remains deferred");
+        assert_eq!(
+            bus.memory
+                .read_internal_byte(super::IMEM_ISR_OFFSET)
+                .unwrap_or(0)
+                & super::ISR_KEYI,
+            super::ISR_KEYI
+        );
+
+        bus.release_key(super::PF1_CODE);
+        bus.memory.write_internal_byte(super::IMEM_ISR_OFFSET, 0);
+        bus.irq_pending = false;
+        assert!(!bus.irq_pending());
+        assert_eq!(
+            bus.memory
+                .read_internal_byte(super::IMEM_ISR_OFFSET)
+                .unwrap_or(0)
+                & super::ISR_KEYI,
+            0
+        );
+    }
+
+    #[test]
+    fn per_instruction_scan_keeps_fifo_separate_from_raw_keyi() {
         let mut bus = StandaloneBus::new(
             MemoryImage::new(),
             create_lcd(sc62015_core::LcdKind::Hd61202),
@@ -6223,13 +6206,18 @@ mod tests {
             .memory
             .read_internal_byte(super::IMEM_ISR_OFFSET)
             .unwrap_or(0);
-        assert_ne!(
-            isr_after & super::ISR_KEYI,
-            0,
-            "per-instruction scan should assert KEYI"
-        );
+        assert_eq!(isr_after & super::ISR_KEYI, 0);
         assert!(bus.timer.key_irq_latched);
         assert!(bus.pending_kil);
+        let _delivery_selected = bus.irq_pending();
+        assert_ne!(
+            bus.memory
+                .read_internal_byte(super::IMEM_ISR_OFFSET)
+                .unwrap_or(0)
+                & super::ISR_KEYI,
+            0,
+            "raw held matrix level should assert KEYI"
+        );
     }
 
     #[test]
@@ -6246,6 +6234,7 @@ mod tests {
             None,
         );
         let mut state = LlamaState::new();
+        state.set_reg(RegName::S, 0x0200);
         // Enable master + ONK mask.
         bus.memory
             .write_internal_byte(super::IMEM_IMR_OFFSET, super::IMR_MASTER | super::IMR_ONK);
@@ -7426,5 +7415,48 @@ mod tests {
         );
         let snap = bus.keyboard.snapshot_state();
         assert_eq!(snap.press_threshold, 1);
+    }
+
+    #[test]
+    fn keyboard_trace_resolves_relocatable_iocs_fifo() {
+        let mut bus = StandaloneBus::new(
+            MemoryImage::new(),
+            create_lcd(sc62015_core::LcdKind::Hd61202),
+            TimerContext::new(true, 1, 1),
+            false,
+            0,
+            false,
+            None,
+            None,
+            None,
+        );
+        assert_eq!(bus.keyboard_fifo_addresses(), None);
+        bus.memory
+            .store(PCE500_IOCS_WS_PTR_ADDR, 24, 0x00BF9B4)
+            .expect("store IOCS workspace pointer");
+        bus.memory
+            .store(0x00BF9B6, 16, 0x0050)
+            .expect("store FIFO offset");
+
+        assert_eq!(
+            bus.keyboard_fifo_addresses(),
+            Some((0x00BFA04, 0x00BF9B8, 0x00BF9B9))
+        );
+        assert!(bus.is_keyboard_fifo_address(0x00BF9B8));
+        assert!(bus.is_keyboard_fifo_address(0x00BF9B9));
+        assert!(bus.is_keyboard_fifo_address(0x00BFA04));
+        assert!(bus.is_keyboard_fifo_address(0x00BFA13));
+        assert!(!bus.is_keyboard_fifo_address(0x00BFC96));
+
+        bus.memory
+            .store(PCE500_IOCS_WS_PTR_ADDR, 24, 0x00BFA00)
+            .expect("relocate IOCS workspace pointer");
+        bus.memory
+            .store(0x00BFA02, 16, 0x0170)
+            .expect("store relocated FIFO offset");
+        assert_eq!(
+            bus.keyboard_fifo_addresses(),
+            Some((0x00BFB70, 0x00BFA04, 0x00BFA05))
+        );
     }
 }

--- a/sc62015/core/src/bin/sc62015_lcd.rs
+++ b/sc62015/core/src/bin/sc62015_lcd.rs
@@ -113,7 +113,7 @@ struct Args {
     #[arg(long, value_name = "host|off|YYYYMMDDHHMM", default_value = "host")]
     iq7000_rtc: String,
 
-    /// Force-enable KEY IRQ delivery when injecting keys (debug helper).
+    /// Synthetically assert KEYI when injecting keys (debug-only override).
     #[arg(long, default_value_t = false)]
     force_key_irq: bool,
 
@@ -1150,9 +1150,8 @@ fn inject_key(
         runtime.timer.kb_irq_enabled = true;
     }
     if let Some(kb) = runtime.keyboard.as_mut() {
-        let kb_irq_enabled = runtime.timer.kb_irq_enabled || force_key_irq;
         kb.press_matrix_code(code, &mut runtime.memory);
-        if kb_irq_enabled {
+        if force_key_irq {
             runtime.timer.key_irq_latched = true;
             if let Some(cur) = runtime.memory.read_internal_byte(IMEM_ISR_OFFSET) {
                 runtime
@@ -1199,7 +1198,7 @@ fn inject_input_event(runtime: &mut CoreRuntime, code: u8, force_key_irq: bool) 
     if events == 0 {
         return false;
     }
-    if kb_irq_enabled {
+    if force_key_irq {
         runtime.timer.key_irq_latched = true;
         runtime.timer.irq_pending = true;
         if runtime.timer.irq_source.is_none() && !runtime.timer.in_interrupt {

--- a/sc62015/core/src/iq7000.rs
+++ b/sc62015/core/src/iq7000.rs
@@ -28,15 +28,70 @@ pub enum Iq7000ContractStatus {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Iq7000IocsDeviceRecord {
+    pub address: u32,
+    pub next: u32,
     pub device: u8,
     pub attr: u8,
     pub handler: u32,
+    /// The NUL-terminated name stored in the ROM record, without the NUL.
     pub name: &'static str,
     pub status: Iq7000ContractStatus,
 }
 
-pub const IQ7000_IOCS_DEVICE_RECORDS: &[Iq7000IocsDeviceRecord] = &[
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Iq7000CardLocalIocsContract {
+    pub owner: &'static str,
+    pub list_start: u32,
+    pub list_mirror: u32,
+    pub runtime_head_pointer: u32,
+    pub activation_load: u32,
+    pub activation_store: u32,
+    pub public_entry: u32,
+    pub resolver: u32,
+    pub list_lookup: u32,
+    pub broadcast: u32,
+    pub indirect_dispatch: u32,
+    pub handler_pointer_width: usize,
+    pub system_fallback: u32,
+    pub header_probe_alias: u32,
+    pub runtime_backed_by_default_loader: bool,
+    pub required_overlay: &'static str,
+}
+
+pub const IQ7000_IOCS_LIST_END: u32 = 0x0FFFFF;
+pub const IQ7000_ACTIVE_IOCS_LIST_POINTER: u32 = 0x01FDA8;
+pub const IQ7000_ACTIVE_IOCS_LIST_START: u32 = 0x0F03F5;
+pub const IQ7000_SC12_IOCS_LIST_START: u32 = 0x051729;
+pub const IQ7000_SC12_IOCS_LIST_MIRROR: u32 = 0x071729;
+
+/// S-C12 cartridge-local IOCS path. Successful normal/clear activation loads
+/// the ROM list at 0x51729 and stores it in the card workspace at 0x3FD4A.
+/// This head is resolved by the card's 0x40100 entry and never replaces the
+/// built-in system IOCS head at [`IQ7000_ACTIVE_IOCS_LIST_POINTER`].
+pub const IQ7000_SC12_IOCS_CONTRACT: Iq7000CardLocalIocsContract = Iq7000CardLocalIocsContract {
+    owner: "S-C12 cartridge runtime",
+    list_start: IQ7000_SC12_IOCS_LIST_START,
+    list_mirror: IQ7000_SC12_IOCS_LIST_MIRROR,
+    runtime_head_pointer: 0x03FD4A,
+    activation_load: 0x05C38B,
+    activation_store: 0x05C38F,
+    public_entry: 0x05FFF4,
+    resolver: 0x040100,
+    list_lookup: 0x040225,
+    broadcast: 0x04026A,
+    indirect_dispatch: 0x040268,
+    handler_pointer_width: 3,
+    system_fallback: 0x0FFFE8,
+    header_probe_alias: 0x060000,
+    runtime_backed_by_default_loader: false,
+    required_overlay: "explicit S-C12 ROM + SRAM cartridge overlay",
+};
+
+/// IOCS list installed at [`IQ7000_ACTIVE_IOCS_LIST_POINTER`] during ROM boot.
+pub const IQ7000_ACTIVE_IOCS_DEVICE_RECORDS: &[Iq7000IocsDeviceRecord] = &[
     Iq7000IocsDeviceRecord {
+        address: 0x00F03F5,
+        next: 0x00F0408,
         device: 0x00,
         attr: 0xA2,
         handler: 0x00F04A5,
@@ -44,6 +99,8 @@ pub const IQ7000_IOCS_DEVICE_RECORDS: &[Iq7000IocsDeviceRecord] = &[
         status: Iq7000ContractStatus::RuntimeCovered,
     },
     Iq7000IocsDeviceRecord {
+        address: 0x00F0408,
+        next: 0x00F041B,
         device: 0x01,
         attr: 0xA1,
         handler: 0x00F360A,
@@ -51,6 +108,8 @@ pub const IQ7000_IOCS_DEVICE_RECORDS: &[Iq7000IocsDeviceRecord] = &[
         status: Iq7000ContractStatus::RuntimeCovered,
     },
     Iq7000IocsDeviceRecord {
+        address: 0x00F041B,
+        next: 0x00F0428,
         device: 0x02,
         attr: 0xD3,
         handler: 0x00FA5FE,
@@ -58,6 +117,8 @@ pub const IQ7000_IOCS_DEVICE_RECORDS: &[Iq7000IocsDeviceRecord] = &[
         status: Iq7000ContractStatus::StructurallyMapped,
     },
     Iq7000IocsDeviceRecord {
+        address: 0x00F0428,
+        next: 0x00F043A,
         device: 0x03,
         attr: 0xA2,
         handler: 0x00FB439,
@@ -65,6 +126,8 @@ pub const IQ7000_IOCS_DEVICE_RECORDS: &[Iq7000IocsDeviceRecord] = &[
         status: Iq7000ContractStatus::StructurallyMapped,
     },
     Iq7000IocsDeviceRecord {
+        address: 0x00F043A,
+        next: 0x00F0447,
         device: 0x04,
         attr: 0xD7,
         handler: 0x00FAEC0,
@@ -72,6 +135,8 @@ pub const IQ7000_IOCS_DEVICE_RECORDS: &[Iq7000IocsDeviceRecord] = &[
         status: Iq7000ContractStatus::StructurallyMapped,
     },
     Iq7000IocsDeviceRecord {
+        address: 0x00F0447,
+        next: 0x00F0459,
         device: 0x06,
         attr: 0xC3,
         handler: 0x00F7C83,
@@ -79,6 +144,8 @@ pub const IQ7000_IOCS_DEVICE_RECORDS: &[Iq7000IocsDeviceRecord] = &[
         status: Iq7000ContractStatus::StructurallyMapped,
     },
     Iq7000IocsDeviceRecord {
+        address: 0x00F0459,
+        next: 0x00F0468,
         device: 0x08,
         attr: 0x00,
         handler: 0x00F5702,
@@ -86,6 +153,8 @@ pub const IQ7000_IOCS_DEVICE_RECORDS: &[Iq7000IocsDeviceRecord] = &[
         status: Iq7000ContractStatus::StructurallyMapped,
     },
     Iq7000IocsDeviceRecord {
+        address: 0x00F0468,
+        next: 0x00F0475,
         device: 0x0A,
         attr: 0x00,
         handler: 0x00F31EF,
@@ -93,6 +162,8 @@ pub const IQ7000_IOCS_DEVICE_RECORDS: &[Iq7000IocsDeviceRecord] = &[
         status: Iq7000ContractStatus::RuntimeCovered,
     },
     Iq7000IocsDeviceRecord {
+        address: 0x00F0475,
+        next: 0x00F0484,
         device: 0x0B,
         attr: 0xC0,
         handler: 0x00FBC3D,
@@ -100,6 +171,8 @@ pub const IQ7000_IOCS_DEVICE_RECORDS: &[Iq7000IocsDeviceRecord] = &[
         status: Iq7000ContractStatus::StructurallyMapped,
     },
     Iq7000IocsDeviceRecord {
+        address: 0x00F0484,
+        next: 0x00F0493,
         device: 0x0C,
         attr: 0x53,
         handler: 0x00FBC00,
@@ -107,270 +180,118 @@ pub const IQ7000_IOCS_DEVICE_RECORDS: &[Iq7000IocsDeviceRecord] = &[
         status: Iq7000ContractStatus::StructurallyMapped,
     },
     Iq7000IocsDeviceRecord {
+        address: 0x00F0493,
+        next: 0x00F049C,
         device: 0x0D,
         attr: 0x00,
         handler: 0x00F6777,
-        name: "dev0D:System/UserDic/Alarm",
+        name: "",
         status: Iq7000ContractStatus::StructurallyMapped,
     },
     Iq7000IocsDeviceRecord {
+        address: 0x00F049C,
+        next: IQ7000_IOCS_LIST_END,
         device: 0x0E,
         attr: 0x00,
         handler: 0x00F5C88,
-        name: "dev0E:SCR handshake",
+        name: "",
         status: Iq7000ContractStatus::StructurallyMapped,
     },
 ];
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct Iq7000HeaderRecord {
-    pub address: u32,
-    pub name: &'static str,
-    pub attr: Option<u8>,
-    pub entry_or_walker: Option<u32>,
-    pub trailer_ptr: Option<u32>,
-    pub trailer_index: Option<u8>,
-    pub status: Iq7000ContractStatus,
-}
-
-pub const IQ7000_HEADER_RECORDS: &[Iq7000HeaderRecord] = &[
-    Iq7000HeaderRecord {
-        address: 0x051720,
+/// Byte-accurate IOCS list owned by the S-C12 cartridge runtime. It is rooted
+/// at the card-local workspace pointer 0x3FD4A and must not be substituted for
+/// the built-in list rooted at 0x1FDA8.
+pub const IQ7000_SC12_IOCS_DEVICE_RECORDS: &[Iq7000IocsDeviceRecord] = &[
+    Iq7000IocsDeviceRecord {
+        address: 0x0051729,
+        next: 0x005173C,
+        device: 0x00,
+        attr: 0xA2,
+        handler: 0x0050DDF,
         name: "STDO:SCRN:",
-        attr: Some(0xA2),
-        entry_or_walker: Some(0x0602EC),
-        trailer_ptr: Some(0x05174F),
-        trailer_index: Some(0x01),
-        status: Iq7000ContractStatus::StructurallyMapped,
+        status: Iq7000ContractStatus::RomAuthoritative,
     },
-    Iq7000HeaderRecord {
-        address: 0x051740,
+    Iq7000IocsDeviceRecord {
+        address: 0x005173C,
+        next: 0x005174F,
+        device: 0x01,
+        attr: 0xA1,
+        handler: 0x0050AE2,
         name: "STDI:KYBD:",
-        attr: Some(0xA1),
-        entry_or_walker: None,
-        trailer_ptr: Some(0x05175C),
-        trailer_index: Some(0x02),
-        status: Iq7000ContractStatus::StructurallyMapped,
+        status: Iq7000ContractStatus::RomAuthoritative,
     },
-    Iq7000HeaderRecord {
-        address: 0x051750,
+    Iq7000IocsDeviceRecord {
+        address: 0x005174F,
+        next: 0x005175C,
+        device: 0x02,
+        attr: 0xD3,
+        handler: 0x00458CB,
         name: "COM:",
-        attr: Some(0xD3),
-        entry_or_walker: None,
-        trailer_ptr: Some(0x05176E),
-        trailer_index: Some(0x03),
-        status: Iq7000ContractStatus::StructurallyMapped,
+        status: Iq7000ContractStatus::RomAuthoritative,
     },
-    Iq7000HeaderRecord {
-        address: 0x051760,
+    Iq7000IocsDeviceRecord {
+        address: 0x005175C,
+        next: 0x005176E,
+        device: 0x03,
+        attr: 0xA2,
+        handler: 0x004574A,
         name: "STDL:PRN:",
-        attr: Some(0xA2),
-        entry_or_walker: None,
-        trailer_ptr: Some(0x05177B),
-        trailer_index: Some(0x04),
-        status: Iq7000ContractStatus::StructurallyMapped,
+        status: Iq7000ContractStatus::RomAuthoritative,
     },
-    Iq7000HeaderRecord {
-        address: 0x051770,
+    Iq7000IocsDeviceRecord {
+        address: 0x005176E,
+        next: 0x005177B,
+        device: 0x04,
+        attr: 0xD7,
+        handler: 0x0045235,
         name: "CAS:",
-        attr: Some(0xD7),
-        entry_or_walker: None,
-        trailer_ptr: Some(0x051790),
-        trailer_index: Some(0x06),
-        status: Iq7000ContractStatus::StructurallyMapped,
+        status: Iq7000ContractStatus::RomAuthoritative,
     },
-    Iq7000HeaderRecord {
-        address: 0x051780,
+    Iq7000IocsDeviceRecord {
+        address: 0x005177B,
+        next: 0x0051790,
+        device: 0x06,
+        attr: 0xC3,
+        handler: 0x0050000,
         name: "S1:S2:S3:S4:",
-        attr: Some(0xC3),
-        entry_or_walker: None,
-        trailer_ptr: Some(0x05179F),
-        trailer_index: Some(0x05),
-        status: Iq7000ContractStatus::StructurallyMapped,
+        status: Iq7000ContractStatus::RomAuthoritative,
     },
-    Iq7000HeaderRecord {
-        address: 0x051790,
+    Iq7000IocsDeviceRecord {
+        address: 0x0051790,
+        next: 0x005179F,
+        device: 0x05,
+        attr: 0x83,
+        handler: 0x004345E,
         name: "E:F:G:",
-        attr: Some(0x83),
-        entry_or_walker: None,
-        trailer_ptr: Some(0x0517AE),
-        trailer_index: Some(0x0C),
-        status: Iq7000ContractStatus::StructurallyMapped,
+        status: Iq7000ContractStatus::RomAuthoritative,
     },
-    Iq7000HeaderRecord {
-        address: 0x0517A0,
+    Iq7000IocsDeviceRecord {
+        address: 0x005179F,
+        next: 0x00517AE,
+        device: 0x0C,
+        attr: 0xD7,
+        handler: 0x005F868,
         name: "PACOM:",
-        attr: Some(0xD7),
-        entry_or_walker: None,
-        trailer_ptr: Some(0x0517B7),
-        trailer_index: Some(0x09),
-        status: Iq7000ContractStatus::StructurallyMapped,
+        status: Iq7000ContractStatus::RomAuthoritative,
     },
-    Iq7000HeaderRecord {
-        address: 0x0517B0,
-        name: "SYSTEM block",
-        attr: None,
-        entry_or_walker: Some(0x048C31),
-        trailer_ptr: None,
-        trailer_index: None,
-        status: Iq7000ContractStatus::StructurallyMapped,
+    Iq7000IocsDeviceRecord {
+        address: 0x00517AE,
+        next: 0x00517B7,
+        device: 0x09,
+        attr: 0x00,
+        handler: 0x0048C31,
+        name: "",
+        status: Iq7000ContractStatus::RomAuthoritative,
     },
-];
-
-pub const IQ7000_STDO_WALKER_BLOB_START: u32 = 0x060200;
-pub const IQ7000_STDO_WALKER_ENTRY: u32 = 0x0602EC;
-pub const IQ7000_STDO_WALKER_DEVICE_STRING_ADDR: u32 = 0x060980;
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct Iq7000RomField {
-    pub address: u32,
-    pub width: u8,
-    pub value: u64,
-    pub name: &'static str,
-    pub role: &'static str,
-    pub status: Iq7000ContractStatus,
-}
-
-pub const IQ7000_STDO_HEADER_FIELDS: &[Iq7000RomField] = &[
-    Iq7000RomField {
-        address: 0x051720,
-        width: 6,
-        value: 0x47303A3B3D42,
-        name: "stdo_header_preamble_tag_seed",
-        role: "raw STDO preamble bytes consumed by the colocated bootstrap/walker path",
-        status: Iq7000ContractStatus::StructurallyMapped,
-    },
-    Iq7000RomField {
-        address: 0x051726,
-        width: 3,
-        value: IQ7000_STDO_WALKER_ENTRY as u64,
-        name: "stdo_header_walker_entry",
-        role: "24-bit pointer into the 0x060200 walker blob",
-        status: Iq7000ContractStatus::Confirmed,
-    },
-    Iq7000RomField {
-        address: 0x051729,
-        width: 3,
-        value: 0x05173C,
-        name: "stdo_header_next_record_ptr",
-        role: "24-bit pointer to the next header record boundary",
-        status: Iq7000ContractStatus::Confirmed,
-    },
-    Iq7000RomField {
-        address: 0x05172C,
-        width: 1,
-        value: 0x00,
-        name: "stdo_header_zero_flag",
-        role: "flag byte; no nonzero use identified in decoded walker paths",
-        status: Iq7000ContractStatus::StructurallyMapped,
-    },
-    Iq7000RomField {
-        address: 0x05172D,
-        width: 1,
-        value: 0xA2,
-        name: "stdo_header_iocs_attr",
-        role: "matches the STDO IOCS blob attribute",
-        status: Iq7000ContractStatus::Confirmed,
-    },
-    Iq7000RomField {
-        address: 0x05172E,
-        width: 1,
-        value: 0xDF,
-        name: "stdo_header_mode_mask",
-        role: "mode/mask byte adjacent to attr; exact bit semantics pending",
-        status: Iq7000ContractStatus::StructurallyMapped,
-    },
-    Iq7000RomField {
-        address: 0x05172F,
-        width: 1,
-        value: 0x0D,
-        name: "stdo_header_terminator_or_selector",
-        role: "trailing selector/terminator byte in long STDO preamble",
-        status: Iq7000ContractStatus::StructurallyMapped,
-    },
-    Iq7000RomField {
-        address: 0x051730,
-        width: 12,
-        value: 0,
-        name: "stdo_header_name_chunk",
-        role: "length/name bytes for STDO:SCRN: ending at the NUL before trailer",
-        status: Iq7000ContractStatus::Confirmed,
-    },
-    Iq7000RomField {
-        address: 0x05173C,
-        width: 4,
-        value: 0x0105174F,
-        name: "stdo_header_trailer",
-        role: "24-bit intra-header pointer 0x05174F plus trailer index 0x01",
-        status: Iq7000ContractStatus::Confirmed,
-    },
-];
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct Iq7000WalkerStep {
-    pub address: u32,
-    pub role: &'static str,
-    pub consumed_state: &'static str,
-    pub produced_state: &'static str,
-    pub status: Iq7000ContractStatus,
-}
-
-pub const IQ7000_STDO_WALKER_STEPS: &[Iq7000WalkerStep] = &[
-    Iq7000WalkerStep {
-        address: 0x060204,
-        role: "copy up to six bytes from a device tag, stopping at ':' and padding with space",
-        consumed_state: "Y source tag, X destination tag buffer",
-        produced_state: "six-byte display/device tag field",
-        status: Iq7000ContractStatus::Confirmed,
-    },
-    Iq7000WalkerStep {
-        address: 0x060225,
-        role: "walk linked records through [X] until [X+3] matches D6",
-        consumed_state: "record list pointer in X, selector in D6",
-        produced_state: "carry-coded match result",
-        status: Iq7000ContractStatus::Confirmed,
-    },
-    Iq7000WalkerStep {
-        address: 0x06026A,
-        role: "walk records rooted at 0x3FD4A and emit IL=0x40 through the walker callback",
-        consumed_state: "3FD4A linked-list root, record tag at X+5",
-        produced_state: "callback-visible copied tag and advanced X=[X]",
-        status: Iq7000ContractStatus::StructurallyMapped,
-    },
-    Iq7000WalkerStep {
-        address: 0x0602B1,
-        role: "scan 0x1F-byte records behind (PX+0A) until an 0xFF marker",
-        consumed_state: "(PX+0A) base and +0x0C length",
-        produced_state: "D8 record index/count",
-        status: Iq7000ContractStatus::Confirmed,
-    },
-    Iq7000WalkerStep {
-        address: 0x0604DA,
-        role: "store a record index into the 0x3FD2F table",
-        consumed_state: "A table index, D8 record index",
-        produced_state: "3FD2F[A]=D8",
-        status: Iq7000ContractStatus::Confirmed,
-    },
-    Iq7000WalkerStep {
-        address: 0x060892,
-        role: "initialize walker header tables and emit stdo:stdi:stdl: tags",
-        consumed_state: "walker scratch at 0x3FD2F..0x3FD45 and string at 0x06098D",
-        produced_state: "cleared table, FFFF terminator, initialized tag set",
-        status: Iq7000ContractStatus::Confirmed,
-    },
-    Iq7000WalkerStep {
-        address: 0x0609A5,
-        role: "compare 8.3-style names with ? wildcard and dot separator handling",
-        consumed_state: "X/Y name buffers",
-        produced_state: "carry-coded compare result",
-        status: Iq7000ContractStatus::Confirmed,
-    },
-    Iq7000WalkerStep {
-        address: 0x060A2B,
-        role: "format a four-byte name, '.', then two-byte suffix",
-        consumed_state: "source bytes and output pointer",
-        produced_state: "formatted dotted label",
-        status: Iq7000ContractStatus::Confirmed,
+    Iq7000IocsDeviceRecord {
+        address: 0x00517B7,
+        next: IQ7000_IOCS_LIST_END,
+        device: 0x08,
+        attr: 0x00,
+        handler: 0x0049C5B,
+        name: "SYSTM:",
+        status: Iq7000ContractStatus::RomAuthoritative,
     },
 ];
 
@@ -430,6 +351,70 @@ pub struct Iq7000KeyboardActionTarget {
     pub role: &'static str,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Iq7000InterruptVectorContract {
+    pub dispatch_selector: u8,
+    pub ram_entry: u32,
+    pub default_target: u32,
+    pub source: &'static str,
+}
+
+/// Default IQ-7000 interrupt vectors in the ROM dispatcher's priority order.
+///
+/// The final `0x80` selector is internal to the ROM's `IR`-opcode fallback. It
+/// is not an ISR source bit; `IMR.IRM` uses the same numeric bit as the master
+/// interrupt enable.
+pub const IQ7000_INTERRUPT_VECTOR_CONTRACTS: &[Iq7000InterruptVectorContract] = &[
+    Iq7000InterruptVectorContract {
+        dispatch_selector: 0x20,
+        ram_entry: 0x001FDE2,
+        default_target: 0x00F563C,
+        source: "ISR.RXRI / IMR.RXRM serial receive",
+    },
+    Iq7000InterruptVectorContract {
+        dispatch_selector: 0x40,
+        ram_entry: 0x001FDE5,
+        default_target: 0x00F527F,
+        source: "ISR.EXI / IMR.EXM external level; physical source unresolved",
+    },
+    Iq7000InterruptVectorContract {
+        dispatch_selector: 0x10,
+        ram_entry: 0x001FDDF,
+        default_target: 0x00F525D,
+        source: "ISR.TXRI / IMR.TXRM serial transmit; default RETF",
+    },
+    Iq7000InterruptVectorContract {
+        dispatch_selector: 0x08,
+        ram_entry: 0x001FDDC,
+        default_target: 0x00F5247,
+        source: "ISR.ONKI / IMR.ONKM ON-key level; guarded 0xF70FD callback",
+    },
+    Iq7000InterruptVectorContract {
+        dispatch_selector: 0x04,
+        ram_entry: 0x001FDD9,
+        default_target: 0x00F523E,
+        source: "ISR.KEYI / IMR.KEYM keyboard; disable-on-return stub",
+    },
+    Iq7000InterruptVectorContract {
+        dispatch_selector: 0x02,
+        ram_entry: 0x001FDD6,
+        default_target: 0x00F52FF,
+        source: "ISR.STI / IMR.STM display refresh tick",
+    },
+    Iq7000InterruptVectorContract {
+        dispatch_selector: 0x01,
+        ram_entry: 0x001FDD3,
+        default_target: 0x00F525E,
+        source: "ISR.MTI / IMR.MTM keyboard scan tick",
+    },
+    Iq7000InterruptVectorContract {
+        dispatch_selector: 0x80,
+        ram_entry: 0x001FDE8,
+        default_target: 0x00F525D,
+        source: "software IR opcode fallback selector; not an ISR bit",
+    },
+];
+
 pub const IQ7000_KEYBOARD_ACTION_TARGETS: &[Iq7000KeyboardActionTarget] = &[
     Iq7000KeyboardActionTarget {
         address: 0x00F523E,
@@ -437,7 +422,7 @@ pub const IQ7000_KEYBOARD_ACTION_TARGETS: &[Iq7000KeyboardActionTarget] = &[
     },
     Iq7000KeyboardActionTarget {
         address: 0x00F5247,
-        role: "ack alarm IRQ then run RTC alarm worker when pending",
+        role: "ISR.ONKI / IMR.ONKM level handler with guarded 0xF70FD callback",
     },
     Iq7000KeyboardActionTarget {
         address: 0x00F525D,
@@ -457,7 +442,7 @@ pub const IQ7000_KEYBOARD_ACTION_TARGETS: &[Iq7000KeyboardActionTarget] = &[
     },
     Iq7000KeyboardActionTarget {
         address: 0x00F527F,
-        role: "serial TX interrupt action: services COM IL=0x46 or defers with 1FDC5 bit 0x40",
+        role: "ISR.EXI / IMR.EXM external-level action: STDO IL=0x46 sets raw annunciator bit 0x80 or defers with 1FDC5 bit 0x40",
     },
     Iq7000KeyboardActionTarget {
         address: 0x00F55CF,
@@ -532,7 +517,7 @@ pub const IQ7000_KEYBOARD_MATRIX_CONTRACTS: &[Iq7000KeyboardMatrixContract] = &[
     Iq7000KeyboardMatrixContract {
         address: 0x00F55AE,
         name: "row_column_translate",
-        role: "computes idx=col*8+row and translates via 1FDC5/1FDCD tables",
+        role: "computes idx=col*8+row and translates via pointers at 1FDC7/1FDCD",
         f0_effect: "not modified",
         f1_effect: "not modified",
         status: Iq7000ContractStatus::Confirmed,
@@ -549,22 +534,37 @@ pub struct Iq7000TranslationTableAnchor {
 pub const IQ7000_KEYBOARD_TRANSLATION_TABLES: &[Iq7000TranslationTableAnchor] = &[
     Iq7000TranslationTableAnchor {
         address: 0x00F4019,
-        role: "8x8 unshifted/runtime keycode grid used through 1FDC5",
-        status: Iq7000ContractStatus::StructurallyMapped,
+        role: "13x8 primary keycode byte map used through the pointer at 1FDC7",
+        status: Iq7000ContractStatus::Confirmed,
+    },
+    Iq7000TranslationTableAnchor {
+        address: 0x00F4081,
+        role: "20-byte reset/default secondary identity map for primary values 0x60..0x73",
+        status: Iq7000ContractStatus::Confirmed,
     },
     Iq7000TranslationTableAnchor {
         address: 0x0050DB7,
-        role: "8x8 shifted/ASCII-like keycode grid used through 1FDCD",
-        status: Iq7000ContractStatus::StructurallyMapped,
+        role: "20-byte alternate secondary map selected by 0x50DA0 for A=1; value 0x64 maps to 0x01",
+        status: Iq7000ContractStatus::Confirmed,
+    },
+    Iq7000TranslationTableAnchor {
+        address: 0x0050DCB,
+        role: "20-byte secondary identity map selected by 0x50DA0 for A=0",
+        status: Iq7000ContractStatus::Confirmed,
     },
     Iq7000TranslationTableAnchor {
         address: 0x001FDAB,
-        role: "row mask table consumed by the physical KIL sampler",
+        role: "17-byte RAM row-mask table filled with 0xFF by reset; consumed by the physical KIL sampler",
         status: Iq7000ContractStatus::Confirmed,
     },
     Iq7000TranslationTableAnchor {
         address: 0x001FDC5,
-        role: "primary translation-table pointer/flag byte; bit 0x40 gates scan dequeue",
+        role: "keyboard flag byte; not a translation-table pointer; bit 0x40 gates scan dequeue",
+        status: Iq7000ContractStatus::Confirmed,
+    },
+    Iq7000TranslationTableAnchor {
+        address: 0x001FDC7,
+        role: "24-bit primary keycode-map pointer; reset value 0xF4019",
         status: Iq7000ContractStatus::Confirmed,
     },
     Iq7000TranslationTableAnchor {
@@ -927,7 +927,7 @@ pub const IQ7000_PRN_COMMAND_TABLE: &[Iq7000CommandTarget] = &[
     },
 ];
 
-pub const IQ7000_PACOM_PANET_COMMAND_TABLE: &[Iq7000CommandTarget] = &[
+pub const IQ7000_PACOM_COMMAND_TABLE: &[Iq7000CommandTarget] = &[
     Iq7000CommandTarget {
         index_or_command: 0x00,
         target: 0x00FBC3B,
@@ -976,9 +976,15 @@ pub const IQ7000_PACOM_PANET_COMMAND_TABLE: &[Iq7000CommandTarget] = &[
     Iq7000CommandTarget {
         index_or_command: 0x09,
         target: 0x00F069F,
-        role: "stub return",
+        role: "instruction-interior near RET back to PACOM wrapper; carry is inherited",
     },
 ];
+
+/// Compatibility alias for older callers.  The active PANET record points at
+/// `FBC3D` (`RC; RETF`) and never dispatches through this table; `FBC29` is the
+/// PACOM table owned by handler `FBC00`.
+#[deprecated(note = "FBC29 is PACOM-only; use IQ7000_PACOM_COMMAND_TABLE")]
+pub const IQ7000_PACOM_PANET_COMMAND_TABLE: &[Iq7000CommandTarget] = IQ7000_PACOM_COMMAND_TABLE;
 
 pub const IQ7000_RAM_DISK_COMMAND_TABLE: &[Iq7000CommandTarget] = &[
     Iq7000CommandTarget {
@@ -1019,17 +1025,17 @@ pub const IQ7000_RAM_DISK_COMMAND_TABLE: &[Iq7000CommandTarget] = &[
     Iq7000CommandTarget {
         index_or_command: 0x46,
         target: 0x00F823F,
-        role: "record helper, pending full semantics",
+        role: "preflight record pointers and parse name; A=0x09 on parse failure",
     },
     Iq7000CommandTarget {
         index_or_command: 0x47,
         target: 0x00F8269,
-        role: "record helper, pending full semantics",
+        role: "copy 0x2E status template, parse 8.3 name, append 0xFF",
     },
     Iq7000CommandTarget {
         index_or_command: 0x48,
         target: 0x00F8308,
-        role: "record helper, pending full semantics",
+        role: "copy selected record-list span to caller",
     },
     Iq7000CommandTarget {
         index_or_command: 0x49,
@@ -1059,17 +1065,17 @@ pub const IQ7000_RAM_DISK_COMMAND_TABLE: &[Iq7000CommandTarget] = &[
     Iq7000CommandTarget {
         index_or_command: 0x4E,
         target: 0x00F89BF,
-        role: "pending classification",
+        role: "insert/shift record region and update header offsets",
     },
     Iq7000CommandTarget {
         index_or_command: 0x4F,
         target: 0x00F8A65,
-        role: "pending classification",
+        role: "copy record body after 0x29-byte header to caller",
     },
     Iq7000CommandTarget {
         index_or_command: 0x50,
         target: 0x00F8AA2,
-        role: "pending classification",
+        role: "copy caller bytes into record body; zero length returns offset",
     },
     Iq7000CommandTarget {
         index_or_command: 0x51,
@@ -1084,7 +1090,7 @@ pub const IQ7000_RAM_DISK_COMMAND_TABLE: &[Iq7000CommandTarget] = &[
     Iq7000CommandTarget {
         index_or_command: 0x53,
         target: 0x00F8412,
-        role: "pending classification",
+        role: "workspace readiness, busy-bit, and caller-range validator",
     },
 ];
 
@@ -1353,10 +1359,40 @@ pub const IQ7000_RTC_COMMAND_SPECS: &[Iq7000RtcCommandSpec] = &[
         role: "read status",
     },
     Iq7000RtcCommandSpec {
+        command: 0xF9,
+        payload_len: 0,
+        response_len: 0,
+        role: "command-only control",
+    },
+    Iq7000RtcCommandSpec {
+        command: 0xFA,
+        payload_len: 0,
+        response_len: 0,
+        role: "command-only control",
+    },
+    Iq7000RtcCommandSpec {
+        command: 0xFB,
+        payload_len: 0,
+        response_len: 0,
+        role: "command-only control",
+    },
+    Iq7000RtcCommandSpec {
+        command: 0xFC,
+        payload_len: 0,
+        response_len: 2,
+        role: "read two-byte preamble/status",
+    },
+    Iq7000RtcCommandSpec {
         command: 0xFD,
         payload_len: 0,
         response_len: 1,
         role: "read status",
+    },
+    Iq7000RtcCommandSpec {
+        command: 0xFF,
+        payload_len: 0,
+        response_len: 0,
+        role: "command-only reset/control",
     },
 ];
 
@@ -1557,13 +1593,156 @@ pub const IQ7000_DEV0D_COMMAND_TABLE: &[Iq7000CommandTarget] = &[
 pub const IQ7000_DEV0E_COMMAND_TABLE: &[Iq7000CommandTarget] = &[
     Iq7000CommandTarget {
         index_or_command: 0x40,
-        target: 0x00F5CA8,
-        role: "store X to global 0x0CAE5C",
+        target: 0x00F5CAC,
+        role: "successful no-op (RC; RETF)",
     },
     Iq7000CommandTarget {
         index_or_command: 0x41,
         target: 0x00F5CAE,
         role: "timed SCR/SSR wait variant",
+    },
+];
+
+/// S-C12 card-local dev09 `(CH)=0` numeric table at `0x48C80`.
+///
+/// These are page-4 near targets. The meanings follow the function-driver IOCS
+/// contract and are corroborated by relocated instruction-identical numeric
+/// workers. Commands `0x5C..0x6F` are not table entries and return as no-ops.
+pub const IQ7000_SC12_DEV09_NUMERIC_COMMAND_TABLE: &[Iq7000CommandTarget] = &[
+    Iq7000CommandTarget {
+        index_or_command: 0x41,
+        target: 0x00491CD,
+        role: "numeric compare Y != X",
+    },
+    Iq7000CommandTarget {
+        index_or_command: 0x42,
+        target: 0x00491B5,
+        role: "numeric compare Y < X",
+    },
+    Iq7000CommandTarget {
+        index_or_command: 0x43,
+        target: 0x00491A5,
+        role: "numeric compare Y > X",
+    },
+    Iq7000CommandTarget {
+        index_or_command: 0x44,
+        target: 0x00491C5,
+        role: "numeric compare Y = X",
+    },
+    Iq7000CommandTarget {
+        index_or_command: 0x45,
+        target: 0x00491BD,
+        role: "numeric compare Y <= X",
+    },
+    Iq7000CommandTarget {
+        index_or_command: 0x46,
+        target: 0x00491AD,
+        role: "numeric compare Y >= X",
+    },
+    Iq7000CommandTarget {
+        index_or_command: 0x47,
+        target: 0x00467D1,
+        role: "numeric add Y + X",
+    },
+    Iq7000CommandTarget {
+        index_or_command: 0x48,
+        target: 0x00467DC,
+        role: "numeric subtract Y - X",
+    },
+    Iq7000CommandTarget {
+        index_or_command: 0x49,
+        target: 0x00467E7,
+        role: "numeric multiply Y * X",
+    },
+    Iq7000CommandTarget {
+        index_or_command: 0x4A,
+        target: 0x0046800,
+        role: "numeric divide Y / X",
+    },
+    Iq7000CommandTarget {
+        index_or_command: 0x4B,
+        target: 0x004773D,
+        role: "numeric power Y raised to X",
+    },
+    Iq7000CommandTarget {
+        index_or_command: 0x4C,
+        target: 0x00472D8,
+        role: "EXP",
+    },
+    Iq7000CommandTarget {
+        index_or_command: 0x4D,
+        target: 0x0046B9A,
+        role: "SIN",
+    },
+    Iq7000CommandTarget {
+        index_or_command: 0x4E,
+        target: 0x0046BA3,
+        role: "COS",
+    },
+    Iq7000CommandTarget {
+        index_or_command: 0x4F,
+        target: 0x0046BAC,
+        role: "TAN",
+    },
+    Iq7000CommandTarget {
+        index_or_command: 0x50,
+        target: 0x0047025,
+        role: "ASN",
+    },
+    Iq7000CommandTarget {
+        index_or_command: 0x51,
+        target: 0x004702E,
+        role: "ACS",
+    },
+    Iq7000CommandTarget {
+        index_or_command: 0x52,
+        target: 0x0047037,
+        role: "ATN",
+    },
+    Iq7000CommandTarget {
+        index_or_command: 0x53,
+        target: 0x0048483,
+        role: "DEG conversion",
+    },
+    Iq7000CommandTarget {
+        index_or_command: 0x54,
+        target: 0x004848C,
+        role: "DMS conversion",
+    },
+    Iq7000CommandTarget {
+        index_or_command: 0x55,
+        target: 0x00480E6,
+        role: "ABS",
+    },
+    Iq7000CommandTarget {
+        index_or_command: 0x56,
+        target: 0x00480EF,
+        role: "INT",
+    },
+    Iq7000CommandTarget {
+        index_or_command: 0x57,
+        target: 0x0048456,
+        role: "SGN",
+    },
+    Iq7000CommandTarget {
+        index_or_command: 0x58,
+        target: 0x0048600,
+        role: "RND",
+    },
+    Iq7000CommandTarget {
+        index_or_command: 0x59,
+        target: 0x0046A2C,
+        role: "SQR via BP-rooted numeric worker 0x46A30",
+    },
+    Iq7000CommandTarget {
+        index_or_command: 0x5A,
+        target: 0x0047725,
+        role: "LN via log-mode worker 0x47729",
+    },
+    Iq7000CommandTarget {
+        index_or_command: 0x5B,
+        target: 0x004771C,
+        role: "LOG via common-log-mode worker 0x47730",
     },
 ];
 
@@ -1694,14 +1873,14 @@ pub const IQ7000_RTC_SEMANTIC_CONTRACTS: &[Iq7000SemanticContract] = &[
         status: Iq7000ContractStatus::Confirmed,
     },
     Iq7000SemanticContract {
-        area: "RTC alarm IRQ",
+        area: "RTC/alarm worker",
         address: 0x00F70FD,
         name: "rtc_alarm_worker",
         inputs: "BA flags from rtc_alarm_state_query_eca65 and state byte 1FE75",
         outputs:
             "queues the 0x0C-byte alarm payload in 1FE76 and dispatches phase1/phase2 handlers depending on BA&1 / BA&2",
         side_effects:
-            "loads alarm payload via FFFDC BA=0x33, sets 1FE75 bits 0x01/0x02, then phase2 clears ISR bit 0x08",
+            "loads alarm payload via FFFDC BA=0x33, sets 1FE75 bits 0x01/0x02, then phase2 clears ISR.ONKI",
         status: Iq7000ContractStatus::Confirmed,
     },
     Iq7000SemanticContract {
@@ -1895,16 +2074,16 @@ pub const IQ7000_STORAGE_SIDE_EFFECT_CONTRACTS: &[Iq7000SemanticContract] = &[
 
 pub const IQ7000_LINK_ABI_CONTRACTS: &[Iq7000SemanticContract] = &[
     Iq7000SemanticContract {
-        area: "PACOM/PANET dispatch",
+        area: "PACOM dispatch",
         address: 0x00FBC29,
-        name: "pacom_panet_word_table",
+        name: "pacom_word_table",
         inputs: "IL index or IL-0x3F alias",
         outputs: "16-bit in-bank target pushed to S then RET",
         side_effects: "selects handshake/frame/record helper entries",
         status: Iq7000ContractStatus::Confirmed,
     },
     Iq7000SemanticContract {
-        area: "PACOM/PANET handshake",
+        area: "PACOM handshake",
         address: 0x00FBC3F,
         name: "receive_a5_reply_8000",
         inputs: "incoming 0xA5 byte over EIH/EOH bit-banged link",
@@ -1913,7 +2092,7 @@ pub const IQ7000_LINK_ABI_CONTRACTS: &[Iq7000SemanticContract] = &[
         status: Iq7000ContractStatus::Confirmed,
     },
     Iq7000SemanticContract {
-        area: "PACOM/PANET handshake",
+        area: "PACOM handshake",
         address: 0x00FBC7A,
         name: "send_a5_parse_response",
         inputs: "link peer ready on EIH.6",
@@ -1922,7 +2101,7 @@ pub const IQ7000_LINK_ABI_CONTRACTS: &[Iq7000SemanticContract] = &[
         status: Iq7000ContractStatus::Confirmed,
     },
     Iq7000SemanticContract {
-        area: "PACOM/PANET frame send",
+        area: "PACOM frame send",
         address: 0x00FBCF9,
         name: "send_frame_checksum_wait_fa",
         inputs: "payload at X and length in Y",
@@ -1931,7 +2110,7 @@ pub const IQ7000_LINK_ABI_CONTRACTS: &[Iq7000SemanticContract] = &[
         status: Iq7000ContractStatus::Confirmed,
     },
     Iq7000SemanticContract {
-        area: "PACOM/PANET frame receive",
+        area: "PACOM frame receive",
         address: 0x00FBD54,
         name: "receive_frame_checksum_ack",
         inputs: "destination buffer X and length Y",
@@ -1945,7 +2124,7 @@ pub const IQ7000_LINK_ABI_CONTRACTS: &[Iq7000SemanticContract] = &[
         name: "printer_word_table_dispatch",
         inputs: "IL<0x3F maps via IL-8, else IL-0x3F",
         outputs: "16-bit in-bank target pushed to S then RET",
-        side_effects: "shares prologue/epilogue and bit-banged helpers with PACOM/PANET",
+        side_effects: "shares prologue/epilogue and bit-banged helpers with PACOM",
         status: Iq7000ContractStatus::StructurallyMapped,
     },
     Iq7000SemanticContract {
@@ -1962,15 +2141,15 @@ pub const IQ7000_LINK_ABI_CONTRACTS: &[Iq7000SemanticContract] = &[
         area: "PRN output",
         address: 0x00FB6FD,
         name: "printer_printing_ui_send_workflow",
-        inputs: "printer/PANET config and current output buffer",
+        inputs: "printer/link config and current output buffer",
         outputs: "PRINTING status UI and bit-banged payload transfer",
         side_effects: "uses IOCS IL=0x5E/0x42/0x5F around the inline 'PRINTING' label",
         status: Iq7000ContractStatus::Confirmed,
     },
     Iq7000SemanticContract {
-        area: "PANET packet",
+        area: "PRN packet",
         address: 0x00FB8A7,
-        name: "panet_packet_xfer_mode1",
+        name: "printer_packet_xfer_mode1",
         inputs: "packet buffer X, 1FE50 mode flags, 1FE51 zero-pad count",
         outputs: "packet bytes sent with 0x59/0x70 framing and FA ACK",
         side_effects:
@@ -1978,9 +2157,9 @@ pub const IQ7000_LINK_ABI_CONTRACTS: &[Iq7000SemanticContract] = &[
         status: Iq7000ContractStatus::Confirmed,
     },
     Iq7000SemanticContract {
-        area: "PANET packet",
+        area: "PRN packet",
         address: 0x00FB8AF,
-        name: "panet_packet_xfer_mode0",
+        name: "printer_packet_xfer_mode0",
         inputs: "packet buffer X, 1FE50 mode flags, 1FE51 zero-pad count",
         outputs: "packet bytes sent with 0x59/0x70 framing and FA ACK",
         side_effects: "same transport as mode1 but without the leading BP+00 mode bit",
@@ -1994,7 +2173,7 @@ pub const IQ7000_KEY_TRANSLATION_SEMANTICS: &[Iq7000SemanticContract] = &[
         address: 0x00F55AE,
         name: "matrix_to_translation_code",
         inputs: "row, column from sweep loop",
-        outputs: "idx=col*8+row; primary byte from 1FDC5+2+idx; optional secondary byte from 1FDCD",
+        outputs: "idx=col*8+row; primary byte from [1FDC7]+idx; for values >=0x60, secondary byte from [1FDCD]+value-0x60",
         side_effects: "returns keycode/dispatch index to higher-level STDI paths",
         status: Iq7000ContractStatus::Confirmed,
     },
@@ -2080,18 +2259,18 @@ pub const IQ7000_STATUS_CONTRACTS: &[Iq7000StatusContract] = &[
         area: "COM/link",
         code: 0xFE,
         meaning: "deferred/busy/timeout-style failure",
-        producers: "COM gates and PACOM/PANET BBCD when 1FDC5&0x40 is set",
+        producers: "COM gates and PACOM shared-ready gate FBBCD when 1FDC5&0x40 is set",
         status: Iq7000ContractStatus::Confirmed,
     },
     Iq7000StatusContract {
-        area: "PACOM/PANET",
+        area: "PACOM",
         code: 0xFA,
         meaning: "frame checksum accepted ACK",
         producers: "receive frame FBD54/FBD4B",
         status: Iq7000ContractStatus::Confirmed,
     },
     Iq7000StatusContract {
-        area: "PACOM/PANET",
+        area: "PACOM",
         code: 0xF0,
         meaning: "frame checksum mismatch or negative handshake response",
         producers: "receive frame FBD54/FBD4B and A5 response parser",
@@ -2112,7 +2291,7 @@ pub const IQ7000_STATUS_CONTRACTS: &[Iq7000StatusContract] = &[
         status: Iq7000ContractStatus::Confirmed,
     },
     Iq7000StatusContract {
-        area: "PACOM/PANET",
+        area: "PACOM",
         code: 0x0B,
         meaning: "guarded receive-frame first byte did not match caller expectation",
         producers: "FBD4B/FBD54 guarded receive path",
@@ -2130,8 +2309,8 @@ pub struct Iq7000DeviceGap {
 pub const IQ7000_REMAINING_GAPS: &[Iq7000DeviceGap] = &[
     Iq7000DeviceGap {
         area: "STDO:SCRN",
-        rust_contract: "rendering, exact STDO header fields, and decoded walker steps",
-        remaining: "only mirrored-header/hardware-parity caller tracing remains",
+        rust_contract: "rendering plus byte-accurate system and S-C12 cartridge-local linked IOCS records",
+        remaining: "explicit S-C12 ROM+SRAM overlay mode and hardware-parity tracing versus system IOCS fallback",
     },
     Iq7000DeviceGap {
         area: "STDI:KYBD",
@@ -2139,9 +2318,14 @@ pub const IQ7000_REMAINING_GAPS: &[Iq7000DeviceGap] = &[
         remaining: "hardware keycap-to-row/column parity labels",
     },
     Iq7000DeviceGap {
-        area: "COM/PANET/PACOM/PRN",
-        rust_contract: "IOCS records, COM/PRN/PACOM/PANET IL tables, line/status/ring/flow/link helpers",
-        remaining: "cycle-accurate external UART/printer/PANET/PACOM peripherals and user-facing call-site traces",
+        area: "COM/PACOM/PRN",
+        rust_contract: "IOCS records, COM/PRN/PACOM IL tables, line/status/ring/flow/link helpers",
+        remaining: "cycle-accurate external UART/printer/PACOM peripherals and user-facing call-site traces",
+    },
+    Iq7000DeviceGap {
+        area: "PANET",
+        rust_contract: "active handler FBC3D is an unconditional RC/RETF no-op for every command",
+        remaining: "hardware context for why the advertised device is a ROM no-op",
     },
     Iq7000DeviceGap {
         area: "CAS",
@@ -2529,65 +2713,171 @@ mod tests {
         assembled ^ 0xFF
     }
 
-    #[test]
-    fn iocs_device_records_lock_known_handlers() {
-        assert_eq!(IQ7000_IOCS_DEVICE_RECORDS.len(), 12);
+    fn assert_variable_length_iocs_chain(records: &[Iq7000IocsDeviceRecord], expected_start: u32) {
+        assert_eq!(
+            records.first().map(|record| record.address),
+            Some(expected_start)
+        );
+        for pair in records.windows(2) {
+            let record = pair[0];
+            let following = pair[1];
+            assert_eq!(record.next, following.address);
+            assert_eq!(
+                following.address - record.address,
+                8 + record.name.len() as u32 + 1,
+                "record at {:#07x} does not end after its NUL-terminated name",
+                record.address
+            );
+        }
+        assert_eq!(
+            records.last().map(|record| record.next),
+            Some(IQ7000_IOCS_LIST_END)
+        );
+    }
 
-        let stdo = IQ7000_IOCS_DEVICE_RECORDS
+    #[test]
+    fn active_iocs_device_records_lock_boot_list() {
+        assert_eq!(IQ7000_ACTIVE_IOCS_LIST_POINTER, 0x01FDA8);
+        assert_eq!(IQ7000_ACTIVE_IOCS_DEVICE_RECORDS.len(), 12);
+        assert_variable_length_iocs_chain(
+            IQ7000_ACTIVE_IOCS_DEVICE_RECORDS,
+            IQ7000_ACTIVE_IOCS_LIST_START,
+        );
+
+        let stdo = IQ7000_ACTIVE_IOCS_DEVICE_RECORDS
             .iter()
             .find(|record| record.name == "STDO:SCRN:")
             .expect("STDO record");
+        assert_eq!(stdo.address, IQ7000_ACTIVE_IOCS_LIST_START);
+        assert_eq!(stdo.next, 0x00F0408);
         assert_eq!(stdo.device, 0x00);
         assert_eq!(stdo.attr, 0xA2);
         assert_eq!(stdo.handler, 0x00F04A5);
         assert_eq!(stdo.status, Iq7000ContractStatus::RuntimeCovered);
 
-        let rtc = IQ7000_IOCS_DEVICE_RECORDS
+        let rtc = IQ7000_ACTIVE_IOCS_DEVICE_RECORDS
             .iter()
             .find(|record| record.name == "RTC:")
             .expect("RTC record");
         assert_eq!(rtc.device, 0x0A);
         assert_eq!(rtc.handler, 0x00F31EF);
 
-        let dev0d = IQ7000_IOCS_DEVICE_RECORDS
+        let dev0d = IQ7000_ACTIVE_IOCS_DEVICE_RECORDS
             .iter()
             .find(|record| record.device == 0x0D)
             .expect("dev0D record");
         assert_eq!(dev0d.handler, 0x00F6777);
-        assert_eq!(dev0d.name, "dev0D:System/UserDic/Alarm");
+        assert_eq!(dev0d.name, "");
+
+        let dev0e = IQ7000_ACTIVE_IOCS_DEVICE_RECORDS
+            .iter()
+            .find(|record| record.device == 0x0E)
+            .expect("dev0E record");
+        assert_eq!(dev0e.handler, 0x00F5C88);
+        assert_eq!(dev0e.name, "");
     }
 
     #[test]
-    fn header_records_lock_stdo_walker_and_trailers() {
-        let stdo = IQ7000_HEADER_RECORDS
+    fn sc12_iocs_records_are_card_local_rom_authoritative_chain() {
+        assert_eq!(IQ7000_SC12_IOCS_DEVICE_RECORDS.len(), 10);
+        assert_variable_length_iocs_chain(
+            IQ7000_SC12_IOCS_DEVICE_RECORDS,
+            IQ7000_SC12_IOCS_LIST_START,
+        );
+        assert_ne!(IQ7000_SC12_IOCS_LIST_START, IQ7000_ACTIVE_IOCS_LIST_START);
+        assert_eq!(
+            IQ7000_SC12_IOCS_LIST_MIRROR,
+            IQ7000_SC12_IOCS_LIST_START + 0x20000
+        );
+        assert!(IQ7000_SC12_IOCS_DEVICE_RECORDS
             .iter()
-            .find(|record| record.address == 0x051720)
-            .expect("STDO header record");
-        assert_eq!(stdo.name, "STDO:SCRN:");
-        assert_eq!(stdo.attr, Some(0xA2));
-        assert_eq!(stdo.entry_or_walker, Some(IQ7000_STDO_WALKER_ENTRY));
-        assert_eq!(stdo.trailer_ptr, Some(0x05174F));
-        assert_eq!(stdo.trailer_index, Some(0x01));
+            .all(|record| record.status == Iq7000ContractStatus::RomAuthoritative));
 
-        assert_eq!(IQ7000_STDO_WALKER_BLOB_START, 0x060200);
-        assert_eq!(IQ7000_STDO_WALKER_ENTRY, 0x0602EC);
-        assert_eq!(IQ7000_STDO_WALKER_DEVICE_STRING_ADDR, 0x060980);
-
-        let system = IQ7000_HEADER_RECORDS
+        let actual: Vec<(u32, u32, u8, u8, u32, &str)> = IQ7000_SC12_IOCS_DEVICE_RECORDS
             .iter()
-            .find(|record| record.name == "SYSTEM block")
-            .expect("SYSTEM header block");
-        assert_eq!(system.entry_or_walker, Some(0x048C31));
-        assert_eq!(system.trailer_index, None);
+            .map(|record| {
+                (
+                    record.address,
+                    record.next,
+                    record.device,
+                    record.attr,
+                    record.handler,
+                    record.name,
+                )
+            })
+            .collect();
+        assert_eq!(
+            actual,
+            vec![
+                (0x051729, 0x05173C, 0x00, 0xA2, 0x050DDF, "STDO:SCRN:"),
+                (0x05173C, 0x05174F, 0x01, 0xA1, 0x050AE2, "STDI:KYBD:"),
+                (0x05174F, 0x05175C, 0x02, 0xD3, 0x0458CB, "COM:"),
+                (0x05175C, 0x05176E, 0x03, 0xA2, 0x04574A, "STDL:PRN:"),
+                (0x05176E, 0x05177B, 0x04, 0xD7, 0x045235, "CAS:"),
+                (0x05177B, 0x051790, 0x06, 0xC3, 0x050000, "S1:S2:S3:S4:"),
+                (0x051790, 0x05179F, 0x05, 0x83, 0x04345E, "E:F:G:"),
+                (0x05179F, 0x0517AE, 0x0C, 0xD7, 0x05F868, "PACOM:"),
+                (0x0517AE, 0x0517B7, 0x09, 0x00, 0x048C31, ""),
+                (
+                    0x0517B7,
+                    IQ7000_IOCS_LIST_END,
+                    0x08,
+                    0x00,
+                    0x049C5B,
+                    "SYSTM:",
+                ),
+            ]
+        );
 
-        assert!(IQ7000_STDO_HEADER_FIELDS.iter().any(|field| {
-            field.address == 0x051726
-                && field.value == u64::from(IQ7000_STDO_WALKER_ENTRY)
-                && field.name == "stdo_header_walker_entry"
-        }));
-        assert!(IQ7000_STDO_WALKER_STEPS.iter().any(|step| {
-            step.address == 0x060892 && step.role.contains("initialize walker header tables")
-        }));
+        let active_stdo = &IQ7000_ACTIVE_IOCS_DEVICE_RECORDS[0];
+        let sc12_stdo = &IQ7000_SC12_IOCS_DEVICE_RECORDS[0];
+        assert_eq!(active_stdo.device, sc12_stdo.device);
+        assert_ne!(active_stdo.handler, sc12_stdo.handler);
+    }
+
+    #[test]
+    fn sc12_dev09_numeric_table_keeps_page_four_tail_targets() {
+        assert_eq!(IQ7000_SC12_DEV09_NUMERIC_COMMAND_TABLE.len(), 27);
+        assert!(IQ7000_SC12_DEV09_NUMERIC_COMMAND_TABLE
+            .iter()
+            .enumerate()
+            .all(|(index, entry)| entry.index_or_command == 0x41 + index as u8));
+        let tail: Vec<(u8, u32)> = IQ7000_SC12_DEV09_NUMERIC_COMMAND_TABLE[24..]
+            .iter()
+            .map(|entry| (entry.index_or_command, entry.target))
+            .collect();
+        assert_eq!(
+            tail,
+            vec![(0x59, 0x0046A2C), (0x5A, 0x0047725), (0x5B, 0x004771C)]
+        );
+    }
+
+    #[test]
+    fn sc12_iocs_contract_keeps_card_and_system_heads_separate() {
+        let contract = IQ7000_SC12_IOCS_CONTRACT;
+        assert_eq!(contract.owner, "S-C12 cartridge runtime");
+        assert_eq!(contract.list_start, IQ7000_SC12_IOCS_LIST_START);
+        assert_eq!(contract.list_mirror, IQ7000_SC12_IOCS_LIST_MIRROR);
+        assert_eq!(contract.runtime_head_pointer, 0x03FD4A);
+        assert_eq!(contract.activation_load, 0x05C38B);
+        assert_eq!(contract.activation_store, 0x05C38F);
+        assert_eq!(contract.public_entry, 0x05FFF4);
+        assert_eq!(contract.resolver, 0x040100);
+        assert_eq!(contract.list_lookup, 0x040225);
+        assert_eq!(contract.broadcast, 0x04026A);
+        assert_eq!(contract.indirect_dispatch, 0x040268);
+        assert_eq!(contract.handler_pointer_width, 3);
+        assert_eq!(contract.system_fallback, 0x0FFFE8);
+        assert_eq!(contract.header_probe_alias, 0x060000);
+        assert!(!contract.runtime_backed_by_default_loader);
+        assert_eq!(
+            contract.required_overlay,
+            "explicit S-C12 ROM + SRAM cartridge overlay"
+        );
+        assert_ne!(
+            contract.runtime_head_pointer,
+            IQ7000_ACTIVE_IOCS_LIST_POINTER
+        );
     }
 
     #[test]
@@ -2616,13 +2906,61 @@ mod tests {
             .iter()
             .any(|target| target.address == 0x00F563C
                 && target.role == "serial RX interrupt handler"));
+        assert!(IQ7000_KEYBOARD_ACTION_TARGETS.iter().any(|target| {
+            target.address == 0x00F5247
+                && target.role == "ISR.ONKI / IMR.ONKM level handler with guarded 0xF70FD callback"
+        }));
+        assert!(IQ7000_KEYBOARD_ACTION_TARGETS.iter().any(|target| {
+            target.address == 0x00F527F
+                && target.role
+                    == "ISR.EXI / IMR.EXM external-level action: STDO IL=0x46 sets raw annunciator bit 0x80 or defers with 1FDC5 bit 0x40"
+        }));
+        let vectors: Vec<(u8, u32, u32)> = IQ7000_INTERRUPT_VECTOR_CONTRACTS
+            .iter()
+            .map(|entry| {
+                (
+                    entry.dispatch_selector,
+                    entry.ram_entry,
+                    entry.default_target,
+                )
+            })
+            .collect();
+        assert_eq!(
+            vectors,
+            vec![
+                (0x20, 0x001FDE2, 0x00F563C),
+                (0x40, 0x001FDE5, 0x00F527F),
+                (0x10, 0x001FDDF, 0x00F525D),
+                (0x08, 0x001FDDC, 0x00F5247),
+                (0x04, 0x001FDD9, 0x00F523E),
+                (0x02, 0x001FDD6, 0x00F52FF),
+                (0x01, 0x001FDD3, 0x00F525E),
+                (0x80, 0x001FDE8, 0x00F525D),
+            ]
+        );
+        assert!(IQ7000_INTERRUPT_VECTOR_CONTRACTS[1]
+            .source
+            .contains("physical source unresolved"));
+        assert!(IQ7000_INTERRUPT_VECTOR_CONTRACTS[7]
+            .source
+            .contains("not an ISR bit"));
         assert!(IQ7000_KEYBOARD_MATRIX_CONTRACTS.iter().any(|entry| {
             entry.address == 0x00F5548
                 && entry.f0_effect == "F0 receives the active output-line mask"
         }));
-        assert!(IQ7000_KEYBOARD_TRANSLATION_TABLES
-            .iter()
-            .any(|entry| entry.address == 0x00F4019));
+        assert_eq!(
+            IQ7000_KEYBOARD_TRANSLATION_TABLES
+                .iter()
+                .map(|entry| entry.address)
+                .collect::<Vec<_>>(),
+            vec![
+                0x00F4019, 0x00F4081, 0x0050DB7, 0x0050DCB, 0x001FDAB, 0x001FDC5, 0x001FDC7,
+                0x001FDCD,
+            ]
+        );
+        assert!(IQ7000_KEYBOARD_TRANSLATION_TABLES.iter().any(|entry| {
+            entry.address == 0x001FDC5 && entry.role.contains("not a translation-table pointer")
+        }));
     }
 
     #[test]
@@ -2641,9 +2979,20 @@ mod tests {
             Iq7000CommandTarget {
                 index_or_command: 0x53,
                 target: 0x00F8412,
-                role: "pending classification",
+                role: "workspace readiness, busy-bit, and caller-range validator",
             }
         );
+
+        for command in [0xF9, 0xFA, 0xFB, 0xFF] {
+            let spec = IQ7000_RTC_COMMAND_SPECS
+                .iter()
+                .find(|spec| spec.command == command)
+                .expect("command-only RTC contract");
+            assert_eq!((spec.payload_len, spec.response_len), (0, 0));
+        }
+        assert!(IQ7000_RTC_COMMAND_SPECS.iter().any(|spec| {
+            spec.command == 0xFC && spec.payload_len == 0 && spec.response_len == 2
+        }));
 
         let current_time = IQ7000_RTC_COMMAND_SPECS
             .iter()
@@ -2689,8 +3038,8 @@ mod tests {
             &[
                 Iq7000CommandTarget {
                     index_or_command: 0x40,
-                    target: 0x00F5CA8,
-                    role: "store X to global 0x0CAE5C",
+                    target: 0x00F5CAC,
+                    role: "successful no-op (RC; RETF)",
                 },
                 Iq7000CommandTarget {
                     index_or_command: 0x41,
@@ -2720,7 +3069,7 @@ mod tests {
         }));
         assert!(IQ7000_STATUS_CONTRACTS
             .iter()
-            .any(|entry| { entry.area == "PACOM/PANET" && entry.code == 0xFA }));
+            .any(|entry| { entry.area == "PACOM" && entry.code == 0xFA }));
     }
 
     #[test]
@@ -2737,7 +3086,7 @@ mod tests {
         assert!(IQ7000_PRN_COMMAND_TABLE
             .iter()
             .any(|entry| { entry.index_or_command == 0x41 && entry.target == 0x00FB6FD }));
-        assert!(IQ7000_PACOM_PANET_COMMAND_TABLE
+        assert!(IQ7000_PACOM_COMMAND_TABLE
             .iter()
             .any(|entry| { entry.index_or_command == 0x04 && entry.target == 0x00FBD54 }));
         assert!(IQ7000_KEY_TRANSLATION_SEMANTICS.iter().any(|entry| {
@@ -2753,7 +3102,8 @@ mod tests {
         for area in [
             "STDO:SCRN",
             "STDI:KYBD",
-            "COM/PANET/PACOM/PRN",
+            "COM/PACOM/PRN",
+            "PANET",
             "CAS",
             "S1:S2:S3:S4 / E:F:G",
             "RTC",

--- a/sc62015/core/src/keyboard.rs
+++ b/sc62015/core/src/keyboard.rs
@@ -317,6 +317,22 @@ impl KeyboardMatrix {
         value
     }
 
+    /// Return the selected, undebounced electrical matrix level.
+    ///
+    /// This is the hardware source for KIL/KEYI. Host FIFO events, repeat
+    /// state, and the compatibility `raw_kil` presentation option do not
+    /// participate.
+    pub fn compute_physical_kil(&self) -> u8 {
+        let active = self.active_columns();
+        self.states.iter().fold(0u8, |value, state| {
+            if state.pressed && active.contains(&state.location.column) {
+                value | (1 << (state.location.row & 0x07))
+            } else {
+                value
+            }
+        })
+    }
+
     fn enqueue_event(&mut self, code: u8, release: bool, count_irq: bool) -> usize {
         let mut value = code & 0x7F;
         if release {
@@ -352,7 +368,10 @@ impl KeyboardMatrix {
         self.keyi_latch = false;
     }
 
-    /// Inject a matrix event immediately, bypassing debounce, and assert KEYI if enabled.
+    /// Inject a matrix event immediately, bypassing debounce.
+    ///
+    /// This updates physical key state and host FIFO bookkeeping. The CPU
+    /// samples selected physical KIL separately to assert raw KEYI.
     pub fn inject_matrix_event(
         &mut self,
         code: u8,
@@ -416,47 +435,23 @@ impl KeyboardMatrix {
         events
     }
 
-    pub fn write_fifo_to_memory(&mut self, memory: &mut MemoryImage, kb_irq_enabled: bool) {
-        // Assert KEYI only if keyboard IRQs are enabled, matching Python gating.
-        if self.keyi_latch && self.fifo_count > 0 && kb_irq_enabled {
-            if let Some(isr) = memory.read_internal_byte(0xFC) {
-                if (isr & 0x04) == 0 {
-                    memory.write_internal_byte(0xFC, isr | 0x04);
-                    let mut guard = crate::PERFETTO_TRACER.enter();
-                    guard.with_some(|tracer| {
-                        let (seq, pc) = crate::llama::eval::perfetto_instr_context()
-                            .unwrap_or_else(|| {
-                                (
-                                    crate::llama::eval::perfetto_last_instr_index(),
-                                    crate::llama::eval::perfetto_last_pc(),
-                                )
-                            });
-                        let substep = crate::llama::eval::perfetto_next_substep();
-                        tracer.record_mem_write_with_substep(
-                            seq,
-                            pc,
-                            crate::INTERNAL_MEMORY_START + 0xFC,
-                            (isr | 0x04) as u32,
-                            "internal",
-                            8,
-                            substep,
-                        );
-                    });
-                }
-            }
-        }
+    pub fn write_fifo_to_memory(&mut self, _memory: &mut MemoryImage, _kb_irq_enabled: bool) {
+        // The ROM-facing FIFO is not an electrical KEYI source. KEYI is
+        // sampled from compute_physical_kil() at the CPU scheduling boundary.
     }
 
     /// Drain debounced matrix events into the PC-E500 ROM IOCS key FIFO.
     ///
     /// The generic keyboard matrix owns the physical scan/debounce FIFO. The PC-E500 ROM
-    /// consumes a separate ring buffer inside the IOCS workspace (`IOCS_WS+0x50` after
-    /// normal boot). Timer-driven scans call this after `scan_tick` so `STDI:41h/42h/43h`
-    /// can observe physical key events without tests seeding the ROM FIFO directly.
+    /// consumes a separate relocatable ring buffer inside the IOCS workspace. Its u16
+    /// data offset is stored at `IOCS_WS+0x02` (normally `0x0050`), while producer and
+    /// consumer indices live at `+0x04/+0x05`. Timer-driven scans call this after
+    /// `scan_tick` so `STDI:41h/42h/43h` can observe physical key events without tests
+    /// seeding the ROM FIFO directly.
     pub fn drain_fifo_to_pce500_iocs_workspace(
         &mut self,
         memory: &mut MemoryImage,
-        kb_irq_enabled: bool,
+        _kb_irq_enabled: bool,
     ) -> usize {
         if self.fifo_count == 0 {
             self.keyi_latch = false;
@@ -464,15 +459,13 @@ impl KeyboardMatrix {
         }
 
         let Some(base) = read_u24(memory, PCE500_IOCS_WS_PTR_MIRROR)
-            .or_else(|| read_u24(memory, PCE500_IOCS_WS_PTR))
+            .filter(|base| *base != 0)
+            .or_else(|| read_u24(memory, PCE500_IOCS_WS_PTR).filter(|base| *base != 0))
         else {
             return 0;
         };
-        if base == 0 {
-            return 0;
-        }
 
-        let Some(buffer_offset) = memory.load(base + PCE500_KEY_FIFO_BASE_OFFSET, 8) else {
+        let Some(buffer_offset) = memory.load(base + PCE500_KEY_FIFO_BASE_OFFSET, 16) else {
             return 0;
         };
         let Some(mut tail) = memory
@@ -503,11 +496,6 @@ impl KeyboardMatrix {
 
         if written > 0 {
             let _ = memory.store(base + PCE500_KEY_FIFO_TAIL_OFFSET, 8, u32::from(tail));
-            if kb_irq_enabled {
-                if let Some(isr) = memory.read_internal_byte(0xFC) {
-                    memory.write_internal_byte(0xFC, isr | 0x04);
-                }
-            }
             self.consume_pending_events();
         }
         written
@@ -801,11 +789,11 @@ impl KeyboardMatrix {
             state.release_ticks = 0;
             state.repeat_ticks = self.repeat_delay;
             self.kil_latch = self.compute_kil(false);
-            // Parity: defer event enqueue/KEYI to timer-driven scan_tick; do not push KIL to IMEM here.
+            // Defer host-event enqueueing to timer-driven scan_tick; do not
+            // push KIL into IMEM here. Raw KEYI is sampled independently.
             if self.keyi_on_any_press && !was_pressed {
-                // Some ROMs (e.g., IQ‑7000) park KOL/KOH inactive while waiting and rely on KEYI
-                // to kick off scanning. Wake on any new physical press to avoid a deadlock where
-                // a key cannot be seen until columns are strobed.
+                // Preserve the compatibility host-event queue used by input
+                // bridges without treating it as an electrical IRQ source.
                 self.enqueue_event(code & 0x7F, false, true);
             }
         }
@@ -820,7 +808,7 @@ impl KeyboardMatrix {
             state.release_ticks = 0;
             state.repeat_ticks = 0;
             self.kil_latch = self.compute_kil(false);
-            // Parity: defer event enqueue/KEYI to timer-driven scan_tick.
+            // Defer host-event enqueueing to timer-driven scan_tick.
         }
     }
 
@@ -968,7 +956,7 @@ mod tests {
     }
 
     #[test]
-    fn scan_tick_respects_irq_disable() {
+    fn scan_tick_never_manufactures_raw_keyi() {
         let mut kb = KeyboardMatrix::new();
         kb.set_press_threshold(1);
         let mut mem = MemoryImage::new();
@@ -980,7 +968,11 @@ mod tests {
         let isr = mem
             .read_internal_byte(crate::memory::IMEM_ISR_OFFSET)
             .unwrap_or(0);
-        assert_eq!(isr & 0x04, 0, "KEYI should remain clear when IRQs disabled");
+        assert_eq!(
+            isr & 0x04,
+            0,
+            "host scan events must not manufacture raw KEYI"
+        );
         assert!(kb.fifo_len() > 0, "FIFO should still capture the event");
     }
 
@@ -1012,6 +1004,46 @@ mod tests {
 
         assert_eq!(events, 1);
         assert_eq!(kb.fifo_snapshot(), vec![0xA3]);
+    }
+
+    #[test]
+    fn iocs_fifo_uses_bfd17_when_e6_is_zero_and_reads_u16_data_offset() {
+        let mut kb = KeyboardMatrix::new();
+        let mut mem = MemoryImage::new();
+        let workspace_base = 0x00BF9B4;
+        let fifo_offset = 0x0170;
+
+        mem.store(PCE500_IOCS_WS_PTR_MIRROR, 24, 0)
+            .expect("clear live IOCS workspace image");
+        mem.store(PCE500_IOCS_WS_PTR, 24, workspace_base)
+            .expect("store authoritative IOCS workspace pointer");
+        mem.store(
+            workspace_base + PCE500_KEY_FIFO_BASE_OFFSET,
+            16,
+            fifo_offset,
+        )
+        .expect("store 16-bit FIFO data offset");
+        mem.store(workspace_base + PCE500_KEY_FIFO_TAIL_OFFSET, 8, 0)
+            .expect("clear FIFO producer index");
+        mem.store(workspace_base + PCE500_KEY_FIFO_HEAD_OFFSET, 8, 0)
+            .expect("clear FIFO consumer index");
+        assert_eq!(kb.inject_input_event(0x23, &mut mem, false), 1);
+
+        assert_eq!(kb.drain_fifo_to_pce500_iocs_workspace(&mut mem, true), 1);
+        assert_eq!(
+            mem.load(workspace_base + fifo_offset, 8),
+            Some(0x23),
+            "the high byte of the stored FIFO offset must affect the destination"
+        );
+        assert_eq!(
+            mem.load(workspace_base + PCE500_KEY_FIFO_TAIL_OFFSET, 8),
+            Some(1)
+        );
+        assert_eq!(
+            mem.read_internal_byte(0xFC).unwrap_or(0) & 0x04,
+            0,
+            "draining a host FIFO must not manufacture raw KEYI"
+        );
     }
 
     #[test]

--- a/sc62015/core/src/lib.rs
+++ b/sc62015/core/src/lib.rs
@@ -413,6 +413,7 @@ pub struct CoreRuntime {
     iq7000_rtc: Option<iq7000::Iq7000RtcPeripheral>,
     onk_level: bool,
     external_interrupt_level: bool,
+    poisoned: Option<String>,
 }
 
 struct DeviceRuntimeSettings {
@@ -457,6 +458,7 @@ impl CoreRuntime {
             iq7000_rtc: None,
             onk_level: false,
             external_interrupt_level: false,
+            poisoned: None,
         };
         rt.set_device_model(DeviceModel::PcE500)
             .expect("device model settings missing");
@@ -588,8 +590,12 @@ impl CoreRuntime {
             rtc_active: self.iq7000_rtc.is_some(),
             pc: self.state.pc() & ADDRESS_MASK,
         };
-        crate::llama::eval::power_on_reset(&mut bus, &mut self.state)
-            .map_err(|error| CoreError::Other(format!("power-on reset: {error}")))
+        let result = crate::llama::eval::power_on_reset(&mut bus, &mut self.state)
+            .map_err(|error| CoreError::Other(format!("power-on reset: {error}")));
+        if result.is_ok() {
+            self.poisoned = None;
+        }
+        result
     }
 
     /// Provide an optional host overlay reader for IMEM regions that require Python/device handling
@@ -1236,6 +1242,12 @@ impl CoreRuntime {
     }
 
     pub fn step(&mut self, instructions: usize) -> Result<()> {
+        if let Some(reason) = self.poisoned.as_deref() {
+            return Err(CoreError::Other(format!(
+                "SC62015 CoreRuntime is poisoned after a failed side-effecting operation; \
+                 power-on reset required: {reason}"
+            )));
+        }
         // Execute real instructions through the LLAMA evaluator instead of bumping PC.
         struct RuntimeBus<'a> {
             mem: &'a mut MemoryImage,
@@ -2275,6 +2287,9 @@ impl CoreRuntime {
 
         self.memory.validate_snapshot_overlay_contract()?;
         let mut active = Vec::new();
+        if self.poisoned.is_some() {
+            active.push("poisoned fail-stop runtime state");
+        }
         if self.sio.is_some() {
             active.push("SIO queues/line/timing state");
         }
@@ -2831,7 +2846,7 @@ impl CoreRuntime {
         self.state.set_reg(RegName::IMR, cleared_imr as u32);
         record_stack_write(imr_addr, 8, cleared_imr as u32);
 
-        let vec = {
+        let vector_result = {
             let host_read = self
                 .host_read
                 .as_mut()
@@ -2853,7 +2868,21 @@ impl CoreRuntime {
             };
             vector_transfer
                 .consume_after_architectural_fetch(INTERRUPT_VECTOR_ADDR, &self.state, &mut bus)
-                .map_err(|error| CoreError::Other(format!("IRQ vector transfer: {error}")))?
+                .map_err(|error| CoreError::Other(format!("IRQ vector transfer: {error}")))
+        };
+        let vec = match vector_result {
+            Ok(vec) => vec,
+            Err(error) => {
+                // HW-014 establishes that the architectural vector read occurs
+                // after the complete frame and IMR.IRM clear. Those writes are
+                // already observable and cannot be rolled back safely, so a
+                // failed transfer must prevent a second frame from being
+                // manufactured on a later step.
+                if self.poisoned.is_none() {
+                    self.poisoned = Some(error.to_string());
+                }
+                return Err(error);
+            }
         };
 
         // Emit a single delivery marker (matches Python tracer).
@@ -4103,6 +4132,64 @@ mod tests {
         assert_eq!(rt.timer.last_fired.as_deref(), Some("ONK"));
         assert!(rt.timer.delivered_masks.is_empty());
         assert_eq!(rt.timer.irq_total, 0);
+        assert!(rt.poisoned.is_none());
+    }
+
+    #[test]
+    fn post_frame_irq_vector_failure_poisons_until_power_on_reset() {
+        let mut rt = CoreRuntime::new();
+        let source_pc = 0x012345;
+        rt.state.set_reg(RegName::PC, source_pc);
+        // The three PC frame writes land on the IRQ vector itself. The
+        // architectural post-frame fetch therefore observes source_pc rather
+        // than the silently validated handler target.
+        rt.state.set_reg(RegName::S, 0x0FFFFD);
+        rt.state.set_reg(RegName::F, 0x03);
+        rt.memory.write_external_byte(source_pc, 0x00); // valid NOP target
+        rt.memory.write_external_byte(INTERRUPT_VECTOR_ADDR, 0x00);
+        rt.memory
+            .write_external_byte(INTERRUPT_VECTOR_ADDR + 1, 0x02);
+        rt.memory
+            .write_external_byte(INTERRUPT_VECTOR_ADDR + 2, 0x00);
+        rt.memory.write_external_byte(0x00200, 0x00);
+        rt.memory
+            .write_internal_byte(IMEM_IMR_OFFSET, IMR_MASTER | IMR_KEY);
+        rt.memory.write_internal_byte(IMEM_ISR_OFFSET, ISR_KEYI);
+        rt.timer.irq_pending = true;
+        rt.timer.irq_source = Some("KEY".to_string());
+
+        let error = rt
+            .step(1)
+            .expect_err("post-frame vector mismatch must fail closed");
+
+        assert!(error
+            .to_string()
+            .contains(crate::llama::eval::VECTOR_CHANGED_DURING_PREFLIGHT_ERROR));
+        assert_eq!(rt.state.get_reg(RegName::PC), source_pc);
+        assert_eq!(rt.state.get_reg(RegName::S), 0x0FFFF8);
+        assert_eq!(rt.memory.read_internal_byte(IMEM_IMR_OFFSET), Some(IMR_KEY));
+        assert_eq!(
+            [
+                rt.memory.load(INTERRUPT_VECTOR_ADDR, 8).unwrap() as u8,
+                rt.memory.load(INTERRUPT_VECTOR_ADDR + 1, 8).unwrap() as u8,
+                rt.memory.load(INTERRUPT_VECTOR_ADDR + 2, 8).unwrap() as u8,
+            ],
+            [0x45, 0x23, 0x01]
+        );
+        assert!(rt.poisoned.is_some());
+
+        let registers_after_failure = collect_registers(&rt.state);
+        let writes_after_failure = rt.memory.memory_write_count();
+        let retry = rt.step(1).expect_err("poison must block another frame");
+        assert!(retry.to_string().contains("poisoned"));
+        assert_eq!(collect_registers(&rt.state), registers_after_failure);
+        assert_eq!(rt.memory.memory_write_count(), writes_after_failure);
+
+        // External reset is the recovery boundary. The untouched reset vector
+        // resolves to zero in this fixture, where a NOP is available.
+        rt.power_on_reset().expect("power-on reset clears poison");
+        assert!(rt.poisoned.is_none());
+        rt.step(1).expect("execution resumes after reset");
     }
 
     #[test]

--- a/sc62015/core/src/lib.rs
+++ b/sc62015/core/src/lib.rs
@@ -127,7 +127,8 @@ use crate::llama::eval::{perfetto_last_pc, LlamaBus};
 use crate::llama::state::{mask_for, CallMetricsSnapshot};
 use crate::memory::{
     IMEM_IMR_OFFSET, IMEM_ISR_OFFSET, IMEM_KIL_OFFSET, IMEM_KOH_OFFSET, IMEM_KOL_OFFSET,
-    IMEM_RXD_OFFSET, IMEM_SSR_OFFSET, IMEM_TXD_OFFSET, IMEM_UCR_OFFSET, IMEM_USR_OFFSET,
+    IMEM_LCC_OFFSET, IMEM_RXD_OFFSET, IMEM_SSR_OFFSET, IMEM_TXD_OFFSET, IMEM_UCR_OFFSET,
+    IMEM_USR_OFFSET,
 };
 
 pub type Result<T> = std::result::Result<T, CoreError>;
@@ -1020,18 +1021,25 @@ impl CoreRuntime {
         self.memory.write_internal_byte(0xF6, high);
     }
 
-    fn refresh_key_irq_latch(&mut self) {
-        if self.timer.in_interrupt {
-            // Parity: do not reassert KEYI while already in an interrupt handler.
-            return;
+    fn raw_selected_kil(&self) -> u8 {
+        // LCC.KSD disconnects keyboard scanning. Otherwise the physical level
+        // is independent of debounce/FIFO policy and IMR.
+        if self
+            .memory
+            .read_internal_byte_silent(IMEM_LCC_OFFSET)
+            .unwrap_or(0)
+            & 0x04
+            != 0
+        {
+            return 0;
         }
-        if self.keyboard.is_some() {
-            // Only reassert when a latch is already active; do not recreate one purely from FIFO
-            // contents. New latches are set at event time by the timer/keyboard path.
-            if !self.timer.key_irq_latched {
-                return;
-            }
-            self.timer.key_irq_latched = true;
+        self.keyboard
+            .as_ref()
+            .map_or(0, KeyboardMatrix::compute_physical_kil)
+    }
+
+    fn refresh_raw_key_irq_level(&mut self) {
+        if self.raw_selected_kil() != 0 {
             let isr = self.memory.read_internal_byte(IMEM_ISR_OFFSET).unwrap_or(0);
             if (isr & ISR_KEYI) == 0 {
                 let new_isr = isr | ISR_KEYI;
@@ -1043,7 +1051,7 @@ impl CoreRuntime {
                 self.timer.irq_isr = isr;
             }
             self.timer.irq_pending = true;
-            if self.timer.irq_source.is_none() {
+            if !self.timer.in_interrupt && self.timer.irq_source.is_none() {
                 self.timer.irq_source = Some("KEY".to_string());
             }
             self.timer.last_fired = self.timer.irq_source.clone();
@@ -1055,9 +1063,6 @@ impl CoreRuntime {
     }
 
     pub(crate) fn tick_timers_and_keyboard(&mut self, cycle: u64) {
-        if self.timer.in_interrupt {
-            return;
-        }
         let kb_irq_enabled = self.timer.kb_irq_enabled;
         let mirror_pce500_fifo = matches!(
             self.device_model(),
@@ -1099,9 +1104,6 @@ impl CoreRuntime {
     }
 
     fn arm_pending_irq_from_isr(&mut self) {
-        if self.timer.in_interrupt {
-            return;
-        }
         if self.timer.irq_pending {
             return;
         }
@@ -1109,10 +1111,7 @@ impl CoreRuntime {
         if isr == 0 {
             return;
         }
-        let mut isr_effective = isr;
-        if !self.timer.kb_irq_enabled {
-            isr_effective &= !ISR_KEYI;
-        }
+        let isr_effective = isr;
         let imr = self.memory.read_internal_byte(IMEM_IMR_OFFSET).unwrap_or(0);
         // Parity: Python marks irq_pending as soon as ISR bits are asserted, even if IMR master is 0
         // or the source mask is currently disabled. Delivery is still gated later.
@@ -1140,12 +1139,14 @@ impl CoreRuntime {
         self.timer.irq_isr = isr_effective;
         self.timer.irq_imr = imr;
         // Allow a newly latched KEY/ONK to override earlier timer sources to match Python priority.
-        match self.timer.irq_source.as_deref() {
-            None => self.timer.irq_source = src.map(str::to_string),
-            Some(cur) => {
-                if let Some(src_name) = src {
-                    if irq_source_priority(src_name) < irq_source_priority(cur) {
-                        self.timer.irq_source = Some(src_name.to_string());
+        if !self.timer.in_interrupt {
+            match self.timer.irq_source.as_deref() {
+                None => self.timer.irq_source = src.map(str::to_string),
+                Some(cur) => {
+                    if let Some(src_name) = src {
+                        if irq_source_priority(src_name) < irq_source_priority(cur) {
+                            self.timer.irq_source = Some(src_name.to_string());
+                        }
                     }
                 }
             }
@@ -1192,7 +1193,7 @@ impl CoreRuntime {
             .memory
             .read_internal_byte_silent(IMEM_ISR_OFFSET)
             .unwrap_or(0);
-        let key_will_reassert = self.keyboard.is_some() && self.timer.key_irq_latched;
+        let key_will_reassert = self.raw_selected_kil() != 0;
         let sio_rx_will_assert = self.sio.is_some()
             && (imr & IMR_RX) != 0
             && (self
@@ -1216,19 +1217,12 @@ impl CoreRuntime {
             predicted_isr |= ISR_RXI;
         }
 
-        // A bare KEYI only arms the host keyboard source when generation is
-        // enabled. An existing pending source or synchronous re-latch still
-        // makes the complete ISR image eligible for the delivery selector.
-        let mut armable_isr = asserted_isr;
-        if !self.timer.kb_irq_enabled {
-            armable_isr &= !ISR_KEYI;
-        }
         let pending_or_will_reassert = self.timer.irq_pending
             || key_will_reassert
             || self.onk_level
             || self.external_interrupt_level
             || sio_rx_will_assert
-            || (armable_isr & ISR_KNOWN_MASK) != 0;
+            || (asserted_isr & ISR_KNOWN_MASK) != 0;
 
         pending_or_will_reassert && (predicted_isr & imr & ISR_KNOWN_MASK) != 0
     }
@@ -1600,6 +1594,7 @@ impl CoreRuntime {
         }
 
         for _ in 0..instructions {
+            let halted_at_step_entry = self.state.is_halted();
             let irq_transfer_selected = self.irq_transfer_selected_at_step_entry();
             // Reject quarantined/invalid encodings before level re-latching,
             // SIO/keyboard/device callbacks, IRQ wake/delivery, or timer
@@ -1671,9 +1666,9 @@ impl CoreRuntime {
                     state_ptr: &self.state as *const LlamaState,
                 };
                 // Fully validate the current instruction through the silent
-                // bus only when it can execute on this slot. An IRQ selected
-                // at entry replaces that PC after one discarded architectural
-                // opcode fetch, so its operands and encoding are irrelevant.
+                // bus first. A malformed current encoding takes precedence
+                // even when the IRQ destination aliases it, and must consume
+                // zero architectural reads.
                 let silent_prepared_opcode = if should_preflight && !irq_transfer_selected {
                     let silent_opcode = bus.peek_byte_silent(pc).ok_or_else(|| {
                         CoreError::Other(format!(
@@ -1756,18 +1751,13 @@ impl CoreRuntime {
                             "IRQ vector preflight: callback-backed vector/target".to_string(),
                         ));
                     }
+                    // A deliverable asynchronous IRQ replaces the current
+                    // instruction after exactly one opcode-byte fetch. Do not
+                    // decode or read operands from the discarded instruction.
+                    let _discarded_opcode = bus.load(pc, 8);
                 }
 
-                if irq_transfer_selected {
-                    // PC-E500 captures show one architectural fetch at the
-                    // saved/fall-through PC before an already-selected IRQ
-                    // writes its frame.  The fetched byte is discarded: do
-                    // not decode it, reject reserved values, or require a
-                    // callback-backed byte to remain stable across the
-                    // scheduler boundary.
-                    let _discarded_opcode = bus.load(pc, 8) as u8;
-                    None
-                } else if let Some(silent_opcode) = silent_prepared_opcode {
+                if let Some(silent_opcode) = silent_prepared_opcode {
                     let opcode = bus.load(pc, 8) as u8;
                     if opcode != silent_opcode {
                         return Err(CoreError::Other(format!(
@@ -1777,7 +1767,7 @@ impl CoreRuntime {
                     }
                     let transfer = match opcode {
                         0xFE => Some(
-                            crate::llama::eval::fetch_validated_vector(
+                            crate::llama::eval::prepare_validated_vector(
                                 INTERRUPT_VECTOR_ADDR,
                                 &self.state,
                                 &mut bus,
@@ -1804,27 +1794,23 @@ impl CoreRuntime {
                 }
             };
             if irq_transfer_selected {
-                // IRQ entry consumes this CoreRuntime scheduling slot. The
-                // handler instruction is prepared on the next slot, matching
-                // the runtime's established step/count contract while the
-                // replaced current PC is never decoded or executed.
-                // Materialize any level/latch state that the side-effect-free
-                // entry decision included before committing delivery.
+                // Materialize level-sensitive sources only after the silent
+                // vector proof and discarded-opcode fetch above. Delivery
+                // writes the frame, then performs the architectural vector
+                // reads. The recursive one-instruction step executes the
+                // selected handler within this caller's instruction budget.
                 self.refresh_on_key_interrupt_level();
                 self.refresh_external_interrupt_level();
                 self.refresh_sio_interrupts();
-                self.refresh_key_irq_latch();
+                self.refresh_raw_key_irq_level();
                 self.arm_pending_irq_from_isr();
                 self.deliver_pending_irq()?;
-                let mut guard = PERFETTO_TRACER.enter();
-                guard.with_some(|tracer| {
-                    tracer.update_counters(
-                        self.metadata.instruction_count,
-                        self.state.call_depth(),
-                        self.memory.memory_read_count(),
-                        self.memory.memory_write_count(),
-                    );
-                });
+                if !self.timer.in_interrupt {
+                    return Err(CoreError::Other(
+                        "selected IRQ boundary did not enter its handler".to_string(),
+                    ));
+                }
+                self.step(1)?;
                 continue;
             }
             if self.state.is_off() {
@@ -1927,8 +1913,9 @@ impl CoreRuntime {
                 });
                 // Mirror SIO hardware status bits into ISR before foreground/IRQ polling.
                 self.refresh_sio_interrupts();
-                // Reassert KEYI if the FIFO still holds events even after firmware clears ISR.
-                self.refresh_key_irq_latch();
+                // Sample the selected, undebounced matrix level. Host FIFO and
+                // debounce bookkeeping are not silicon KEYI sources.
+                self.refresh_raw_key_irq_level();
                 // If ISR already has pending bits (e.g., host write) arm a pending IRQ so delivery can occur once IMR allows it.
                 self.arm_pending_irq_from_isr();
 
@@ -1970,51 +1957,48 @@ impl CoreRuntime {
                     }
                 }
 
-                // Halted cores still consume idle cycles and allow timers/IRQs to run.
-                if self.state.is_halted() {
+                // A HALT boundary remains an idle boundary even when a status
+                // level wakes the core. Execute the first foreground opcode
+                // on the next scheduler step, after it receives its own
+                // silent validation and architectural fetch.
+                if halted_at_step_entry {
                     let prev_cycle = self.metadata.cycle_count;
                     let new_cycle = prev_cycle.wrapping_add(1);
                     self.metadata.cycle_count = new_cycle;
-                    if !self.timer.in_interrupt {
-                        let kb_irq_enabled = self.timer.kb_irq_enabled;
-                        let mirror_pce500_fifo = matches!(
-                            self.device_model(),
-                            DeviceModel::PcE500 | DeviceModel::PcE500Jp
-                        );
-                        let _ = self.timer.tick_timers_with_keyboard(
-                            &mut self.memory,
-                            new_cycle,
-                            |mem| {
-                                if let Some(kb) = self.keyboard.as_mut() {
-                                    // Parity: always count/key-latch events even when IRQs are masked.
-                                    let events = kb.scan_tick(mem, true);
-                                    if events > 0 || (kb_irq_enabled && kb.fifo_len() > 0) {
-                                        let drained = if mirror_pce500_fifo {
-                                            kb.drain_fifo_to_pce500_iocs_workspace(
-                                                mem,
-                                                kb_irq_enabled,
-                                            )
-                                        } else {
-                                            0
-                                        };
-                                        if drained == 0 {
-                                            kb.write_fifo_to_memory(mem, kb_irq_enabled);
-                                        }
+                    let kb_irq_enabled = self.timer.kb_irq_enabled;
+                    let mirror_pce500_fifo = matches!(
+                        self.device_model(),
+                        DeviceModel::PcE500 | DeviceModel::PcE500Jp
+                    );
+                    let _ = self.timer.tick_timers_with_keyboard(
+                        &mut self.memory,
+                        new_cycle,
+                        |mem| {
+                            if let Some(kb) = self.keyboard.as_mut() {
+                                // Parity: always count/key-latch events even when IRQs are masked.
+                                let events = kb.scan_tick(mem, true);
+                                if events > 0 || (kb_irq_enabled && kb.fifo_len() > 0) {
+                                    let drained = if mirror_pce500_fifo {
+                                        kb.drain_fifo_to_pce500_iocs_workspace(mem, kb_irq_enabled)
+                                    } else {
+                                        0
+                                    };
+                                    if drained == 0 {
+                                        kb.write_fifo_to_memory(mem, kb_irq_enabled);
                                     }
-                                    (events, kb.fifo_len() > 0, Some(kb.telemetry()))
-                                } else {
-                                    (0, false, None)
                                 }
-                            },
-                            Some(self.state.get_reg(RegName::Y)),
-                            Some(self.state.get_reg(RegName::PC)),
-                        );
-                        if let Some(isr) = self.memory.read_internal_byte(0xFC) {
-                            self.timer.irq_isr = isr;
-                        }
-                        // Reassert KEYI latch only when enabled, mirroring Python HALT wake behavior.
-                        self.refresh_key_irq_latch();
+                                (events, kb.fifo_len() > 0, Some(kb.telemetry()))
+                            } else {
+                                (0, false, None)
+                            }
+                        },
+                        Some(self.state.get_reg(RegName::Y)),
+                        Some(self.state.get_reg(RegName::PC)),
+                    );
+                    if let Some(isr) = self.memory.read_internal_byte(0xFC) {
+                        self.timer.irq_isr = isr;
                     }
+                    self.refresh_raw_key_irq_level();
                     let mut guard = PERFETTO_TRACER.enter();
                     guard.with_some(|tracer| {
                         tracer.update_counters(
@@ -2170,40 +2154,39 @@ impl CoreRuntime {
                         DeviceModel::PcE500 | DeviceModel::PcE500Jp
                     );
                     for cyc in prev_cycle + 1..=new_cycle {
-                        if !self.timer.in_interrupt {
-                            let kb_irq_enabled = self.timer.kb_irq_enabled;
-                            let _ = self.timer.tick_timers_with_keyboard(
-                                &mut self.memory,
-                                cyc,
-                                |mem| {
-                                    if let Some(kb) = self.keyboard.as_mut() {
-                                        // Parity: always count/key-latch events even when IRQs are masked.
-                                        let events = kb.scan_tick(mem, true);
-                                        if events > 0 || (kb_irq_enabled && kb.fifo_len() > 0) {
-                                            let drained = if mirror_pce500_fifo {
-                                                kb.drain_fifo_to_pce500_iocs_workspace(
-                                                    mem,
-                                                    kb_irq_enabled,
-                                                )
-                                            } else {
-                                                0
-                                            };
-                                            if drained == 0 {
-                                                kb.write_fifo_to_memory(mem, kb_irq_enabled);
-                                            }
+                        let kb_irq_enabled = self.timer.kb_irq_enabled;
+                        let _ = self.timer.tick_timers_with_keyboard(
+                            &mut self.memory,
+                            cyc,
+                            |mem| {
+                                if let Some(kb) = self.keyboard.as_mut() {
+                                    // Parity: always count/key-latch events even when IRQs are masked.
+                                    let events = kb.scan_tick(mem, true);
+                                    if events > 0 || (kb_irq_enabled && kb.fifo_len() > 0) {
+                                        let drained = if mirror_pce500_fifo {
+                                            kb.drain_fifo_to_pce500_iocs_workspace(
+                                                mem,
+                                                kb_irq_enabled,
+                                            )
+                                        } else {
+                                            0
+                                        };
+                                        if drained == 0 {
+                                            kb.write_fifo_to_memory(mem, kb_irq_enabled);
                                         }
-                                        (events, kb.fifo_len() > 0, Some(kb.telemetry()))
-                                    } else {
-                                        (0, false, None)
                                     }
-                                },
-                                Some(self.state.get_reg(RegName::Y)),
-                                Some(self.state.get_reg(RegName::PC)),
-                            );
-                            // KEYI delivery is handled inside tick_timers_with_keyboard and respects kb_irq_enabled.
-                            if let Some(isr) = self.memory.read_internal_byte(0xFC) {
-                                self.timer.irq_isr = isr;
-                            }
+                                    (events, kb.fifo_len() > 0, Some(kb.telemetry()))
+                                } else {
+                                    (0, false, None)
+                                }
+                            },
+                            Some(self.state.get_reg(RegName::Y)),
+                            Some(self.state.get_reg(RegName::PC)),
+                        );
+                        // Timer status mirrors are independent of raw KEYI,
+                        // which is sampled at instruction boundaries.
+                        if let Some(isr) = self.memory.read_internal_byte(0xFC) {
+                            self.timer.irq_isr = isr;
                         }
                     }
                 }
@@ -2695,95 +2678,91 @@ impl CoreRuntime {
 
         // Resolve the vector and statically validate its destination before
         // constructing the interrupt frame or changing IMR/runtime metadata.
-        // The three vector bytes are still fetched architecturally exactly
-        // once after a side-effect-free preflight.
-        let vec = {
-            struct VectorBus<'a> {
-                mem: &'a mut MemoryImage,
-                host_read: Option<*mut (dyn FnMut(u32) -> Option<u8> + Send)>,
-                host_peek: Option<*mut (dyn FnMut(u32) -> Option<u8> + Send)>,
-                lcd_ptr: Option<*mut dyn LcdHal>,
-                keyboard_active: bool,
-                sio_active: bool,
-                rtc_active: bool,
-                pc: u32,
-            }
+        // The proof remains silent until the complete frame is present.
+        struct VectorBus<'a> {
+            mem: &'a mut MemoryImage,
+            host_read: Option<*mut (dyn FnMut(u32) -> Option<u8> + Send)>,
+            host_peek: Option<*mut (dyn FnMut(u32) -> Option<u8> + Send)>,
+            lcd_ptr: Option<*mut dyn LcdHal>,
+            keyboard_active: bool,
+            sio_active: bool,
+            rtc_active: bool,
+            pc: u32,
+        }
 
-            impl LlamaBus for VectorBus<'_> {
-                fn load(&mut self, addr: u32, bits: u8) -> u32 {
-                    let addr = addr & ADDRESS_MASK;
-                    if self.mem.requires_python(addr) {
-                        if let Some(read) = self.host_read {
-                            // SAFETY: this synchronous bus exclusively owns
-                            // the callback pointer while delivering the IRQ.
-                            if let Some(value) = unsafe { (*read)(addr) } {
-                                self.mem.bump_read_count();
-                                return u32::from(value);
-                            }
+        impl LlamaBus for VectorBus<'_> {
+            fn load(&mut self, addr: u32, bits: u8) -> u32 {
+                let addr = addr & ADDRESS_MASK;
+                if self.mem.requires_python(addr) {
+                    if let Some(read) = self.host_read {
+                        // SAFETY: this synchronous bus exclusively owns
+                        // the callback pointer while delivering the IRQ.
+                        if let Some(value) = unsafe { (*read)(addr) } {
+                            self.mem.bump_read_count();
+                            return u32::from(value);
                         }
                     }
-                    self.mem
-                        .load_with_pc(addr, bits, Some(self.pc))
-                        .unwrap_or(0)
                 }
+                self.mem
+                    .load_with_pc(addr, bits, Some(self.pc))
+                    .unwrap_or(0)
+            }
 
-                fn store(&mut self, _addr: u32, _bits: u8, _value: u32) {
-                    unreachable!("IRQ vector validation must never write memory")
-                }
+            fn store(&mut self, _addr: u32, _bits: u8, _value: u32) {
+                unreachable!("IRQ vector validation must never write memory")
+            }
 
-                fn peek_byte_silent(&mut self, addr: u32) -> Option<u8> {
-                    self.peek_byte_silent_at(addr, self.pc)
-                }
+            fn peek_byte_silent(&mut self, addr: u32) -> Option<u8> {
+                self.peek_byte_silent_at(addr, self.pc)
+            }
 
-                fn peek_byte_silent_at(&mut self, addr: u32, context_pc: u32) -> Option<u8> {
-                    let addr = addr & ADDRESS_MASK;
-                    if let Some(offset) = MemoryImage::internal_offset(addr) {
-                        if (self.keyboard_active
+            fn peek_byte_silent_at(&mut self, addr: u32, context_pc: u32) -> Option<u8> {
+                let addr = addr & ADDRESS_MASK;
+                if let Some(offset) = MemoryImage::internal_offset(addr) {
+                    if (self.keyboard_active
+                        && matches!(offset, IMEM_KOL_OFFSET | IMEM_KOH_OFFSET | IMEM_KIL_OFFSET))
+                        || (self.rtc_active && offset == iq7000::IMEM_EIL_OFFSET)
+                        || (self.sio_active
                             && matches!(
                                 offset,
-                                IMEM_KOL_OFFSET | IMEM_KOH_OFFSET | IMEM_KIL_OFFSET
+                                IMEM_UCR_OFFSET
+                                    | IMEM_USR_OFFSET
+                                    | IMEM_RXD_OFFSET
+                                    | IMEM_TXD_OFFSET
                             ))
-                            || (self.rtc_active && offset == iq7000::IMEM_EIL_OFFSET)
-                            || (self.sio_active
-                                && matches!(
-                                    offset,
-                                    IMEM_UCR_OFFSET
-                                        | IMEM_USR_OFFSET
-                                        | IMEM_RXD_OFFSET
-                                        | IMEM_TXD_OFFSET
-                                ))
-                        {
-                            return None;
-                        }
+                    {
+                        return None;
                     }
-                    if let Some(lcd_ptr) = self.lcd_ptr {
-                        // SAFETY: address classification is read-only.
-                        if unsafe { (&*lcd_ptr).handles(addr) } {
-                            return None;
-                        }
+                }
+                if let Some(lcd_ptr) = self.lcd_ptr {
+                    // SAFETY: address classification is read-only.
+                    if unsafe { (&*lcd_ptr).handles(addr) } {
+                        return None;
                     }
-                    if self.mem.requires_python(addr) {
-                        return self.host_peek.and_then(|peek| {
-                            // SAFETY: this is the explicit safe callback.
-                            unsafe { (*peek)(addr) }
-                        });
-                    }
-                    self.mem.read_byte_for_preflight(addr, Some(context_pc))
                 }
-
-                fn vector_transfer_provenance(&self) -> (usize, u64) {
-                    self.mem.vector_transfer_provenance()
+                if self.mem.requires_python(addr) {
+                    return self.host_peek.and_then(|peek| {
+                        // SAFETY: this is the explicit safe callback.
+                        unsafe { (*peek)(addr) }
+                    });
                 }
-
-                fn instruction_byte_is_stable(&self, addr: u32) -> bool {
-                    self.mem.instruction_byte_is_stable(addr)
-                }
-
-                fn supports_wait_cycles(&self) -> bool {
-                    true
-                }
+                self.mem.read_byte_for_preflight(addr, Some(context_pc))
             }
 
+            fn vector_transfer_provenance(&self) -> (usize, u64) {
+                self.mem.vector_transfer_provenance()
+            }
+
+            fn instruction_byte_is_stable(&self, addr: u32) -> bool {
+                self.mem.instruction_byte_is_stable(addr)
+            }
+
+            fn supports_wait_cycles(&self) -> bool {
+                true
+            }
+        }
+
+        let vector_transfer = {
             let host_read = self
                 .host_read
                 .as_mut()
@@ -2803,9 +2782,12 @@ impl CoreRuntime {
                 rtc_active: self.iq7000_rtc.is_some(),
                 pc: self.state.pc() & ADDRESS_MASK,
             };
-            crate::llama::eval::fetch_validated_vector(INTERRUPT_VECTOR_ADDR, &self.state, &mut bus)
-                .map_err(|error| CoreError::Other(format!("IRQ vector transfer: {error}")))?
-                .target()
+            crate::llama::eval::prepare_validated_vector(
+                INTERRUPT_VECTOR_ADDR,
+                &self.state,
+                &mut bus,
+            )
+            .map_err(|error| CoreError::Other(format!("IRQ vector transfer: {error}")))?
         };
 
         let pc = self.state.pc() & ADDRESS_MASK;
@@ -2848,6 +2830,31 @@ impl CoreRuntime {
             .record_bit_watch_transition("IMR", imr_mem as u8, cleared_imr, pc);
         self.state.set_reg(RegName::IMR, cleared_imr as u32);
         record_stack_write(imr_addr, 8, cleared_imr as u32);
+
+        let vec = {
+            let host_read = self
+                .host_read
+                .as_mut()
+                .map(|f| &mut **f as *mut (dyn FnMut(u32) -> Option<u8> + Send));
+            let host_peek = self
+                .host_peek
+                .as_mut()
+                .map(|f| &mut **f as *mut (dyn FnMut(u32) -> Option<u8> + Send));
+            let lcd_ptr = self.lcd.as_mut().map(|lcd| lcd.as_mut() as *mut dyn LcdHal);
+            let mut bus = VectorBus {
+                mem: &mut self.memory,
+                host_read,
+                host_peek,
+                lcd_ptr,
+                keyboard_active: self.keyboard.is_some(),
+                sio_active: self.sio.is_some(),
+                rtc_active: self.iq7000_rtc.is_some(),
+                pc,
+            };
+            vector_transfer
+                .consume_after_architectural_fetch(INTERRUPT_VECTOR_ADDR, &self.state, &mut bus)
+                .map_err(|error| CoreError::Other(format!("IRQ vector transfer: {error}")))?
+        };
 
         // Emit a single delivery marker (matches Python tracer).
         if src_name == "KEY" {
@@ -4234,7 +4241,7 @@ mod tests {
     }
 
     #[test]
-    fn arm_pending_irq_ignores_keyi_when_kb_irq_disabled() {
+    fn arm_pending_irq_honors_asserted_keyi_when_host_event_generation_is_disabled() {
         let mut rt = CoreRuntime::new();
         rt.timer.set_keyboard_irq_enabled(false);
         rt.memory.write_internal_byte(IMEM_ISR_OFFSET, ISR_KEYI);
@@ -4245,11 +4252,8 @@ mod tests {
 
         rt.arm_pending_irq_from_isr();
 
-        assert!(
-            !rt.timer.irq_pending,
-            "KEYI should be masked when kb IRQs are disabled"
-        );
-        assert!(rt.timer.irq_source.is_none());
+        assert!(rt.timer.irq_pending);
+        assert_eq!(rt.timer.irq_source.as_deref(), Some("KEY"));
     }
 
     #[test]
@@ -4305,7 +4309,7 @@ mod tests {
     }
 
     #[test]
-    fn arm_pending_irq_ignored_during_interrupt() {
+    fn arm_pending_irq_records_status_during_interrupt_without_selecting_nested_source() {
         let mut rt = CoreRuntime::new();
         rt.timer.in_interrupt = true;
         rt.memory
@@ -4318,8 +4322,8 @@ mod tests {
         rt.arm_pending_irq_from_isr();
 
         assert!(
-            !rt.timer.irq_pending,
-            "pending should not arm while already in an interrupt"
+            rt.timer.irq_pending,
+            "status remains pending while already in an interrupt"
         );
         assert!(
             rt.timer.irq_source.is_none(),
@@ -4328,7 +4332,7 @@ mod tests {
     }
 
     #[test]
-    fn refresh_key_irq_latch_requires_existing_latch() {
+    fn raw_selected_key_reasserts_without_host_event_latch() {
         let mut rt = CoreRuntime::new();
         let kb = rt.keyboard.as_mut().unwrap();
         // Press a key and strobe columns so scan_tick can debounce and leave FIFO populated.
@@ -4349,37 +4353,30 @@ mod tests {
         rt.timer.key_irq_latched = false;
         rt.timer.irq_pending = false;
         rt.timer.irq_source = None;
-        rt.refresh_key_irq_latch();
+        rt.refresh_raw_key_irq_level();
         let isr = rt.memory.read_internal_byte(IMEM_ISR_OFFSET).unwrap_or(0);
-        assert_eq!(
-            isr & ISR_KEYI,
-            0,
-            "KEYI should not reassert once the latch was cleared"
-        );
+        assert_eq!(isr & ISR_KEYI, ISR_KEYI);
         assert!(
             !rt.timer.key_irq_latched,
             "latch should remain cleared without new events"
         );
-        assert!(
-            !rt.timer.irq_pending,
-            "pending IRQ should stay cleared without a latch"
-        );
-        assert!(rt.timer.irq_source.is_none());
+        assert!(rt.timer.irq_pending);
+        assert_eq!(rt.timer.irq_source.as_deref(), Some("KEY"));
     }
 
     #[test]
-    fn refresh_key_irq_latch_respects_kb_irq_disable() {
+    fn unselected_host_key_event_does_not_assert_raw_keyi() {
         let mut rt = CoreRuntime::new();
         rt.timer.set_keyboard_irq_enabled(false);
         let kb = rt.keyboard.as_mut().unwrap();
         // Inject a matrix event to populate FIFO without relying on IRQ enable.
         kb.inject_matrix_event(0x10, false, &mut rt.memory, rt.timer.kb_irq_enabled);
-        rt.refresh_key_irq_latch();
+        rt.refresh_raw_key_irq_level();
         let isr = rt.memory.read_internal_byte(IMEM_ISR_OFFSET).unwrap_or(0);
         assert_eq!(
             isr & ISR_KEYI,
             0,
-            "KEYI should stay masked when keyboard IRQs are disabled"
+            "an unselected key and host FIFO event are not raw KEYI sources"
         );
         assert!(
             !rt.timer.irq_pending,
@@ -4388,7 +4385,7 @@ mod tests {
     }
 
     #[test]
-    fn refresh_key_irq_latch_respects_kb_irq_disable_with_fifo_data() {
+    fn raw_selected_key_ignores_host_event_irq_disable() {
         let mut rt = CoreRuntime::new();
         rt.timer.set_keyboard_irq_enabled(false);
         let kb = rt.keyboard.as_mut().unwrap();
@@ -4409,18 +4406,11 @@ mod tests {
         rt.timer.irq_pending = false;
         rt.timer.irq_source = None;
 
-        rt.refresh_key_irq_latch();
+        rt.refresh_raw_key_irq_level();
 
         let isr = rt.memory.read_internal_byte(IMEM_ISR_OFFSET).unwrap_or(0);
-        assert_eq!(
-            isr & ISR_KEYI,
-            0,
-            "KEYI should remain masked when kb IRQs are disabled even with FIFO data"
-        );
-        assert!(
-            !rt.timer.irq_pending,
-            "pending should not arm from FIFO latch when kb IRQs are disabled"
-        );
+        assert_eq!(isr & ISR_KEYI, ISR_KEYI);
+        assert!(rt.timer.irq_pending);
         assert!(
             !rt.timer.key_irq_latched,
             "latch should clear while kb IRQs are disabled"
@@ -4428,7 +4418,7 @@ mod tests {
     }
 
     #[test]
-    fn refresh_key_irq_latch_preserves_latch_when_irq_disabled() {
+    fn selected_raw_key_ignores_host_event_disable_and_preserves_bookkeeping() {
         let mut rt = CoreRuntime::new();
         let kb = rt.keyboard.as_mut().unwrap();
         // Create a latched KEYI while IRQs are enabled.
@@ -4442,7 +4432,7 @@ mod tests {
         }
         kb.write_fifo_to_memory(&mut rt.memory, rt.timer.kb_irq_enabled);
         rt.timer.key_irq_latched = true;
-        rt.refresh_key_irq_latch();
+        rt.refresh_raw_key_irq_level();
         assert!(
             rt.timer.key_irq_latched,
             "latch should be set while enabled"
@@ -4451,7 +4441,7 @@ mod tests {
         rt.timer.set_keyboard_irq_enabled(false);
         rt.memory.write_internal_byte(IMEM_ISR_OFFSET, 0);
         rt.timer.irq_pending = false;
-        rt.refresh_key_irq_latch();
+        rt.refresh_raw_key_irq_level();
 
         let isr = rt.memory.read_internal_byte(IMEM_ISR_OFFSET).unwrap_or(0);
         assert_ne!(isr & ISR_KEYI, 0, "KEYI should stay asserted while latched");
@@ -4467,20 +4457,20 @@ mod tests {
     }
 
     #[test]
-    fn refresh_key_irq_latch_skips_when_in_interrupt() {
+    fn host_event_latch_alone_does_not_assert_keyi_during_interrupt() {
         let mut rt = CoreRuntime::new();
         rt.timer.in_interrupt = true;
         rt.timer.key_irq_latched = true;
         rt.memory.write_internal_byte(IMEM_ISR_OFFSET, 0);
         rt.timer.irq_pending = false;
 
-        rt.refresh_key_irq_latch();
+        rt.refresh_raw_key_irq_level();
 
         let isr = rt.memory.read_internal_byte(IMEM_ISR_OFFSET).unwrap_or(0);
         assert_eq!(
             isr & ISR_KEYI,
             0,
-            "ISR should not change while in interrupt"
+            "host event bookkeeping alone must not assert raw KEYI"
         );
         assert!(
             !rt.timer.irq_pending,
@@ -4489,7 +4479,46 @@ mod tests {
     }
 
     #[test]
-    fn refresh_key_irq_latch_reasserts_when_latched() {
+    fn raw_selected_key_reasserts_during_handler_until_release() {
+        let mut rt = CoreRuntime::new();
+        rt.timer.in_interrupt = true;
+        {
+            let kb = rt.keyboard.as_mut().unwrap();
+            kb.press_matrix_code(0x10, &mut rt.memory);
+            kb.handle_write(IMEM_KOL_OFFSET, 0xFF, &mut rt.memory);
+            kb.handle_write(IMEM_KOH_OFFSET, 0x0F, &mut rt.memory);
+        }
+        rt.memory.write_internal_byte(IMEM_ISR_OFFSET, 0);
+        rt.timer.irq_pending = false;
+
+        rt.refresh_raw_key_irq_level();
+
+        assert_eq!(
+            rt.memory.read_internal_byte(IMEM_ISR_OFFSET).unwrap_or(0) & ISR_KEYI,
+            ISR_KEYI
+        );
+        assert!(rt.timer.irq_pending);
+        assert!(
+            rt.timer.irq_source.is_none(),
+            "no nested source is selected"
+        );
+
+        rt.keyboard
+            .as_mut()
+            .unwrap()
+            .release_matrix_code(0x10, &mut rt.memory);
+        rt.memory.write_internal_byte(IMEM_ISR_OFFSET, 0);
+        rt.timer.irq_pending = false;
+        rt.refresh_raw_key_irq_level();
+        assert_eq!(
+            rt.memory.read_internal_byte(IMEM_ISR_OFFSET).unwrap_or(0) & ISR_KEYI,
+            0
+        );
+        assert!(!rt.timer.irq_pending);
+    }
+
+    #[test]
+    fn selected_raw_key_reasserts_independently_of_host_latch() {
         let mut rt = CoreRuntime::new();
         let kb = rt.keyboard.as_mut().unwrap();
         // Generate a debounced key event and mark the latch as active (set at event time).
@@ -4507,7 +4536,7 @@ mod tests {
         rt.timer.irq_pending = false;
         rt.timer.irq_source = None;
 
-        rt.refresh_key_irq_latch();
+        rt.refresh_raw_key_irq_level();
 
         let isr = rt.memory.read_internal_byte(IMEM_ISR_OFFSET).unwrap_or(0);
         assert_ne!(isr & ISR_KEYI, 0, "KEYI should reassert when latched");
@@ -4604,60 +4633,6 @@ mod tests {
     }
 
     #[test]
-    fn selected_irq_fetches_discarded_callback_opcode_once_without_preflight() {
-        use std::sync::atomic::{AtomicUsize, Ordering};
-        use std::sync::Arc;
-
-        let mut rt = CoreRuntime::new();
-        let current_pc = 0x02000;
-        let handler_pc = 0x03000;
-        rt.state.set_pc(current_pc);
-        rt.state.set_reg(RegName::S, 0x00400);
-        rt.memory.write_external_byte(current_pc, 0x20);
-        rt.memory.write_external_byte(handler_pc, 0x00);
-        rt.memory
-            .write_external_byte(INTERRUPT_VECTOR_ADDR, handler_pc as u8);
-        rt.memory
-            .write_external_byte(INTERRUPT_VECTOR_ADDR + 1, (handler_pc >> 8) as u8);
-        rt.memory
-            .write_external_byte(INTERRUPT_VECTOR_ADDR + 2, (handler_pc >> 16) as u8);
-        rt.memory
-            .write_internal_byte(IMEM_IMR_OFFSET, IMR_MASTER | IMR_ONK);
-        rt.memory.write_internal_byte(IMEM_ISR_OFFSET, 0);
-        rt.onk_level = true;
-        rt.memory.set_python_ranges(vec![(current_pc, current_pc)]);
-
-        let architectural_reads = Arc::new(AtomicUsize::new(0));
-        let silent_peeks = Arc::new(AtomicUsize::new(0));
-        let read_count = Arc::clone(&architectural_reads);
-        rt.set_host_read(move |addr| {
-            assert_eq!(addr, current_pc);
-            read_count.fetch_add(1, Ordering::Relaxed);
-            Some(0x20)
-        });
-        let peek_count = Arc::clone(&silent_peeks);
-        rt.set_host_peek(move |addr| {
-            assert_eq!(addr, current_pc);
-            peek_count.fetch_add(1, Ordering::Relaxed);
-            Some(0x20)
-        });
-
-        rt.step(1)
-            .expect("selected IRQ must replace a reserved callback opcode");
-
-        assert_eq!(architectural_reads.load(Ordering::Relaxed), 1);
-        assert_eq!(silent_peeks.load(Ordering::Relaxed), 0);
-        assert_eq!(rt.metadata.instruction_count, 0);
-        assert_eq!(rt.state.pc(), handler_pc);
-        assert_eq!(rt.state.get_reg(RegName::S), 0x003FB);
-        assert!(rt.timer.in_interrupt);
-        assert_ne!(
-            rt.memory.read_internal_byte(IMEM_ISR_OFFSET).unwrap_or(0) & ISR_ONKI,
-            0
-        );
-    }
-
-    #[test]
     fn active_interrupt_handler_does_not_preflight_irq_vector() {
         let mut rt = CoreRuntime::new();
         rt.state.set_pc(0);
@@ -4748,17 +4723,23 @@ mod tests {
 
         let kb_irq_enabled = rt.timer.kb_irq_enabled;
         let kb = rt.keyboard.as_mut().expect("keyboard present");
+        kb.handle_write(IMEM_KOL_OFFSET, 0xFF, &mut rt.memory);
+        kb.handle_write(IMEM_KOH_OFFSET, 0x0F, &mut rt.memory);
         let events = kb.inject_matrix_event(0x56, false, &mut rt.memory, kb_irq_enabled);
         assert!(events > 0, "key injection should enqueue an event");
 
         let isr = rt.memory.read_internal_byte(IMEM_ISR_OFFSET).unwrap_or(0);
-        assert_ne!(isr & ISR_KEYI, 0, "KEYI should be asserted after injection");
+        assert_eq!(isr & ISR_KEYI, 0, "FIFO injection alone is not raw KEYI");
 
         rt.step(1).expect("halt wake step");
 
         assert!(
             !rt.state.is_halted(),
             "HALT should clear on injected key event"
+        );
+        assert_ne!(
+            rt.memory.read_internal_byte(IMEM_ISR_OFFSET).unwrap_or(0) & ISR_KEYI,
+            0
         );
     }
 
@@ -4773,10 +4754,18 @@ mod tests {
 
         let kb_irq_enabled = rt.timer.kb_irq_enabled;
         let kb = rt.keyboard.as_mut().expect("keyboard present");
+        kb.handle_write(IMEM_KOL_OFFSET, 0xFF, &mut rt.memory);
+        kb.handle_write(IMEM_KOH_OFFSET, 0x0F, &mut rt.memory);
         let events = kb.inject_matrix_event(0x56, false, &mut rt.memory, kb_irq_enabled);
         assert!(events > 0, "key injection should enqueue an event");
 
         rt.step(1).expect("halt wake step");
+
+        assert!(!rt.state.is_halted(), "wake is an idle boundary");
+        assert_eq!(rt.state.pc(), 0);
+        assert_eq!(rt.instruction_count(), 0);
+
+        rt.step(1).expect("execute HALT after wake");
 
         assert!(rt.state.is_halted(), "HALT should re-enter halt state");
         assert_eq!(rt.state.pc(), 1, "HALT should advance PC");
@@ -5004,8 +4993,8 @@ mod tests {
         let _ = rt.step(1);
         assert_eq!(
             rt.state.get_reg(RegName::PC) & ADDRESS_MASK,
-            0x001234,
-            "PC should jump to interrupt vector when IMR master enabled"
+            0x001235,
+            "the selected handler's first NOP executes on the delivery step"
         );
     }
 
@@ -5050,8 +5039,8 @@ mod tests {
         let _ = rt.step(1);
         assert_eq!(
             rt.state.get_reg(RegName::PC) & ADDRESS_MASK,
-            0x005678,
-            "PC should jump to vector on ONK delivery"
+            0x005679,
+            "the ONK handler's first NOP executes on the delivery step"
         );
     }
 
@@ -5064,7 +5053,8 @@ mod tests {
         rt.memory.write_external_byte(0x0FFFFA, 0x10); // vector low
         rt.memory.write_external_byte(0x0FFFFB, 0x00);
         rt.memory.write_external_byte(0x0FFFFC, 0x00);
-        rt.memory.write_external_byte(0x0010, 0x01); // RETI opcode
+        rt.memory.write_external_byte(0x0010, 0x00); // first handler NOP
+        rt.memory.write_external_byte(0x0011, 0x01); // RETI opcode
                                                      // Seed IMR/ISR and pending IRQ.
         rt.memory
             .write_internal_byte(IMEM_IMR_OFFSET, IMR_MASTER | IMR_KEY);
@@ -5075,7 +5065,7 @@ mod tests {
         // First step: deliver IRQ and jump to vector.
         rt.step(1).expect("deliver irq");
         assert!(rt.timer.in_interrupt, "interrupt flag should set on entry");
-        assert_eq!(rt.state.get_reg(RegName::PC) & ADDRESS_MASK, 0x0010);
+        assert_eq!(rt.state.get_reg(RegName::PC) & ADDRESS_MASK, 0x0011);
 
         // Second step: RETI restores state and clears emulator bookkeeping only.
         rt.step(1).expect("execute reti");
@@ -5130,7 +5120,7 @@ mod tests {
     }
 
     #[test]
-    fn timers_do_not_tick_during_interrupts() {
+    fn timers_tick_and_latch_status_during_interrupts_without_nesting() {
         let mut rt = CoreRuntime::new();
         rt.timer.enabled = true;
         rt.timer.mti_period = 1;
@@ -5140,13 +5130,21 @@ mod tests {
 
         rt.step(1).expect("step while in interrupt");
         assert!(
-            !rt.timer.irq_pending,
-            "timer should not pend IRQs while in_interrupt"
+            rt.timer.irq_pending,
+            "timer status should pend while the handler is active"
         );
         assert_eq!(
-            rt.timer.next_mti, 1,
-            "next_mti should stay unchanged when ticking is gated"
+            rt.memory.read_internal_byte(IMEM_ISR_OFFSET).unwrap_or(0) & ISR_MTI,
+            ISR_MTI,
+            "MTI should latch in ISR while the handler is active"
         );
+        assert_eq!(rt.timer.next_mti, 2, "MTI phase should keep advancing");
+        assert_eq!(
+            rt.state.pc(),
+            1,
+            "the handler executes without a nested frame"
+        );
+        assert!(rt.timer.in_interrupt, "handler service remains active");
     }
 
     #[test]
@@ -5542,12 +5540,14 @@ mod tests {
         assert_eq!(rt.timer.irq_total, 0);
         assert_eq!(rt.timer.irq_key, 0);
 
-        // Deliver the IRQ (one step runs IR intrinsic, second executes RETI).
+        // Delivery and the selected handler's first instruction share this
+        // runtime step; the handler contains RETI.
         rt.step(1).expect("deliver irq");
         assert_eq!(rt.timer.irq_total, 1);
         assert_eq!(rt.timer.irq_key, 1);
-        rt.step(1).expect("execute RETI");
-        // Counters should remain at one after RETI.
+        rt.memory.write_internal_byte(IMEM_ISR_OFFSET, 0);
+        rt.step(1)
+            .expect("execute foreground instruction after acknowledgement");
         assert_eq!(rt.timer.irq_total, 1);
         assert_eq!(rt.timer.irq_key, 1);
     }
@@ -5555,8 +5555,9 @@ mod tests {
     #[test]
     fn hardware_irq_updates_call_depth() {
         let mut rt = CoreRuntime::new();
-        // Vector points to RETI at 0x0000.
-        rt.memory.write_external_byte(0x0000, 0x01);
+        // Vector points to NOP at 0x0000, followed by RETI.
+        rt.memory.write_external_byte(0x0000, 0x00);
+        rt.memory.write_external_byte(0x0001, 0x01);
         rt.memory.write_external_byte(0x0FFFFA, 0x00);
         rt.memory.write_external_byte(0x0FFFFB, 0x00);
         rt.memory.write_external_byte(0x0FFFFC, 0x00);
@@ -5757,29 +5758,40 @@ mod tests {
     }
 
     #[test]
-    fn malformed_current_opcode_precedes_an_aliased_irq_target() {
+    fn deliverable_irq_fetches_but_does_not_decode_reserved_fallthrough() {
         let mut rt = CoreRuntime::new();
         rt.state.set_pc(0);
+        rt.state.set_reg(RegName::S, 0x0200);
         rt.memory.write_external_byte(0, 0x20);
+        rt.memory.write_external_byte(0x0100, 0x00);
         rt.memory.write_external_byte(INTERRUPT_VECTOR_ADDR, 0x00);
         rt.memory
-            .write_external_byte(INTERRUPT_VECTOR_ADDR + 1, 0x00);
+            .write_external_byte(INTERRUPT_VECTOR_ADDR + 1, 0x01);
         rt.memory
             .write_external_byte(INTERRUPT_VECTOR_ADDR + 2, 0x00);
-        let reads_before = rt.memory.memory_read_count();
-        let writes_before = rt.memory.memory_write_count();
+        rt.memory
+            .write_internal_byte(IMEM_IMR_OFFSET, IMR_MASTER | IMR_KEY);
+        rt.memory.write_internal_byte(IMEM_ISR_OFFSET, ISR_KEYI);
+        rt.timer.irq_pending = true;
+        rt.timer.irq_source = Some("KEY".to_string());
+        rt.memory.set_python_ranges(vec![(0, 0)]);
+        let fallthrough_reads = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let callback_reads = std::sync::Arc::clone(&fallthrough_reads);
+        rt.set_host_read(move |address| {
+            assert_eq!(address, 0);
+            callback_reads.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            Some(0x20)
+        });
 
-        let error = rt
-            .step(1)
-            .expect_err("malformed current opcode must not be masked by IRQ target validation");
+        rt.step(1)
+            .expect("reserved fall-through byte is fetched but not decoded");
 
-        assert!(error.to_string().contains("preflight opcode 0x20"));
-        assert!(!error.to_string().contains("IRQ vector preflight"));
-        assert_eq!(rt.state.pc(), 0);
-        assert_eq!(rt.metadata.instruction_count, 0);
-        assert_eq!(rt.metadata.cycle_count, 0);
-        assert_eq!(rt.memory.memory_read_count(), reads_before);
-        assert_eq!(rt.memory.memory_write_count(), writes_before);
+        assert_eq!(rt.state.pc(), 0x0101);
+        assert_eq!(rt.metadata.instruction_count, 1);
+        assert_eq!(
+            fallthrough_reads.load(std::sync::atomic::Ordering::Relaxed),
+            1
+        );
     }
 
     #[test]

--- a/sc62015/core/src/llama/eval.rs
+++ b/sc62015/core/src/llama/eval.rs
@@ -145,8 +145,8 @@ pub const VECTOR_CHANGED_DURING_PREFLIGHT_ERROR: &str =
 pub const PREPARED_VECTOR_MISMATCH_ERROR: &str =
     "prepared SC62015 vector transfer does not match the current instruction";
 
-/// Opaque proof that one fixed vector was silently validated, fetched once
-/// through the architectural bus, and found to match that silent view.
+/// Opaque proof that one fixed vector was silently validated.  The proof also
+/// records whether its one architectural fetch has already happened.
 ///
 /// Private fields prevent wrappers from manufacturing a target scalar and
 /// bypassing the destination checks. A machine may hold this value across its
@@ -159,6 +159,7 @@ pub struct ValidatedVectorTransfer {
     target: u32,
     target_len: u8,
     provenance: (usize, u64),
+    architectural_fetch_validated: bool,
 }
 
 impl ValidatedVectorTransfer {
@@ -182,6 +183,58 @@ impl ValidatedVectorTransfer {
         self.vector_addr == vector_addr
             && self.source_pc == state.pc() & mask_for(RegName::PC)
             && self.provenance == bus.vector_transfer_provenance()
+    }
+
+    pub fn architectural_fetch_validated(&self) -> bool {
+        self.architectural_fetch_validated
+    }
+
+    /// Consume this proof at the architectural vector-read boundary.
+    ///
+    /// IR/IRQ callers use a silent-only proof and call this after the complete
+    /// five-byte frame has been written. RESET callers use an already-fetched
+    /// proof so reset remains fail-closed before its first mutation.
+    pub fn consume_after_architectural_fetch<B: LlamaBus>(
+        self,
+        vector_addr: u32,
+        state: &LlamaState,
+        bus: &mut B,
+    ) -> Result<u32, &'static str> {
+        if !self.matches(vector_addr, state, bus) {
+            return Err(PREPARED_VECTOR_MISMATCH_ERROR);
+        }
+        if self.architectural_fetch_validated {
+            return Ok(self.target);
+        }
+
+        let fetched_vector = bus.load(vector_addr, 8)
+            | (bus.load(vector_addr.wrapping_add(1), 8) << 8)
+            | (bus.load(vector_addr.wrapping_add(2), 8) << 16);
+        if bus.vector_transfer_provenance() != self.provenance {
+            return Err(PREPARED_VECTOR_MISMATCH_ERROR);
+        }
+        if fetched_vector == self.target {
+            return Ok(fetched_vector);
+        }
+        if fetched_vector & 0xF0_0000 != 0 {
+            return Err(VECTOR_UPPER_NIBBLE_ERROR);
+        }
+
+        // A volatile but canonical vector still needs the same destination
+        // validation as the silently observed value.
+        let opcode = bus
+            .peek_byte_silent_at(fetched_vector, fetched_vector)
+            .ok_or(SILENT_PEEK_UNAVAILABLE_ERROR)?;
+        let mut target_state = state.clone();
+        target_state.set_pc(fetched_vector);
+        LlamaExecutor.validate_before_scheduling_with_options(
+            opcode,
+            &target_state,
+            bus,
+            false,
+            false,
+        )?;
+        Err(VECTOR_CHANGED_DURING_PREFLIGHT_ERROR)
     }
 }
 
@@ -611,7 +664,9 @@ pub fn power_on_reset_with_transfer<B: LlamaBus>(
     state: &mut LlamaState,
     transfer: ValidatedVectorTransfer,
 ) -> Result<(), &'static str> {
-    if !transfer.matches(ROM_RESET_VECTOR_ADDR, state, bus) {
+    if !transfer.architectural_fetch_validated()
+        || !transfer.matches(ROM_RESET_VECTOR_ADDR, state, bus)
+    {
         return Err(PREPARED_VECTOR_MISMATCH_ERROR);
     }
     apply_power_on_reset(bus, state, transfer.target());
@@ -666,6 +721,30 @@ pub fn validate_vector_transfer_with_length<B: LlamaBus>(
     LlamaExecutor.validate_vector_transfer_inner(vector_addr, state, bus)
 }
 
+/// Prepare an IRQ/IR vector transfer using only side-effect-free peeks.
+/// The architectural low-to-high vector reads must be performed later, after
+/// the complete interrupt frame has been written.
+pub fn prepare_validated_vector<B: LlamaBus>(
+    vector_addr: u32,
+    state: &LlamaState,
+    bus: &mut B,
+) -> Result<ValidatedVectorTransfer, &'static str> {
+    let provenance = bus.vector_transfer_provenance();
+    let (target, target_len) =
+        LlamaExecutor.validate_vector_transfer_inner(vector_addr, state, bus)?;
+    if bus.vector_transfer_provenance() != provenance {
+        return Err(PREPARED_VECTOR_MISMATCH_ERROR);
+    }
+    Ok(ValidatedVectorTransfer {
+        vector_addr,
+        source_pc: state.pc() & mask_for(RegName::PC),
+        target,
+        target_len,
+        provenance,
+        architectural_fetch_validated: false,
+    })
+}
+
 /// Perform the one architectural vector fetch after silent validation and
 /// validate the fetched value again if a volatile bus disagrees with the peek.
 /// All rejection points occur before the caller mutates architectural state.
@@ -690,6 +769,7 @@ pub fn fetch_validated_vector<B: LlamaBus>(
             target: fetched_vector,
             target_len,
             provenance,
+            architectural_fetch_validated: true,
         });
     }
     if fetched_vector & 0xF0_0000 != 0 {
@@ -2741,18 +2821,27 @@ impl LlamaExecutor {
         if resolved_entry.kind == InstrKind::Tcl && !bus.supports_timer_phase_clear() {
             return Err(TCL_UNIMPLEMENTED_ERROR);
         }
-        // Finish the architectural vector fetch before reserving trace state
-        // or synchronizing register mirrors. execute_with receives the exact
-        // validated value so IR/RESET cannot re-read a volatile bus later.
-        let prefetched_vector = match (resolved_entry.kind, prepared_transfer) {
-            (InstrKind::Ir, Some(transfer)) | (InstrKind::Reset, Some(transfer)) => {
-                Some(transfer.target())
+        // IRQ/IR retains a silent-only proof until after the frame writes;
+        // RESET retains its historical fail-closed fetch-before-mutation
+        // contract.
+        let vector_transfer = match (resolved_entry.kind, prepared_transfer) {
+            (InstrKind::Ir, Some(transfer)) => {
+                if transfer.architectural_fetch_validated() {
+                    return Err(PREPARED_VECTOR_MISMATCH_ERROR);
+                }
+                Some(transfer)
+            }
+            (InstrKind::Reset, Some(transfer)) => {
+                if !transfer.architectural_fetch_validated() {
+                    return Err(PREPARED_VECTOR_MISMATCH_ERROR);
+                }
+                Some(transfer)
             }
             (InstrKind::Ir, None) => {
-                Some(fetch_validated_vector(INTERRUPT_VECTOR_ADDR, state, bus)?.target())
+                Some(prepare_validated_vector(INTERRUPT_VECTOR_ADDR, state, bus)?)
             }
             (InstrKind::Reset, None) => {
-                Some(fetch_validated_vector(ROM_RESET_VECTOR_ADDR, state, bus)?.target())
+                Some(fetch_validated_vector(ROM_RESET_VECTOR_ADDR, state, bus)?)
             }
             (_, Some(_)) => return Err(PREPARED_VECTOR_MISMATCH_ERROR),
             (_, None) => None,
@@ -2835,7 +2924,7 @@ impl LlamaExecutor {
                 pc_override,
                 prefix_len,
                 instr_index,
-                prefetched_vector,
+                vector_transfer,
             ),
             None => reject_unknown(),
         };
@@ -2930,7 +3019,7 @@ impl LlamaExecutor {
         pc_override: Option<u32>,
         prefix_len: u8,
         instr_index: u64,
-        prefetched_vector: Option<u32>,
+        vector_transfer: Option<ValidatedVectorTransfer>,
     ) -> Result<u8, &'static str> {
         match entry.kind {
             InstrKind::Nop => {
@@ -3377,7 +3466,9 @@ impl LlamaExecutor {
                 Ok(len)
             }
             InstrKind::Reset => {
-                let reset_vector = prefetched_vector.ok_or("RESET vector was not prefetched")?;
+                let reset_vector = vector_transfer
+                    .ok_or("RESET vector was not prefetched")?
+                    .consume_after_architectural_fetch(ROM_RESET_VECTOR_ADDR, state, bus)?;
                 apply_power_on_reset(bus, state, reset_vector);
                 let mem_imr = with_imr_read_suppressed(|| bus.peek_imem_silent(IMEM_IMR_OFFSET));
                 state.set_reg(RegName::IMR, mem_imr as u32);
@@ -3411,7 +3502,6 @@ impl LlamaExecutor {
                 // fallthrough here would make the software-interrupt slot unreachable.
                 let saved_pc = pc_before;
                 let fallthrough = pc_before.wrapping_add(instr_len as u32) & mask_for(RegName::PC);
-                let vec = prefetched_vector.ok_or("IR vector was not prefetched")?;
                 Self::push_stack(state, bus, RegName::S, saved_pc, 24, false);
                 let f = state.get_reg(RegName::F) & 0xFF;
                 Self::push_stack(state, bus, RegName::S, f, 8, false);
@@ -3422,6 +3512,9 @@ impl LlamaExecutor {
                 let cleared_imr = imr & 0x7F;
                 Self::store_traced(bus, imr_addr, 8, cleared_imr);
                 state.set_reg(RegName::IMR, cleared_imr);
+                let vec = vector_transfer
+                    .ok_or("IR vector was not prepared")?
+                    .consume_after_architectural_fetch(INTERRUPT_VECTOR_ADDR, state, bus)?;
                 state.call_depth_inc();
                 state.set_pc(vec);
                 // Parity: emit perfetto IRQ entry like Python IR intrinsic.
@@ -5443,12 +5536,14 @@ mod tests {
         fetched: [u8; 3],
         vector_reads: Vec<u32>,
         writes: Vec<(u32, u8, u32)>,
+        events: Vec<(&'static str, u32)>,
     }
 
     impl LlamaBus for VolatileVectorBus {
         fn load(&mut self, addr: u32, bits: u8) -> u32 {
             if bits == 8 && (INTERRUPT_VECTOR_ADDR..=INTERRUPT_VECTOR_ADDR + 2).contains(&addr) {
                 self.vector_reads.push(addr);
+                self.events.push(("vector-read", addr));
                 return u32::from(self.fetched[(addr - INTERRUPT_VECTOR_ADDR) as usize]);
             }
             u32::from(self.silent.get(addr as usize).copied().unwrap_or(0))
@@ -5456,6 +5551,7 @@ mod tests {
 
         fn store(&mut self, addr: u32, bits: u8, value: u32) {
             self.writes.push((addr, bits, value));
+            self.events.push(("write", addr));
         }
 
         fn peek_byte_silent(&mut self, addr: u32) -> Option<u8> {
@@ -5468,7 +5564,7 @@ mod tests {
     }
 
     #[test]
-    fn synchronous_ir_rejects_vector_changed_after_preflight_before_frame_mutation() {
+    fn synchronous_ir_detects_volatile_vector_change_after_frame_mutation() {
         let _perfetto_lock = crate::perfetto::perfetto_test_guard();
         let mut exec = LlamaExecutor::new();
         reset_perf_counters();
@@ -5490,6 +5586,7 @@ mod tests {
             ],
             vector_reads: Vec::new(),
             writes: Vec::new(),
+            events: Vec::new(),
         };
         let mut state = LlamaState::new();
         state.set_pc(pc as u32);
@@ -5499,18 +5596,22 @@ mod tests {
 
         let err = exec
             .execute(0xFE, &mut state, &mut bus)
-            .expect_err("volatile vector mismatch must fail atomically");
+            .expect_err("volatile vector mismatch must fail after the frame");
 
         assert_eq!(err, VECTOR_CHANGED_DURING_PREFLIGHT_ERROR);
         assert_eq!(state.pc(), pc as u32);
-        assert_eq!(state.get_reg(RegName::S), 0x00400);
+        assert_eq!(state.get_reg(RegName::S), 0x003FB);
         assert_eq!(state.get_reg(RegName::F), 0x03);
-        assert_eq!(state.get_reg(RegName::IMR), 0xA5);
+        assert_eq!(state.get_reg(RegName::IMR), 0x00);
         assert_eq!(state.call_depth(), 0);
         assert_eq!(perfetto_last_instr_index(), 17);
-        assert_eq!(perfetto_last_pc(), 0);
+        assert_eq!(perfetto_last_pc(), pc as u32);
         assert_eq!(perfetto_instr_context(), None);
-        assert!(bus.writes.is_empty());
+        assert_eq!(bus.writes.len(), 6, "five frame bytes plus IMR.IRM clear");
+        assert!(
+            bus.events[..6].iter().all(|(kind, _)| *kind == "write"),
+            "all frame/IMR writes must precede the vector fetch"
+        );
         assert_eq!(
             bus.vector_reads,
             vec![

--- a/sc62015/core/src/timer.rs
+++ b/sc62015/core/src/timer.rs
@@ -577,7 +577,7 @@ impl TimerContext {
         memory: &mut MemoryImage,
         cycle_count: u64,
         mut keyboard_scan: F,
-        y_reg: Option<u32>,
+        _y_reg: Option<u32>,
         pc_hint: Option<u32>,
     ) -> (bool, bool, usize, Option<KeyboardTelemetry>)
     where
@@ -598,55 +598,11 @@ impl TimerContext {
             .map(|(_, pc)| pc)
             .or(pc_hint)
             .unwrap_or_else(perfetto_last_pc);
-        // Only create a new latch when fresh events arrive while IRQs are enabled; otherwise
-        // preserve any existing latch without reviving a cleared one from FIFO contents.
-        let new_latch = self.kb_irq_enabled && key_events > 0;
+        // Preserve the host-event latch for snapshot/FIFO bookkeeping only.
+        // It is not an electrical KEYI source; the runtimes sample the raw,
+        // selected KIL matrix independently at scheduling boundaries.
+        let new_latch = key_events > 0;
         let latch_active = had_latch || new_latch;
-        let should_assert = latch_active;
-        if should_assert {
-            if let Some(isr) = memory.read_internal_byte(ISR_OFFSET) {
-                if (isr & 0x04) == 0 {
-                    let new_isr = isr | 0x04;
-                    memory.write_internal_byte(ISR_OFFSET, new_isr);
-                    let pc_trace = crate::llama::eval::perfetto_instr_context()
-                        .map(|(_, pc)| pc)
-                        .or(pc_hint)
-                        .unwrap_or_else(perfetto_last_pc);
-                    self.record_bit_watch_transition("ISR", isr, new_isr, pc_trace);
-                }
-            }
-            // Mirror Python: key activity (new events or pending FIFO data) latches KEYI and marks a pending IRQ.
-            self.irq_pending = true;
-            self.irq_source = Some("KEY".to_string());
-            self.last_fired = self.irq_source.clone();
-            self.irq_imr = memory.read_internal_byte(0xFB).unwrap_or(self.irq_imr);
-            self.irq_isr = memory
-                .read_internal_byte(ISR_OFFSET)
-                .unwrap_or(self.irq_isr);
-            // Perfetto parity: emit a KeyIRQ marker with PC/cycle context.
-            let mut guard = PERFETTO_TRACER.enter();
-            guard.with_some(|tracer| {
-                let mut payload = HashMap::new();
-                payload.insert(
-                    "events".to_string(),
-                    AnnotationValue::UInt(key_events as u64),
-                );
-                payload.insert(
-                    "imr".to_string(),
-                    AnnotationValue::UInt(self.irq_imr as u64),
-                );
-                payload.insert(
-                    "isr".to_string(),
-                    AnnotationValue::UInt(self.irq_isr as u64),
-                );
-                payload.insert("pc".to_string(), AnnotationValue::Pointer(pc_trace as u64));
-                payload.insert("cycle".to_string(), AnnotationValue::UInt(cycle_count));
-                if let Some(y) = y_reg {
-                    payload.insert("y".to_string(), AnnotationValue::Pointer(y as u64));
-                }
-                tracer.record_irq_event("KeyIRQ", payload);
-            });
-        }
         if key_events == 0 {
             if let Some(stats) = kb_stats.as_ref() {
                 if stats.pressed > 0 {
@@ -674,7 +630,7 @@ impl TimerContext {
                 }
             }
         }
-        // Track latch so KEYI can be reasserted if firmware clears ISR while FIFO remains non-empty.
+        // Track only whether host events remain represented in the FIFO.
         self.key_irq_latched = latch_active;
         // When IRQs are disabled, keep the existing latch state but avoid creating a new one.
         // Perfetto parity: emit a scan event regardless of new key events.
@@ -713,10 +669,6 @@ impl TimerContext {
             payload.insert("pc".to_string(), AnnotationValue::Pointer(pc_trace as u64));
             tracer.record_irq_event("KeyScanEvent", payload);
         });
-        // Maintain bit-watch parity even when KEYI was already set prior to the scan.
-        if should_assert {
-            let _ = memory.read_internal_byte(ISR_OFFSET);
-        }
         (mti, sti, key_events, kb_stats)
     }
 
@@ -1071,7 +1023,7 @@ mod tests {
     }
 
     #[test]
-    fn bit_watch_tracks_keyi_assertion() {
+    fn host_event_latch_does_not_emit_raw_keyi_bit_watch() {
         let mut timer = TimerContext::new(true, 0, 0);
         let mut mem = MemoryImage::new();
         // Simulate ISR initially cleared.
@@ -1081,28 +1033,18 @@ mod tests {
         let pc = 0x234u32;
         let _ =
             timer.tick_timers_with_keyboard(&mut mem, 0, |_mem| (0, true, None), None, Some(pc));
-        let watch = timer
-            .irq_bit_watch
-            .as_ref()
-            .and_then(|w| w.get("ISR"))
-            .and_then(|v| v.as_object())
-            .expect("bit watch table should capture ISR");
-        let bit2 = watch
-            .get("2")
-            .and_then(|v| v.as_object())
-            .expect("bit 2 entry should exist for KEYI");
-        let set = bit2
-            .get("set")
-            .and_then(|v| v.as_array())
-            .expect("'set' array should exist for bit 2");
-        assert!(
-            set.iter().any(|entry| entry.as_u64() == Some(pc as u64)),
-            "bit watch should record KEYI assertion PC"
-        );
+        assert_eq!(mem.read_internal_byte(ISR_OFFSET).unwrap_or(0) & 0x04, 0);
+        assert!(timer.irq_bit_watch.as_ref().is_none_or(|watch| {
+            watch
+                .get("ISR")
+                .and_then(|value| value.as_object())
+                .and_then(|bits| bits.get("2"))
+                .is_none()
+        }));
     }
 
     #[test]
-    fn tick_timers_with_keyboard_sets_keyi() {
+    fn tick_timers_with_keyboard_keeps_events_separate_from_raw_keyi() {
         let mut timer = TimerContext::new(true, 1, 0);
         let mut mem = MemoryImage::new();
         // Simulate keyboard scan emitting one event.
@@ -1110,21 +1052,9 @@ mod tests {
             timer.tick_timers_with_keyboard(&mut mem, 1, |_mem| (1, true, None), None, None);
         assert_eq!(events, 1);
         let isr = mem.read_internal_byte(ISR_OFFSET).unwrap_or(0);
-        assert_eq!(
-            isr & 0x04,
-            0x04,
-            "KEYI bit should be set on MTI with events"
-        );
-        assert!(
-            timer
-                .irq_bit_watch
-                .as_ref()
-                .and_then(|w| w.get("ISR"))
-                .is_some(),
-            "bit watch should track ISR changes for KEYI"
-        );
-        // Perfetto payload should carry src and PC.
-        assert_eq!(timer.irq_source, Some("KEY".to_string()));
+        assert_eq!(isr & 0x04, 0);
+        assert_eq!(isr & 0x01, 0x01, "the independent MTI still fires");
+        assert_eq!(timer.irq_source, Some("MTI".to_string()));
     }
 
     #[test]
@@ -1145,7 +1075,7 @@ mod tests {
     }
 
     #[test]
-    fn key_latch_sets_on_new_events_when_enabled() {
+    fn host_event_latch_sets_without_asserting_raw_keyi() {
         let mut timer = TimerContext::new(true, 1, 0);
         let mut mem = MemoryImage::new();
         timer.key_irq_latched = false;
@@ -1153,13 +1083,13 @@ mod tests {
             timer.tick_timers_with_keyboard(&mut mem, 1, |_mem| (1, false, None), None, None);
         assert_eq!(events, 1);
         let isr = mem.read_internal_byte(ISR_OFFSET).unwrap_or(0);
-        assert_ne!(isr & 0x04, 0, "KEYI should assert on new events");
+        assert_eq!(isr & 0x04, 0);
         assert!(timer.key_irq_latched, "latch should set on new events");
-        assert_eq!(timer.irq_source, Some("KEY".to_string()));
+        assert_eq!(timer.irq_source, Some("MTI".to_string()));
     }
 
     #[test]
-    fn key_events_count_while_irq_masked_and_reassert_on_enable() {
+    fn buffered_key_events_do_not_manufacture_raw_keyi_on_enable() {
         let mut timer = TimerContext::new(true, 1, 0);
         timer.set_keyboard_irq_enabled(false);
         let mut mem = MemoryImage::new();
@@ -1175,7 +1105,8 @@ mod tests {
         let isr = mem.read_internal_byte(ISR_OFFSET).unwrap_or(0);
         assert_eq!(isr & 0x04, 0, "KEYI should stay clear while IRQs disabled");
 
-        // Re-enable IRQs and let the buffered FIFO assert KEYI.
+        // Re-enabling host event generation does not turn buffered FIFO data
+        // into an electrical raw-matrix level.
         timer.set_keyboard_irq_enabled(true);
         let (_mti2, _sti2, events2, _stats2) = timer.tick_timers_with_keyboard(
             &mut mem,
@@ -1197,32 +1128,21 @@ mod tests {
             "no additional events are needed to surface buffered data"
         );
         let isr_after = mem.read_internal_byte(ISR_OFFSET).unwrap_or(0);
-        assert_ne!(
-            isr_after & 0x04,
-            0,
-            "KEYI should assert once IRQs are enabled"
-        );
+        assert_eq!(isr_after & 0x04, 0);
     }
 
     #[test]
-    fn tick_timers_with_keyboard_reasserts_keyi_without_events() {
+    fn tick_timers_with_keyboard_does_not_reassert_keyi_from_fifo_latch() {
         let mut timer = TimerContext::new(true, 1, 0);
         let mut mem = MemoryImage::new();
         timer.key_irq_latched = true;
-        // No new events, but FIFO already has data -> KEYI should still assert on MTI.
+        // No new physical sample is available here; an event/FIFO latch is
+        // insufficient to assert raw KEYI.
         let (_mti, _sti, events, _) =
             timer.tick_timers_with_keyboard(&mut mem, 1, |_mem| (0, true, None), None, None);
         assert_eq!(events, 0);
         let isr = mem.read_internal_byte(ISR_OFFSET).unwrap_or(0);
-        assert_eq!(
-            isr & 0x04,
-            0x04,
-            "KEYI should reassert when FIFO has data even without new events"
-        );
-        assert!(
-            timer.irq_pending,
-            "pending IRQ should be latched when FIFO remains non-empty"
-        );
+        assert_eq!(isr & 0x04, 0);
     }
 
     #[test]

--- a/sc62015/core/tests/keyboard.rs
+++ b/sc62015/core/tests/keyboard.rs
@@ -4,7 +4,7 @@ use sc62015_core::keyboard::KeyboardMatrix;
 use sc62015_core::memory::MemoryImage;
 
 #[test]
-fn scan_tick_populates_fifo_and_sets_keyi() {
+fn scan_tick_populates_fifo_without_manufacturing_keyi() {
     let mut mem = MemoryImage::new();
     let mut kb = KeyboardMatrix::new();
 
@@ -12,7 +12,7 @@ fn scan_tick_populates_fifo_and_sets_keyi() {
     kb.press_matrix_code(0x10, &mut mem);
     assert_eq!(kb.fifo_len(), 0);
 
-    // Strobe columns, then run a scan tick and assert KEYI.
+    // Strobe columns, then run a scan tick to populate host bookkeeping.
     kb.handle_write(0xF0, 0xFF, &mut mem);
     kb.handle_write(0xF1, 0x07, &mut mem);
     let mut events = 0;
@@ -28,7 +28,7 @@ fn scan_tick_populates_fifo_and_sets_keyi() {
     );
     assert!(
         kb.fifo_len() > 0,
-        "FIFO should hold the event before KEYI assert"
+        "FIFO should hold the debounced host event"
     );
     kb.write_fifo_to_memory(&mut mem, true);
     assert!(
@@ -36,17 +36,21 @@ fn scan_tick_populates_fifo_and_sets_keyi() {
         "FIFO should remain pending until the ROM consumes it"
     );
     let isr = mem.read_internal_byte(0xFC).unwrap_or(0);
-    assert_ne!(isr & 0x04, 0, "KEYI should be set after scan");
+    assert_eq!(
+        isr & 0x04,
+        0,
+        "debounce/FIFO bookkeeping must not manufacture raw KEYI"
+    );
     let _ = kb.handle_read(0xF2, &mut mem).unwrap_or(0);
     assert_eq!(kb.fifo_len(), 0, "FIFO should drain after KIL read");
 }
 
 #[test]
-fn keyi_is_not_reasserted_by_kil_read_without_host() {
+fn kil_read_does_not_reassert_keyi_from_host_fifo() {
     let mut mem = MemoryImage::new();
     let mut kb = KeyboardMatrix::new();
 
-    // Seed a press and force a scan via KOL to populate FIFO and set KEYI.
+    // Seed a press and force a scan via KOL to populate the host FIFO.
     kb.press_matrix_code(0x10, &mut mem);
     kb.handle_write(0xF0, 0xFF, &mut mem);
     kb.handle_write(0xF1, 0x07, &mut mem);
@@ -61,19 +65,25 @@ fn keyi_is_not_reasserted_by_kil_read_without_host() {
         "FIFO should remain queued until KIL read"
     );
     let isr_after_scan = mem.read_internal_byte(0xFC).unwrap_or(0);
-    assert_ne!(isr_after_scan & 0x04, 0, "KEYI should be set after scan");
+    assert_eq!(
+        isr_after_scan & 0x04,
+        0,
+        "host FIFO state is not a raw KEYI source"
+    );
 
-    // Clear ISR (e.g., by firmware) after the KEYI latch was asserted.
+    // Model firmware acknowledgement after a CPU boundary latched KEYI.
+    mem.write_internal_byte(0xFC, 0x04);
     mem.write_internal_byte(0xFC, 0x00);
     assert_eq!(mem.read_internal_byte(0xFC).unwrap_or(0) & 0x04, 0);
 
-    // A subsequent KIL read alone should not reassert KEYI; bus/host logic handles that.
+    // A subsequent KIL read/FIFO drain alone does not reassert KEYI. CPU
+    // boundary sampling of selected physical KIL is the separate source.
     let _kil = kb.handle_read(0xF2, &mut mem).unwrap_or(0);
     let isr_reassert = mem.read_internal_byte(0xFC).unwrap_or(0);
     assert_eq!(
         isr_reassert & 0x04,
         0,
-        "Keyboard read should not reassert KEYI without host involvement"
+        "KIL read must not synthesize KEYI from the host FIFO"
     );
 }
 
@@ -98,7 +108,7 @@ fn write_fifo_to_memory_keeps_events_when_irq_masked() {
     let mut mem = MemoryImage::new();
     let mut kb = KeyboardMatrix::new();
 
-    // Populate one event into the FIFO and assert KEYI.
+    // Populate one event into the host FIFO.
     kb.press_matrix_code(0x10, &mut mem);
     kb.handle_write(0xF0, 0xFF, &mut mem);
     kb.handle_write(0xF1, 0x07, &mut mem);
@@ -114,7 +124,7 @@ fn write_fifo_to_memory_keeps_events_when_irq_masked() {
         "FIFO should remain queued while IRQs are masked"
     );
     let isr = mem.read_internal_byte(0xFC).unwrap_or(0);
-    assert_eq!(isr & 0x04, 0, "KEYI should not assert when masked");
+    assert_eq!(isr & 0x04, 0, "host FIFO should not assert raw KEYI");
     let _ = kb.handle_read(0xF2, &mut mem).unwrap_or(0);
     assert_eq!(kb.fifo_len(), 0, "KIL read should consume pending events");
 }

--- a/sc62015/pysc62015/contract_harness.py
+++ b/sc62015/pysc62015/contract_harness.py
@@ -248,13 +248,8 @@ class PythonContractBackend:
         if not matrix.inject_event(key_code, release=release):  # type: ignore[attr-defined]
             return False
 
-        # Mirror scheduler effects: assert KEYI and mark pending.
-        isr_addr = INTERNAL_MEMORY_START + IMEM_ISR_OFFSET
-        isr = self.read(isr_addr)
-        if matrix.scan_enabled:  # type: ignore[attr-defined]
-            self.write(isr_addr, isr | 0x04)
-            self._irq_pending = True
-            self._irq_source = "KEY"
+        # Host injection only updates physical/event state. The scheduler
+        # samples selected KIL and asserts raw KEYI at a CPU boundary.
         return True
 
     def snapshot(self) -> ContractSnapshot:

--- a/sc62015/pysc62015/emulator.py
+++ b/sc62015/pysc62015/emulator.py
@@ -180,6 +180,7 @@ class _ValidatedVectorTransfer:
     """Private, one-shot proof binding a vector fetch to one memory mapping."""
 
     __slots__ = (
+        "_architectural_fetch_validated",
         "_memory",
         "_provenance",
         "_source_pc",
@@ -197,7 +198,10 @@ class _ValidatedVectorTransfer:
         target: int,
         provenance: tuple[int, int],
         scope: str = "instruction",
+        *,
+        architectural_fetch_validated: bool = True,
     ) -> None:
+        self._architectural_fetch_validated = architectural_fetch_validated
         self._memory = memory
         self._provenance = provenance
         self._vector_address = int(vector_address)
@@ -239,11 +243,55 @@ class _ValidatedVectorTransfer:
         if self._used:
             raise RuntimeError("prepared SC62015 vector transfer was already consumed")
         self._used = True
+        if not self._architectural_fetch_validated:
+            raise RuntimeError(
+                "prepared SC62015 vector transfer still requires its "
+                "architectural fetch"
+            )
         matches = self._binding_matches(memory, vector_address, source_pc)
         if not matches:
             raise RuntimeError(
                 "prepared SC62015 vector transfer does not match the current "
                 "instruction or memory mapping"
+            )
+        return self._target
+
+    def consume_after_architectural_fetch(
+        self,
+        memory: Memory,
+        vector_address: int,
+        source_pc: int,
+        actual_raw_vector: int,
+    ) -> int:
+        """Consume a silent proof after the post-frame architectural read."""
+
+        if self._used:
+            raise RuntimeError("prepared SC62015 vector transfer was already consumed")
+        self._used = True
+        if self._architectural_fetch_validated:
+            raise RuntimeError(
+                "prepared SC62015 vector transfer already includes an "
+                "architectural fetch"
+            )
+        if not self._binding_matches(memory, vector_address, source_pc):
+            raise RuntimeError(
+                "prepared SC62015 vector transfer does not match the current "
+                "instruction or memory mapping"
+            )
+        if not 0 <= int(actual_raw_vector) <= 0xFFFFFF:
+            raise RuntimeError("architectural SC62015 vector is not a 24-bit value")
+        actual_raw_vector = int(actual_raw_vector)
+        if actual_raw_vector & 0xF00000:
+            raise NotImplementedError(
+                "SC62015 vector upper-nibble behavior is unverified; refusing "
+                f"noncanonical architectural vector 0x{actual_raw_vector:06X}"
+            )
+        if actual_raw_vector != self._target:
+            raise RuntimeError(
+                "SC62015 architectural vector fetch disagrees with safe "
+                f"preflight at 0x{int(vector_address) & PC_MASK:05X}: "
+                f"fetched 0x{actual_raw_vector:06X}, "
+                f"preflight 0x{self._target:06X}"
             )
         return self._target
 
@@ -355,6 +403,56 @@ def fetch_validated_vector_transfer(
         target,
         provenance,
         scope,
+    )
+
+
+def prepare_validated_vector_transfer(
+    memory: Memory,
+    regs: "Registers",
+    vector_address: int,
+    *,
+    source_pc: int | None = None,
+    require_immutable: bool = False,
+    scope: str = "instruction",
+    require_stability_metadata: bool = False,
+) -> _ValidatedVectorTransfer:
+    """Create a silent proof without performing the architectural read.
+
+    Interrupt entry uses this proof before constructing its frame, then
+    performs and validates the three observable vector reads after all five
+    stack writes, matching the PC-E500 HW-014 capture.
+    """
+
+    if isinstance(vector_address, bool) or not 0 <= int(vector_address) <= PC_MASK:
+        raise ValueError("SC62015 vector address must be canonical 20-bit")
+    vector_address = int(vector_address)
+    vector_pc = (
+        regs.get(RegisterName.PC) if source_pc is None else int(source_pc)
+    ) & PC_MASK
+    provenance = _vector_transfer_provenance(memory)
+    target = validate_vector_transfer(
+        memory,
+        regs,
+        vector_address,
+        source_pc=vector_pc,
+    )
+    validate_vector_transfer_stability(
+        memory,
+        vector_address,
+        target,
+        require_immutable=require_immutable,
+        require_metadata=require_stability_metadata,
+    )
+    if _vector_transfer_provenance(memory) != provenance:
+        raise RuntimeError("SC62015 vector mapping changed during silent preflight")
+    return _ValidatedVectorTransfer(
+        memory,
+        vector_address,
+        vector_pc,
+        target,
+        provenance,
+        scope,
+        architectural_fetch_validated=False,
     )
 
 
@@ -854,11 +952,21 @@ class Emulator:
         require_immutable: bool = False,
         scope: str = "instruction",
     ) -> int:
-        """Architecturally fetch one vector for the next matching operation."""
+        """Retain one vector proof for the next matching operation.
+
+        Software/hardware interrupt entry retains only a silent proof because
+        HW-014 places its architectural vector reads after the frame. RESET
+        retains its already-fetched proof because it has no interrupt frame.
+        """
 
         if self._pending_vector_transfer is not None:
             raise RuntimeError("an SC62015 vector transfer is already prepared")
-        transfer = fetch_validated_vector_transfer(
+        prepare = (
+            prepare_validated_vector_transfer
+            if vector_address == INTERRUPT_VECTOR_ADDR and scope == "instruction"
+            else fetch_validated_vector_transfer
+        )
+        transfer = prepare(
             self.memory,
             self.regs,
             vector_address,
@@ -1061,30 +1169,24 @@ class Emulator:
                 source_pc=address,
             )
 
-        # A prepared software IR must not execute the lifted architectural
-        # vector load after the wrapper's timer tick.  Consume the exact
-        # pre-tick fetch and perform the documented frame writes directly.
+        # A prepared software IR carries only its silent destination proof.
+        # Perform the documented frame writes first, then the one low-to-high
+        # architectural vector fetch measured by HW-014.
         if isinstance(instr, IR) and prepared_transfer is not None:
-            target = prepared_transfer.consume(
-                self.memory, INTERRUPT_VECTOR_ADDR, address
-            )
             info = InstructionInfo()
             instr.analyze(info, address)
             self._execution_may_have_side_effects = True
             saved_pc = address & PC_MASK
-            # Hardware pre-decrements S for every byte and writes the saved PC
-            # high-to-low.  Keep that observable bus order here; subtracting
-            # the full width first and filling the final little-endian image
-            # produces the same bytes but reverses callback/peripheral writes.
+            s = self.regs.get(RegisterName.S) & PC_MASK
             for byte_index in reversed(range(3)):
-                s = (self.regs.get(RegisterName.S) - 1) & PC_MASK
-                self.regs.set(RegisterName.S, s)
+                s = (s - 1) & PC_MASK
                 _write_byte_with_pc(
                     self.memory,
                     s,
                     (saved_pc >> (8 * byte_index)) & 0xFF,
                     saved_pc,
                 )
+            self.regs.set(RegisterName.S, s)
             s = (self.regs.get(RegisterName.S) - 1) & PC_MASK
             self.regs.set(RegisterName.S, s)
             _write_byte_with_pc(
@@ -1099,6 +1201,19 @@ class Emulator:
             self.regs.set(RegisterName.S, s)
             _write_byte_with_pc(self.memory, s, imr, saved_pc)
             _write_byte_with_pc(self.memory, imr_address, imr & 0x7F, saved_pc)
+            raw_vector = 0
+            for byte_index in range(3):
+                raw_vector |= _read_byte_with_pc(
+                    self.memory,
+                    (INTERRUPT_VECTOR_ADDR + byte_index) & PC_MASK,
+                    saved_pc,
+                ) << (byte_index * 8)
+            target = prepared_transfer.consume_after_architectural_fetch(
+                self.memory,
+                INTERRUPT_VECTOR_ADDR,
+                address,
+                raw_vector,
+            )
             self.regs.set(RegisterName.PC, target)
             self.regs.call_sub_level += 1
             return InstructionEvalInfo(instruction_info=info, instruction=instr)

--- a/sc62015/pysc62015/instr/instructions.py
+++ b/sc62015/pysc62015/instr/instructions.py
@@ -1821,10 +1821,30 @@ class OFF(MiscInstruction):
 # 3. After pushing IMR, bit 7 (IRM) of IMR is forcibly cleared to 0.
 class IR(MiscInstruction):
     def lift(self, il: LowLevelILFunction, addr: int) -> None:
-        # Fetch the architectural vector into a dedicated temporary before
-        # any S-stack/IMR mutation. The validation intrinsic compares this
-        # value with a side-effect-free peek and statically checks its target;
-        # the final jump reuses it rather than reading a volatile bus twice.
+        # Fail-closed target proof is silent. HW-014 then requires the five
+        # observable frame writes before the low-to-high architectural vector
+        # fetch, which is retained in a temporary for the final jump.
+        il.append(
+            il.intrinsic(
+                [],
+                PreflightVectorTransferIntrinsic,
+                [
+                    il.const(3, INTERRUPT_VECTOR_ADDR),
+                    il.const(3, addr & PC_MASK),
+                ],
+            )
+        )
+        imr, *_rest = RegIMR().operands()
+        imr_value = imr.lift(il)
+        # Software IR saves the address of the IR opcode itself.  The ROM
+        # dispatcher identifies 0xFE at that saved PC and advances the frame
+        # by one before RETI; hardware interrupt delivery instead saves the
+        # already-current resume PC in the runtime's separate entry path.
+        _lift_s_push(il, 3, il.const(3, addr & PC_MASK))
+        _lift_s_push(il, 1, RegF().lift(il))
+        _lift_s_push(il, 1, imr_value)
+        imr.lift_assign(il, il.and_expr(1, imr.lift(il), il.const(1, 0x7F)))
+
         mem = EMemAddr(width=3)
         mem.value = INTERRUPT_VECTOR_ADDR
         vector_target = TempReg(TempVectorTarget, width=3)
@@ -1840,16 +1860,6 @@ class IR(MiscInstruction):
                 ],
             )
         )
-        imr, *_rest = RegIMR().operands()
-        imr_value = imr.lift(il)
-        # Software IR saves the address of the IR opcode itself.  The ROM
-        # dispatcher identifies 0xFE at that saved PC and advances the frame
-        # by one before RETI; hardware interrupt delivery instead saves the
-        # already-current resume PC in the runtime's separate entry path.
-        _lift_s_push(il, 3, il.const(3, addr & PC_MASK))
-        _lift_s_push(il, 1, RegF().lift(il))
-        _lift_s_push(il, 1, imr_value)
-        imr.lift_assign(il, il.and_expr(1, imr.lift(il), il.const(1, 0x7F)))
 
         il.append(il.jump(vector_target.lift(il)))
 

--- a/sc62015/pysc62015/instr/opcodes.py
+++ b/sc62015/pysc62015/instr/opcodes.py
@@ -220,6 +220,7 @@ HALTIntrinsic = IntrinsicName("HALT")
 OFFIntrinsic = IntrinsicName("OFF")
 RESETIntrinsic = IntrinsicName("RESET")
 ValidateFIntrinsic = IntrinsicName("VALIDATE_F")
+PreflightVectorTransferIntrinsic = IntrinsicName("PREFLIGHT_VECTOR_TRANSFER")
 ValidateVectorTransferIntrinsic = IntrinsicName("VALIDATE_VECTOR_TRANSFER")
 
 # Use distinct temporary registers for various operations in order to avoid

--- a/sc62015/pysc62015/intrinsics.py
+++ b/sc62015/pysc62015/intrinsics.py
@@ -76,16 +76,67 @@ def eval_intrinsic_validate_vector_transfer(
             raise RuntimeError("VALIDATE_VECTOR_TRANSFER input produced no value")
         values.append(int(value))
 
-    # Runtime import avoids an instruction-module cycle during decoder setup.
-    from .emulator import validate_vector_transfer
+    # PREFLIGHT_VECTOR_TRANSFER stores the opaque silent proof on the
+    # instruction-local state. The architectural vector load follows the five
+    # frame writes and this intrinsic consumes the proof exactly once.
+    prepared = getattr(state, "_sc62015_llil_vector_transfer", None)
+    if prepared is None:
+        raise RuntimeError(
+            "VALIDATE_VECTOR_TRANSFER requires a prior silent vector preflight"
+        )
+    delattr(state, "_sc62015_llil_vector_transfer")
+    prepared.consume_after_architectural_fetch(
+        memory,
+        values[0],
+        values[1],
+        values[2],
+    )
+    return None, None
 
-    validate_vector_transfer(
+
+def eval_intrinsic_preflight_vector_transfer(
+    llil: MockLLIL,
+    size: Optional[int],
+    regs: RegistersLike,
+    memory: Memory,
+    state: State,
+    get_flag: FlagGetter,
+    set_flag: FlagSetter,
+) -> Tuple[None, Optional[ResultFlags]]:
+    """Silently prove one vector before interrupt-frame mutation."""
+
+    from binja_test_mocks.eval_llil import evaluate_llil
+
+    params = getattr(llil, "params", ())
+    if len(params) != 2:
+        raise RuntimeError(
+            "PREFLIGHT_VECTOR_TRANSFER requires vector address and source PC"
+        )
+    values: list[int] = []
+    for param in params:
+        value, _flags = evaluate_llil(
+            param,
+            regs,
+            memory,
+            state,
+            get_flag=get_flag,
+            set_flag=set_flag,
+        )
+        if value is None:
+            raise RuntimeError("PREFLIGHT_VECTOR_TRANSFER input produced no value")
+        values.append(int(value))
+    if hasattr(state, "_sc62015_llil_vector_transfer"):
+        raise RuntimeError("an SC62015 LLIL vector transfer is already prepared")
+
+    from .emulator import prepare_validated_vector_transfer
+
+    prepared = prepare_validated_vector_transfer(
         memory,
         regs,  # type: ignore[arg-type]
         values[0],
         source_pc=values[1],
-        actual_raw_vector=values[2],
     )
+    setattr(state, "_sc62015_llil_vector_transfer", prepared)
     return None, None
 
 
@@ -318,6 +369,9 @@ def register_sc62015_intrinsics() -> None:
     register_intrinsic("OFF", eval_intrinsic_off)
     register_intrinsic("RESET", eval_intrinsic_reset)
     register_intrinsic("VALIDATE_F", eval_intrinsic_validate_f)
+    register_intrinsic(
+        "PREFLIGHT_VECTOR_TRANSFER", eval_intrinsic_preflight_vector_transfer
+    )
     register_intrinsic(
         "VALIDATE_VECTOR_TRANSFER", eval_intrinsic_validate_vector_transfer
     )

--- a/sc62015/pysc62015/test_contract_harness.py
+++ b/sc62015/pysc62015/test_contract_harness.py
@@ -296,7 +296,7 @@ def test_onk_press_sets_pending_parity():
     assert py_events == rs_events
 
 
-def test_keyboard_press_helper_sets_pending_parity():
+def test_keyboard_press_helper_does_not_manufacture_keyi_parity():
     py_backend, rust_backend = _init_backends()
     assert py_backend.press_matrix_code(0x00)
     assert rust_backend.press_matrix_code(0x00)
@@ -304,14 +304,11 @@ def test_keyboard_press_helper_sets_pending_parity():
     py_snap = py_backend.snapshot()
     rs_snap = rust_backend.snapshot()
 
-    assert py_snap.isr & 0x04 == rs_snap.isr & 0x04 == 0x04
-    assert py_snap.metadata.get("irq_pending") is True
-    assert rs_snap.metadata.get("irq_pending") is True
-    assert (
-        py_snap.metadata.get("irq_source")
-        == rs_snap.metadata.get("irq_source")
-        == "KEY"
-    )
+    assert py_snap.isr & 0x04 == rs_snap.isr & 0x04 == 0
+    assert py_snap.metadata.get("irq_pending") is False
+    assert rs_snap.metadata.get("irq_pending") is False
+    assert py_snap.metadata.get("irq_source") is None
+    assert rs_snap.metadata.get("irq_source") is None
 
     py_events = [(e.kind, e.address, e.value) for e in py_backend.drain_events()]
     rs_events = [(e.kind, e.address, e.value) for e in rust_backend.drain_events()]

--- a/sc62015/pysc62015/test_emulator.py
+++ b/sc62015/pysc62015/test_emulator.py
@@ -1622,6 +1622,9 @@ def test_instruction_execution(case: InstructionTestCase) -> None:
         )
 
 
+# HW-002 intentionally drives a complete 65,536-iteration register ring. Under
+# coverage, slower CPython runners can legitimately exceed the global 60s guard.
+@pytest.mark.timeout(180)
 @pytest.mark.parametrize(
     ("mnemonic", "instr_bytes", "expected_fz", "write_multiplier"),
     [

--- a/sc62015/pysc62015/test_halt_off_reset.py
+++ b/sc62015/pysc62015/test_halt_off_reset.py
@@ -419,7 +419,7 @@ def test_vector_static_preflight_rejects_invalid_pre_and_tcl_targets(
         validate_vector_transfer(memory, emu.regs, 0xFFFFD)
 
 
-def test_ir_architectural_vector_mismatch_fails_before_frame_or_imr_write():
+def test_ir_architectural_vector_mismatch_fails_after_frame_and_imr_write():
     raw = bytearray([0x00] * ADDRESS_SPACE_SIZE)
     source = 0x1000
     target = 0x0200
@@ -444,14 +444,23 @@ def test_ir_architectural_vector_mismatch_fails_before_frame_or_imr_write():
     emu.regs.set(RegisterName.PC, source)
     emu.regs.set(RegisterName.S, 0x400)
     before_regs = dict(emu.regs._values)
-    before_memory = bytes(raw)
-
     with pytest.raises(RuntimeError, match="fetch disagrees with safe preflight"):
         emu.execute_instruction(source)
 
+    # HW-014 places the architectural vector read after the complete frame.
+    # The evaluator rolls back its register transaction on failure, but the
+    # already-observable frame/IMR writes remain and poison further execution.
     assert dict(emu.regs._values) == before_regs
-    assert bytes(raw) == before_memory
-    assert writes == []
+    assert writes == [
+        (0x3FF, 0x00),
+        (0x3FE, 0x10),
+        (0x3FD, 0x00),
+        (0x3FC, 0x00),
+        (0x3FB, 0xA5),
+        (INTERNAL_MEMORY_START + IMEMRegisters.IMR, 0x25),
+    ]
+    assert raw[0x3FB:0x400] == bytes((0xA5, 0x00, 0x00, 0x10, 0x00))
+    assert raw[INTERNAL_MEMORY_START + IMEMRegisters.IMR] == 0x25
     assert emu._poisoned is not None
 
 

--- a/sc62015/pysc62015/test_instr.py
+++ b/sc62015/pysc62015/test_instr.py
@@ -1464,12 +1464,36 @@ def test_wait_lifts_to_timing_intrinsic() -> None:
     assert [getattr(node, "name", None) for node in il.ils] == ["WAIT"]
 
 
-def test_ir_lifts_vector_validation_before_stack_mutation() -> None:
+def test_ir_lifts_frame_before_architectural_vector_fetch() -> None:
     instr = decode(bytearray([0xFE]), 0x12345)
     il = MockLowLevelILFunction()
     instr.lift(il, 0x12345)
 
-    fetch, validation = il.ils[:2]
+    preflight = il.ils[0]
+    assert getattr(preflight, "name", None) == "PREFLIGHT_VECTOR_TRANSFER"
+    assert "1048570" in repr(preflight)
+    assert "74565" in repr(preflight)
+
+    fetch_index = next(
+        index
+        for index, node in enumerate(il.ils)
+        if node.bare_op() == "SET_REG"
+        and "TEMP6" in repr(node)
+        and "1048570" in repr(node)
+    )
+    validation_index = next(
+        index
+        for index, node in enumerate(il.ils)
+        if getattr(node, "name", None) == "VALIDATE_VECTOR_TRANSFER"
+    )
+    stores = [index for index, node in enumerate(il.ils) if node.bare_op() == "STORE"]
+    # Five stack-frame bytes plus the architectural IMR.IRM clear all precede
+    # the low-to-high vector read.
+    assert len(stores) == 6
+    assert max(stores) < fetch_index < validation_index
+
+    fetch = il.ils[fetch_index]
+    validation = il.ils[validation_index]
     assert fetch.bare_op() == "SET_REG"
     assert "TEMP6" in repr(fetch)
     assert "1048570" in repr(fetch)  # architectural read at 0xFFFFA
@@ -1477,7 +1501,6 @@ def test_ir_lifts_vector_validation_before_stack_mutation() -> None:
     assert "1048570" in repr(validation)
     assert "74565" in repr(validation)  # source PC at 0x12345
     assert "TEMP6" in repr(validation)
-    assert all(node.bare_op() != "STORE" for node in il.ils[:2])
     assert il.ils[-1].bare_op() == "JUMP"
     assert "TEMP6" in repr(il.ils[-1])
     assert "LOAD" not in repr(il.ils[-1])

--- a/sc62015/pysc62015/test_llama_parity_misc.py
+++ b/sc62015/pysc62015/test_llama_parity_misc.py
@@ -648,6 +648,9 @@ def test_reg_imem_offset_imem_selector_uses_pre1(backend: str) -> None:
     assert memory._raw[0x000100] == 0xAA
 
 
+# This hardware-backed parity case executes the complete 65,536-iteration ring;
+# the Python LLIL backend can legitimately exceed the global 60s guard in CI.
+@pytest.mark.timeout(180)
 @pytest.mark.parametrize("backend", ["python", "llama"])
 @pytest.mark.parametrize(
     ("mnemonic", "program", "expected_fz"),

--- a/sc62015/pysc62015/test_llama_parity_tools.py
+++ b/sc62015/pysc62015/test_llama_parity_tools.py
@@ -127,37 +127,6 @@ def test_run_case_seeds_stacks_in_valid_external_memory(monkeypatch) -> None:
     )
 
 
-def test_python_prepared_ir_preserves_measured_stack_bus_order() -> None:
-    pc = 0x12345
-    backing = bytearray(llama_parity_sweep.ADDRESS_SPACE_SIZE)
-    backing[pc] = 0xFE
-    imr_address = (
-        llama_parity_sweep.INTERNAL_MEMORY_START + llama_parity_sweep.IMEMRegisters.IMR
-    )
-    backing[imr_address] = 0xA5
-    memory = llama_parity_sweep.LoggingMemory(backing)
-    cpu = llama_parity_sweep.CPU(memory, reset_on_init=False, backend="python")
-    cpu.apply_snapshot(
-        llama_parity_sweep.CPURegistersSnapshot(
-            pc=pc,
-            s=llama_parity_sweep.STACK_SEED,
-            f=0x03,
-        )
-    )
-
-    cpu.prepare_instruction_before_scheduling(pc)
-    cpu.execute_instruction(pc)
-
-    assert memory.writes == [
-        (llama_parity_sweep.STACK_SEED - 1, 0x01),
-        (llama_parity_sweep.STACK_SEED - 2, 0x23),
-        (llama_parity_sweep.STACK_SEED - 3, 0x45),
-        (llama_parity_sweep.STACK_SEED - 4, 0x03),
-        (llama_parity_sweep.STACK_SEED - 5, 0xA5),
-        (imr_address, 0x25),
-    ]
-
-
 def test_run_case_classifies_two_sided_reserved_rejection(monkeypatch) -> None:
     class RejectingCPU(_FakeCPU):
         def execute_instruction(self, _pc: int) -> None:

--- a/sc62015/rustcore/src/lib.rs
+++ b/sc62015/rustcore/src/lib.rs
@@ -12,8 +12,9 @@ use sc62015_core::{
     llama::{
         eval::{
             fetch_validated_vector, perfetto_last_instr_index, perfetto_last_pc,
-            power_on_reset_with_transfer, reset_perf_counters, set_perf_instr_counter,
-            validate_vector_transfer_with_length, LlamaBus, LlamaExecutor, ValidatedVectorTransfer,
+            power_on_reset_with_transfer, prepare_validated_vector, reset_perf_counters,
+            set_perf_instr_counter, validate_vector_transfer_with_length, LlamaBus, LlamaExecutor,
+            ValidatedVectorTransfer,
         },
         opcodes::RegName as LlamaRegName,
         state::{validate_f_image, CallMetricsSnapshot, LlamaState, PowerState},
@@ -462,7 +463,7 @@ impl LlamaContractBus {
             }
 
             let kb_irq_enabled = self.timer.kb_irq_enabled;
-            let (mti, sti, key_events, _kb_stats) = self.timer.tick_timers_with_keyboard(
+            let (mti, sti, _key_events, _kb_stats) = self.timer.tick_timers_with_keyboard(
                 &mut self.memory,
                 self.cycles,
                 |mem| {
@@ -479,23 +480,6 @@ impl LlamaContractBus {
                 None,
                 None,
             );
-            if kb_irq_enabled {
-                if mti && key_events > 0 && self.keyboard.fifo_len() > 0 {
-                    // Ensure KEYI is asserted; tick_timers_with_keyboard already wrote ISR, but keep parity.
-                    if let Some(isr) = self.memory.read_internal_byte(0xFC) {
-                        if (isr & 0x04) == 0 {
-                            self.memory.write_internal_byte(0xFC, isr | 0x04);
-                        }
-                    }
-                }
-                if sti && self.keyboard.fifo_len() > 0 {
-                    if let Some(cur) = self.memory.read_internal_byte(0xFC) {
-                        if (cur & 0x04) == 0 {
-                            self.memory.write_internal_byte(0xFC, cur | 0x04);
-                        }
-                    }
-                }
-            }
             if mti || sti {
                 let mut value = 0u8;
                 if mti {
@@ -843,102 +827,22 @@ impl LlamaContractBus {
     }
 
     fn keyboard_press_matrix_code(&mut self, code: u8) -> PyResult<bool> {
-        let isr_offset = IMEM_ISR_OFFSET;
-        let isr_addr = INTERNAL_MEMORY_START + isr_offset;
-        let prev_isr = self.memory.read_internal_byte(isr_offset).unwrap_or(0);
-        self.events.push(ContractEvent {
-            kind: "read",
-            address: isr_addr,
-            value: prev_isr,
-            pc: None,
-            detail: None,
-        });
         let events = self.keyboard.inject_matrix_event(
             code & 0x7F,
             false,
             &mut self.memory,
             self.timer.kb_irq_enabled,
         );
-        let new_isr = self
-            .memory
-            .read_internal_byte(isr_offset)
-            .unwrap_or(prev_isr);
-        if new_isr != prev_isr {
-            self.events.push(ContractEvent {
-                kind: "write",
-                address: isr_addr,
-                value: new_isr,
-                pc: None,
-                detail: None,
-            });
-        }
-        if self.timer.kb_irq_enabled && (events > 0 || self.keyboard.fifo_len() > 0) {
-            self.timer.irq_pending = true;
-            self.timer.irq_source = Some("KEY".to_string());
-            self.timer.last_fired = self.timer.irq_source.clone();
-            self.timer.irq_isr = new_isr;
-            self.timer.irq_imr = self
-                .memory
-                .read_internal_byte(IMEM_IMR_OFFSET)
-                .unwrap_or(self.timer.irq_imr);
-            let mut guard = PERFETTO_TRACER.enter();
-            guard.with_some(|tracer| {
-                let mut payload = HashMap::new();
-                payload.insert(
-                    "imr".to_string(),
-                    AnnotationValue::UInt(self.timer.irq_imr as u64),
-                );
-                payload.insert(
-                    "isr".to_string(),
-                    AnnotationValue::UInt(self.timer.irq_isr as u64),
-                );
-                payload.insert("src".to_string(), AnnotationValue::Str("KEY".to_string()));
-                tracer.record_irq_event("KeyIRQ", payload);
-            });
-        }
         Ok(events > 0)
     }
 
     fn keyboard_release_matrix_code(&mut self, code: u8) -> PyResult<bool> {
-        let isr_offset = IMEM_ISR_OFFSET;
-        let isr_addr = INTERNAL_MEMORY_START + isr_offset;
-        let prev_isr = self.memory.read_internal_byte(isr_offset).unwrap_or(0);
-        self.events.push(ContractEvent {
-            kind: "read",
-            address: isr_addr,
-            value: prev_isr,
-            pc: None,
-            detail: None,
-        });
         let events = self.keyboard.inject_matrix_event(
             code & 0x7F,
             true,
             &mut self.memory,
             self.timer.kb_irq_enabled,
         );
-        let new_isr = self
-            .memory
-            .read_internal_byte(isr_offset)
-            .unwrap_or(prev_isr);
-        if new_isr != prev_isr {
-            self.events.push(ContractEvent {
-                kind: "write",
-                address: isr_addr,
-                value: new_isr,
-                pc: None,
-                detail: None,
-            });
-        }
-        if self.timer.kb_irq_enabled && self.keyboard.fifo_len() > 0 {
-            self.timer.irq_pending = true;
-            self.timer.irq_source = Some("KEY".to_string());
-            self.timer.last_fired = self.timer.irq_source.clone();
-            self.timer.irq_isr = new_isr;
-            self.timer.irq_imr = self
-                .memory
-                .read_internal_byte(IMEM_IMR_OFFSET)
-                .unwrap_or(self.timer.irq_imr);
-        }
         Ok(events > 0)
     }
 
@@ -1581,7 +1485,7 @@ impl LlamaBus for LlamaPyBus {
                 }
 
                 let kb_irq_enabled = timer.kb_irq_enabled;
-                let (mti, sti, key_events, _kb_stats) = timer.tick_timers_with_keyboard(
+                let (mti, sti, _key_events, _kb_stats) = timer.tick_timers_with_keyboard(
                     mirror,
                     *cycles_counter,
                     |mem| {
@@ -1594,13 +1498,6 @@ impl LlamaBus for LlamaPyBus {
                     None,
                     None,
                 );
-                if kb_irq_enabled && (key_events > 0 || keyboard.fifo_len() > 0) {
-                    if let Some(cur) = mirror.read_internal_byte(IMEM_ISR_OFFSET) {
-                        if (cur & 0x04) == 0 {
-                            mirror.write_internal_byte(IMEM_ISR_OFFSET, cur | 0x04);
-                        }
-                    }
-                }
                 if mti || sti {
                     let mut value = mirror.read_internal_byte(IMEM_ISR_OFFSET).unwrap_or(0);
                     if mti {
@@ -2402,9 +2299,10 @@ impl LlamaCpu {
             (0..u32::from(target_len)).map(|index| target.wrapping_add(index) & ADDRESS_MASK),
         )?;
 
-        // Re-certify both ranges immediately before the sole architectural
-        // vector read, then let the core repeat silent validation and bind the
-        // resulting proof to the live provenance epoch.
+        // Re-certify both ranges immediately before binding the proof to the
+        // live provenance epoch. IR retains a silent-only proof because its
+        // architectural vector fetch occurs after the frame writes. RESET
+        // keeps its fetched-before-mutation fail-closed contract.
         require_python_instruction_stability(
             py,
             &self.memory,
@@ -2430,7 +2328,11 @@ impl LlamaCpu {
             &mut self.mirror,
             &mut self.cycles,
         )?;
-        let transfer_result = fetch_validated_vector(vector_address, &source_state, &mut bus);
+        let transfer_result = if vector_address == ROM_RESET_VECTOR_ADDR {
+            fetch_validated_vector(vector_address, &source_state, &mut bus)
+        } else {
+            prepare_validated_vector(vector_address, &source_state, &mut bus)
+        };
         self.memory_reads = self.memory_reads.saturating_add(bus.memory_reads);
         let callback_error = bus.take_callback_error();
         drop(bus);
@@ -3103,34 +3005,9 @@ impl LlamaCpu {
                 &mut cpu.mirror,
                 cpu.timer.kb_irq_enabled,
             );
-            if cpu.timer.kb_irq_enabled && (events > 0 || cpu.keyboard.fifo_len() > 0) {
-                // Mirror Python scheduler: latch KEYI and pending IRQ immediately.
-                cpu.timer.irq_pending = true;
-                cpu.timer.irq_source = Some("KEY".to_string());
-                cpu.timer.last_fired = cpu.timer.irq_source.clone();
-                cpu.timer.irq_isr = cpu
-                    .mirror
-                    .read_internal_byte(IMEM_ISR_OFFSET)
-                    .unwrap_or(cpu.timer.irq_isr);
-                cpu.timer.irq_imr = cpu
-                    .mirror
-                    .read_internal_byte(IMEM_IMR_OFFSET)
-                    .unwrap_or(cpu.timer.irq_imr);
-                let mut guard = PERFETTO_TRACER.enter();
-                guard.with_some(|tracer| {
-                    let mut payload = HashMap::new();
-                    payload.insert(
-                        "imr".to_string(),
-                        AnnotationValue::UInt(cpu.timer.irq_imr as u64),
-                    );
-                    payload.insert(
-                        "isr".to_string(),
-                        AnnotationValue::UInt(cpu.timer.irq_isr as u64),
-                    );
-                    payload.insert("src".to_string(), AnnotationValue::Str("KEY".to_string()));
-                    tracer.record_irq_event("KeyIRQ", payload);
-                });
-            }
+            // Host injection updates physical matrix and FIFO bookkeeping.
+            // The machine scheduler, not this helper, samples selected KIL
+            // and asserts raw KEYI at an instruction boundary.
             events > 0
         })
     }
@@ -3223,19 +3100,8 @@ impl LlamaCpu {
                 &mut cpu.mirror,
                 cpu.timer.kb_irq_enabled,
             );
-            if cpu.timer.kb_irq_enabled && cpu.keyboard.fifo_len() > 0 {
-                cpu.timer.irq_pending = true;
-                cpu.timer.irq_source = Some("KEY".to_string());
-                cpu.timer.last_fired = cpu.timer.irq_source.clone();
-                cpu.timer.irq_isr = cpu
-                    .mirror
-                    .read_internal_byte(IMEM_ISR_OFFSET)
-                    .unwrap_or(cpu.timer.irq_isr);
-                cpu.timer.irq_imr = cpu
-                    .mirror
-                    .read_internal_byte(IMEM_IMR_OFFSET)
-                    .unwrap_or(cpu.timer.irq_imr);
-            }
+            // Release changes physical/event state only. It neither
+            // acknowledges an existing KEYI bit nor creates a new one.
             events > 0
         })
     }

--- a/web/src/lib/emulator/pce500.worker.ts
+++ b/web/src/lib/emulator/pce500.worker.ts
@@ -2,6 +2,7 @@ import { normalizeRomModel, type RomModel } from '../rom_model';
 import { normalizeLcdKind, type LcdKind } from '../lcd_kind';
 import { createStubDispatcher, type StubDispatcher } from '../debug/sc62015_stub_dispatch';
 import type { StubRegistration } from '../debug/sc62015_stub_types';
+import { PCE500_KEY_FIFO_CAPACITY, resolvePce500KeyboardFifo } from './pce500_iocs_workspace';
 
 type DebugOptions = {
 	regsOpen: boolean;
@@ -63,9 +64,6 @@ type Frame = {
 
 const MIN_VIRTUAL_HOLD_INSTRUCTIONS = 40_000;
 const IMEM_BASE = 0x100000;
-const FIFO_BASE_ADDR = 0x00bfc96;
-const FIFO_HEAD_ADDR = 0x00bfc9d;
-const FIFO_TAIL_ADDR = 0x00bfc9e;
 
 const RUN_SLICE_MIN_INSTRUCTIONS = 1;
 const RUN_SLICE_MAX_INSTRUCTIONS = 200_000;
@@ -339,9 +337,12 @@ function snapshotKeyboard(): { keyboardDebug: KeyboardDebug; keyboardDebugJson: 
 		const kol = emulator.read_u8?.(IMEM_BASE + 0xf0) ?? null;
 		const koh = emulator.read_u8?.(IMEM_BASE + 0xf1) ?? null;
 		const kil = emulator.read_u8?.(IMEM_BASE + 0xf2) ?? null;
-		const fifoHead = emulator.read_u8?.(FIFO_HEAD_ADDR) ?? null;
-		const fifoTail = emulator.read_u8?.(FIFO_TAIL_ADDR) ?? null;
-		const fifo = Array.from({ length: 16 }, (_, i) => emulator.read_u8?.(FIFO_BASE_ADDR + i) ?? 0);
+		const fifoAddresses = resolvePce500KeyboardFifo((address) => emulator.read_u8?.(address));
+		const fifoHead = fifoAddresses ? (emulator.read_u8?.(fifoAddresses.fifoHead) ?? null) : null;
+		const fifoTail = fifoAddresses ? (emulator.read_u8?.(fifoAddresses.fifoTail) ?? null) : null;
+		const fifo = Array.from({ length: PCE500_KEY_FIFO_CAPACITY }, (_, i) =>
+			fifoAddresses ? (emulator.read_u8?.(fifoAddresses.fifoBase + i) ?? 0) : 0,
+		);
 		const keyboardDebug: KeyboardDebug = {
 			pc,
 			instr,

--- a/web/src/lib/emulator/pce500_iocs_workspace.test.ts
+++ b/web/src/lib/emulator/pce500_iocs_workspace.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { resolvePce500KeyboardFifo } from './pce500_iocs_workspace';
+
+function reader(entries: Array<[number, number]>) {
+	const memory = new Map(entries);
+	return (address: number) => memory.get(address);
+}
+
+describe('resolvePce500KeyboardFifo', () => {
+	it('resolves the English-ROM cold-start mapping', () => {
+		const resolved = resolvePce500KeyboardFifo(
+			reader([
+				[0x00bfd17, 0xb4],
+				[0x00bfd18, 0xf9],
+				[0x00bfd19, 0x0b],
+				[0x00bf9b6, 0x50],
+				[0x00bf9b7, 0x00],
+			]),
+		);
+
+		expect(resolved).toEqual({
+			workspaceBase: 0x00bf9b4,
+			fifoBase: 0x00bfa04,
+			fifoTail: 0x00bf9b8,
+			fifoHead: 0x00bf9b9,
+		});
+	});
+
+	it('follows a relocated workspace and its stored FIFO offset', () => {
+		const resolved = resolvePce500KeyboardFifo(
+			reader([
+				[0x00bfd17, 0x00],
+				[0x00bfd18, 0xfa],
+				[0x00bfd19, 0x0b],
+				[0x00bfa02, 0x70],
+				[0x00bfa03, 0x01],
+			]),
+		);
+
+		expect(resolved).toEqual({
+			workspaceBase: 0x00bfa00,
+			fifoBase: 0x00bfb70,
+			fifoTail: 0x00bfa04,
+			fifoHead: 0x00bfa05,
+		});
+	});
+
+	it('returns null when the workspace pointer is unavailable', () => {
+		expect(resolvePce500KeyboardFifo(() => undefined)).toBeNull();
+	});
+
+	it('rejects an all-zero uninitialised workspace pointer', () => {
+		expect(resolvePce500KeyboardFifo(() => 0)).toBeNull();
+	});
+});

--- a/web/src/lib/emulator/pce500_iocs_workspace.ts
+++ b/web/src/lib/emulator/pce500_iocs_workspace.ts
@@ -1,0 +1,41 @@
+export const PCE500_IOCS_WORKSPACE_PTR_ADDR = 0x00bfd17;
+export const PCE500_KEY_FIFO_BASE_OFFSET = 0x02;
+export const PCE500_KEY_FIFO_TAIL_OFFSET = 0x04;
+export const PCE500_KEY_FIFO_HEAD_OFFSET = 0x05;
+export const PCE500_KEY_FIFO_CAPACITY = 0x10;
+
+export type Pce500KeyboardFifoAddresses = {
+	workspaceBase: number;
+	fifoBase: number;
+	fifoTail: number;
+	fifoHead: number;
+};
+
+type ReadU8 = (address: number) => number | null | undefined;
+
+function readByte(readU8: ReadU8, address: number): number | null {
+	const value = readU8(address);
+	return typeof value === 'number' ? value & 0xff : null;
+}
+
+/** Resolve the relocatable PC-E500 keyboard FIFO through [BFD17]/(E6). */
+export function resolvePce500KeyboardFifo(readU8: ReadU8): Pce500KeyboardFifoAddresses | null {
+	const base0 = readByte(readU8, PCE500_IOCS_WORKSPACE_PTR_ADDR);
+	const base1 = readByte(readU8, PCE500_IOCS_WORKSPACE_PTR_ADDR + 1);
+	const base2 = readByte(readU8, PCE500_IOCS_WORKSPACE_PTR_ADDR + 2);
+	if (base0 === null || base1 === null || base2 === null) return null;
+
+	const workspaceBase = base0 | (base1 << 8) | (base2 << 16);
+	if (workspaceBase === 0) return null;
+	const offset0 = readByte(readU8, workspaceBase + PCE500_KEY_FIFO_BASE_OFFSET);
+	const offset1 = readByte(readU8, workspaceBase + PCE500_KEY_FIFO_BASE_OFFSET + 1);
+	if (offset0 === null || offset1 === null) return null;
+
+	const fifoOffset = offset0 | (offset1 << 8);
+	return {
+		workspaceBase,
+		fifoBase: workspaceBase + fifoOffset,
+		fifoTail: workspaceBase + PCE500_KEY_FIFO_TAIL_OFFSET,
+		fifoHead: workspaceBase + PCE500_KEY_FIFO_HEAD_OFFSET,
+	};
+}

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -13,6 +13,7 @@
 	import type { FunctionRunnerOutput } from '$lib/debug/function_runner_types';
 	import { createPersistedStore } from '$lib/stores/persisted';
 	import { normalizeRomModel, type RomModel } from '$lib/rom_model';
+	import { PCE500_KEY_FIFO_CAPACITY, resolvePce500KeyboardFifo } from '$lib/emulator/pce500_iocs_workspace';
 
 	const ROM_MODEL_STORAGE_KEY = 'sc62015:rom-model';
 	const romModelStore = createPersistedStore<RomModel>(ROM_MODEL_STORAGE_KEY, 'pc-e500', {
@@ -64,9 +65,6 @@
 	const pendingVirtualRelease = new Map<number, number>();
 	const MIN_VIRTUAL_HOLD_INSTRUCTIONS = 40_000;
 	const IMEM_BASE = 0x100000;
-	const FIFO_BASE_ADDR = 0x00bfc96;
-	const FIFO_HEAD_ADDR = 0x00bfc9d;
-	const FIFO_TAIL_ADDR = 0x00bfc9e;
 	const debugLog: string[] = [];
 	let physicalKeyboardEnabled = false;
 	let keyboardDebugOpen = false;
@@ -665,9 +663,12 @@
 			const kol = emulator.read_u8?.(IMEM_BASE + 0xf0) ?? null;
 			const koh = emulator.read_u8?.(IMEM_BASE + 0xf1) ?? null;
 			const kil = emulator.read_u8?.(IMEM_BASE + 0xf2) ?? null;
-			const fifoHead = emulator.read_u8?.(FIFO_HEAD_ADDR) ?? null;
-			const fifoTail = emulator.read_u8?.(FIFO_TAIL_ADDR) ?? null;
-			const fifo = Array.from({ length: 16 }, (_, i) => emulator.read_u8?.(FIFO_BASE_ADDR + i) ?? 0);
+			const fifoAddresses = resolvePce500KeyboardFifo((address) => emulator.read_u8?.(address));
+			const fifoHead = fifoAddresses ? (emulator.read_u8?.(fifoAddresses.fifoHead) ?? null) : null;
+			const fifoTail = fifoAddresses ? (emulator.read_u8?.(fifoAddresses.fifoTail) ?? null) : null;
+			const fifo = Array.from({ length: PCE500_KEY_FIFO_CAPACITY }, (_, i) =>
+				fifoAddresses ? (emulator.read_u8?.(fifoAddresses.fifoBase + i) ?? 0) : 0,
+			);
 			debugKio = { pc, instr, imr, isr, kol, koh, kil, fifoHead, fifoTail, fifo };
 			debugKioJson = safeJson({
 				...debugKio,
@@ -701,9 +702,12 @@
 			const kol = emulator.read_u8?.(IMEM_BASE + 0xf0);
 			const koh = emulator.read_u8?.(IMEM_BASE + 0xf1);
 			const kil = emulator.read_u8?.(IMEM_BASE + 0xf2);
-			const fifoHead = emulator.read_u8?.(FIFO_HEAD_ADDR);
-			const fifoTail = emulator.read_u8?.(FIFO_TAIL_ADDR);
-			const fifo = Array.from({ length: 8 }, (_, i) => emulator.read_u8?.(FIFO_BASE_ADDR + i) ?? 0);
+			const fifoAddresses = resolvePce500KeyboardFifo((address) => emulator.read_u8?.(address));
+			const fifoHead = fifoAddresses ? emulator.read_u8?.(fifoAddresses.fifoHead) : undefined;
+			const fifoTail = fifoAddresses ? emulator.read_u8?.(fifoAddresses.fifoTail) : undefined;
+			const fifo = Array.from({ length: PCE500_KEY_FIFO_CAPACITY }, (_, i) =>
+				fifoAddresses ? (emulator.read_u8?.(fifoAddresses.fifoBase + i) ?? 0) : 0,
+			);
 			console.log(`[pce500] ${tag}`, {
 				pc,
 				instr,


### PR DESCRIPTION
Summary
- apply the remaining real-device findings across Python, Rust core, the PyO3 bridge, and standalone runtimes
- model frame-before-vector IRQ ordering with 20-bit stack wrapping, raw selected-KIL KEYI behavior, and timer latching during interrupt service
- retain ROM-grounded IQ-7000 IOCS workspace behavior and document the updated evidence boundary
- move the exhaustive immediate parity campaign out of required pull-request CI into one weekly or manually dispatched Python 3.11 job

CI impact
- the removed required step took 94 minutes on Python 3.11 and 159 minutes on Python 3.12 in run 33568491206
- required test (3.11) and test (3.12) check names remain unchanged and still run normal parity, contract, full Python, and type-checking gates
- Rust, Web, lint, format, and private-ROM status checks are unchanged

Validation
- final tree matches the state previously validated by the full Python suite: 1162 passed, 2 skipped, plus the private full-ROM harness
- fresh affected Python tests: 201 passed
- Rust core and ROM integration: 479 passed, 6 ignored
- Rust/Python bridge: 26 passed
- Web: Svelte check clean; 50 unit/integration tests passed
- Ruff, Pyright, Prettier, rustfmt, and strict Clippy passed